### PR TITLE
Prepare a portable host configuration validator

### DIFF
--- a/internal/hostnetwork/external_suite_test.go
+++ b/internal/hostnetwork/external_suite_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier:Apache-2.0
+
+//go:build externaltests
+// +build externaltests
+
+package hostnetwork
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	paramsFile string
+)
+
+func init() {
+	flag.StringVar(&paramsFile, "paramsfile", "", "the json file containing the parameters to verify")
+	flag.Parse()
+}
+
+func TestHostNetwork(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "HostNetwork Suite")
+}
+
+var _ = Describe("EXTERNAL", func() {
+
+	Context("underlay", func() {
+		var params UnderlayParams
+
+		BeforeEach(func() {
+			var err error
+			params, err = readParamsFromFile[UnderlayParams](paramsFile)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should be configured", func() {
+			Eventually(func(g Gomega) {
+				validateUnderlay(g, params)
+			}, 30*time.Second, 1*time.Second).Should(Succeed())
+		})
+	})
+
+	Context("vni", func() {
+		var params VNIParams
+		BeforeEach(func() {
+			var err error
+			params, err = readParamsFromFile[VNIParams](paramsFile)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should be configured", func() {
+			Eventually(func(g Gomega) {
+				validateVNI(g, params)
+			}, 30*time.Second, 1*time.Second).Should(Succeed())
+		})
+		It("should be deleted", func() {
+			Eventually(func(g Gomega) {
+				validateVNIIsNotConfigured(g, params)
+			}, 30*time.Second, 1*time.Second).Should(Succeed())
+		})
+
+	})
+
+})
+
+func readParamsFromFile[T any](filePath string) (T, error) {
+	var params T
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return params, fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	byteValue, err := ioutil.ReadAll(file)
+	if err != nil {
+		return params, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	err = json.Unmarshal(byteValue, &params)
+	if err != nil {
+		return params, fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	return params, nil
+}

--- a/internal/hostnetwork/underlay.go
+++ b/internal/hostnetwork/underlay.go
@@ -21,9 +21,9 @@ const (
 const underlayInterfaceSpecialAddr = "172.16.1.1/32"
 
 type UnderlayParams struct {
-	UnderlayInterface string
-	VtepIP            string
-	TargetNS          string
+	UnderlayInterface string `json:"underlay_interface"`
+	VtepIP            string `json:"vtep_ip"`
+	TargetNS          string `json:"target_ns"`
 }
 
 func SetupUnderlay(ctx context.Context, params UnderlayParams) error {

--- a/internal/hostnetwork/vni_test.go
+++ b/internal/hostnetwork/vni_test.go
@@ -48,7 +48,7 @@ var _ = Describe("VNI configuration", func() {
 			validateHostLeg(g, params)
 
 			_ = inNamespace(testNS, func() error {
-				validateNS(g, params)
+				validateVNI(g, params)
 				return nil
 			})
 		}, 30*time.Second, 1*time.Second).Should(Succeed())
@@ -83,7 +83,7 @@ var _ = Describe("VNI configuration", func() {
 			Eventually(func(g Gomega) {
 				validateHostLeg(g, p)
 				_ = inNamespace(testNS, func() error {
-					validateNS(g, p)
+					validateVNI(g, p)
 					return nil
 				})
 			}, 30*time.Second, 1*time.Second).Should(Succeed())
@@ -93,14 +93,14 @@ var _ = Describe("VNI configuration", func() {
 		toDelete := params[1]
 
 		By("removing non configured vnis")
-		err := RemoveNonConfiguredVNIs(testNS, []VNIParams{remaining})
+		err := RemoveNonConfiguredVNIs(testNSName, []VNIParams{remaining})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("checking remaining vnis")
 		Eventually(func(g Gomega) {
 			validateHostLeg(g, remaining)
 			_ = inNamespace(testNS, func() error {
-				validateNS(g, remaining)
+				validateVNI(g, remaining)
 				return nil
 			})
 		}, 30*time.Second, 1*time.Second).Should(Succeed())
@@ -134,7 +134,7 @@ var _ = Describe("VNI configuration", func() {
 			validateHostLeg(g, params)
 
 			_ = inNamespace(testNS, func() error {
-				validateNS(g, params)
+				validateVNI(g, params)
 				return nil
 			})
 		}, 30*time.Second, 1*time.Second).Should(Succeed())
@@ -153,7 +153,7 @@ func validateHostLeg(g Gomega, params VNIParams) {
 	g.Expect(hasIP).To(BeTrue(), "host leg does not have ip", params.VethHostIP)
 }
 
-func validateNS(g Gomega, params VNIParams) {
+func validateVNI(g Gomega, params VNIParams) {
 	loopback, err := netlink.LinkByName(UnderlayLoopback)
 	g.Expect(err).NotTo(HaveOccurred(), "loopback not found", UnderlayLoopback)
 


### PR DESCRIPTION
The idea is to have a way to inspect the expected status inside a router pod by sending the binary and a json with the expected config and run the test from there.