### PR TITLE
Close the target namespace when we use it

### DIFF
--- a/internal/hostnetwork/underlay.go
+++ b/internal/hostnetwork/underlay.go
@@ -133,6 +133,11 @@ func HasUnderlayInterface(namespace string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("HasUnderlayInterface: failed to find network namespace %s: %w", namespace, err)
 	}
+	defer func() {
+		if err := ns.Close(); err != nil {
+			slog.Error("failed to close namespace", "namespace", namespace, "error", err)
+		}
+	}()
 
 	underlayInterface, err := findInterfaceWithIP(ns, underlayInterfaceSpecialAddr)
 	if err != nil {

--- a/internal/hostnetwork/vni.go
+++ b/internal/hostnetwork/vni.go
@@ -45,6 +45,11 @@ func SetupVNI(ctx context.Context, params VNIParams) error {
 	if err != nil {
 		return fmt.Errorf("SetupVNI: Failed to get network namespace %s: %w", params.TargetNS, err)
 	}
+	defer func() {
+		if err := ns.Close(); err != nil {
+			slog.Error("failed to close namespace", "namespace", params.TargetNS, "error", err)
+		}
+	}()
 
 	hostVeth, peVeth, err := setupVeth(ctx, params.VRF, ns)
 	if err != nil {


### PR DESCRIPTION
Not closing it will cause the namespace to be leaked, with the undesired effect of leaving any interface connected to it to be dangling, waiting either to return to the host namespace (in case of physical interface) or to be deleted (in case of virtual interfaces).