### PR TITLE
Underlay neighbor: allowas-in origin

### DIFF
--- a/internal/frr/templates/neighboripfamily.tmpl
+++ b/internal/frr/templates/neighboripfamily.tmpl
@@ -3,11 +3,13 @@
 {{- if activateNeighborFor "ipv4" .IPFamily }}
   address-family ipv4 unicast
     neighbor {{.Addr}} activate
+    neighbor {{.Addr}} allowas-in origin
   exit-address-family
 {{- end -}}
 {{if activateNeighborFor "ipv6" .IPFamily }}
   address-family ipv6 unicast
     neighbor {{.Addr}} activate
+    neighbor {{.Addr}} allowas-in origin
   exit-address-family
 {{- end -}}
 {{- end -}}

--- a/internal/frr/testdata/TestBasic.golden
+++ b/internal/frr/testdata/TestBasic.golden
@@ -19,6 +19,7 @@ router bgp 64512
 
   address-family ipv4 unicast
     neighbor 192.168.1.2 activate
+    neighbor 192.168.1.2 allowas-in origin
   exit-address-family
   address-family ipv4 unicast
     network 100.64.0.1/32


### PR DESCRIPTION
Given we want a consistend ASN across all the instances, we need to enable allowas-in otherwise the routes (specifically to VTEPs) are going to be refused because of our asn being in the as-path.