### PR TITLE
L2 VNI bridge: add a fixed mac address

### DIFF
--- a/internal/hostnetwork/vni.go
+++ b/internal/hostnetwork/vni.go
@@ -167,6 +167,11 @@ func SetupL2VNI(ctx context.Context, params L2VNIParams) error {
 			if err := assignIPToInterface(bridge, *params.L2GatewayIP); err != nil {
 				return fmt.Errorf("failed to assign L2 gateway IP %s to bridge %s: %w", *params.L2GatewayIP, name, err)
 			}
+
+			// setting up the same mac address for all the nodes for distributed gateway
+			if err := setBridgeFixedMacAddress(bridge, params.VNI); err != nil {
+				return fmt.Errorf("failed to set bridge mac address %s: %v", name, err)
+			}
 		}
 
 		return nil


### PR DESCRIPTION
When the distributed gw ip is set, let's have also the same mac address for the bridge so when used with vms, they'll find the same gateway during migration.