### PR TITLE
Remove the router pod when an breaking config happens

### DIFF
--- a/config/all-in-one/crio.yaml
+++ b/config/all-in-one/crio.yaml
@@ -271,6 +271,7 @@ rules:
   resources:
   - pods
   verbs:
+  - delete
   - get
   - list
   - watch

--- a/config/all-in-one/openpe.yaml
+++ b/config/all-in-one/openpe.yaml
@@ -271,6 +271,7 @@ rules:
   resources:
   - pods
   verbs:
+  - delete
   - get
   - list
   - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -17,6 +17,7 @@ rules:
   resources:
   - pods
   verbs:
+  - delete
   - get
   - list
   - watch


### PR DESCRIPTION
When the underlay config changes, we kill the pod so the reconciliation loop starts again instead of recovering everything.