### PR TITLE
Router pod: allow a multus network for TOR connectivity

### DIFF
--- a/API-DOCS.md
+++ b/API-DOCS.md
@@ -199,7 +199,7 @@ _Appears in:_
 | `asn` _integer_ | ASN is the local AS number to use for the session with the TOR switch. |  | Maximum: 4.294967295e+09 <br />Minimum: 1 <br /> |
 | `vtepcidr` _string_ | VTEPCIDR is CIDR to be used to assign IPs to the local VTEP on each node. |  |  |
 | `neighbors` _[Neighbor](#neighbor) array_ | Neighbors is the list of external neighbors to peer with. |  | MinItems: 1 <br /> |
-| `nics` _string array_ | Nics is the list of physical nics to move under the PERouter namespace to connect<br />to external routers. |  | MinItems: 1 <br /> |
+| `nics` _string array_ | Nics is the list of physical nics to move under the PERouter namespace to connect<br />to external routers. This field is optional when using Multus networks for TOR connectivity. |  |  |
 
 
 #### UnderlayStatus

--- a/api/v1alpha1/underlay_types.go
+++ b/api/v1alpha1/underlay_types.go
@@ -37,10 +37,9 @@ type UnderlaySpec struct {
 	Neighbors []Neighbor `json:"neighbors,omitempty"`
 
 	// Nics is the list of physical nics to move under the PERouter namespace to connect
-	// to external routers.
+	// to external routers. This field is optional when using Multus networks for TOR connectivity.
 	// +kubebuilder:validation:Items=Pattern=`^[a-zA-Z][a-zA-Z0-9_-]*$`
 	// +kubebuilder:validation:Items=MaxLength=15
-	// +kubebuilder:validation:MinItems=1
 	Nics []string `json:"nics,omitempty"`
 }
 

--- a/charts/openperouter/README.md
+++ b/charts/openperouter/README.md
@@ -39,6 +39,7 @@ Kubernetes: `>= 1.19.0-0`
 | openperouter.image.tag | string | `""` |  |
 | openperouter.labels | object | `{}` |  |
 | openperouter.logLevel | string | `"info"` | Controller log level. Must be one of: `debug`, `info`, `warn` or `error`. |
+| openperouter.multusNetworkAnnotation | string | `""` | Multus network annotation to be added to router pods |
 | openperouter.nodemarker.resources | object | `{}` |  |
 | openperouter.podAnnotations | object | `{}` |  |
 | openperouter.priorityClassName | string | `""` |  |

--- a/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_underlays.yaml
+++ b/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_underlays.yaml
@@ -115,10 +115,9 @@ spec:
               nics:
                 description: |-
                   Nics is the list of physical nics to move under the PERouter namespace to connect
-                  to external routers.
+                  to external routers. This field is optional when using Multus networks for TOR connectivity.
                 items:
                   type: string
-                minItems: 1
                 type: array
               vtepcidr:
                 description: VTEPCIDR is CIDR to be used to assign IPs to the local

--- a/charts/openperouter/templates/router.yaml
+++ b/charts/openperouter/templates/router.yaml
@@ -119,6 +119,9 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: router
+        {{- if .Values.openperouter.multusNetworkAnnotation }}
+        k8s.v1.cni.cncf.io/networks: {{ .Values.openperouter.multusNetworkAnnotation | quote }}
+        {{- end }}
       labels:
         {{- include "openperouter.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: router

--- a/charts/openperouter/values.yaml
+++ b/charts/openperouter/values.yaml
@@ -13,6 +13,8 @@ openperouter:
   # -- Controller log level. Must be one of: `debug`, `info`, `warn` or `error`.
   logLevel: info
   tolerateMaster: true
+  # -- Multus network annotation to be added to router pods
+  multusNetworkAnnotation: ""
   image:
     repository: quay.io/openperouter/router
     tag: ""

--- a/config/all-in-one/crio.yaml
+++ b/config/all-in-one/crio.yaml
@@ -336,10 +336,9 @@ spec:
               nics:
                 description: |-
                   Nics is the list of physical nics to move under the PERouter namespace to connect
-                  to external routers.
+                  to external routers. This field is optional when using Multus networks for TOR connectivity.
                 items:
                   type: string
-                minItems: 1
                 type: array
               vtepcidr:
                 description: VTEPCIDR is CIDR to be used to assign IPs to the local

--- a/config/all-in-one/openpe.yaml
+++ b/config/all-in-one/openpe.yaml
@@ -336,10 +336,9 @@ spec:
               nics:
                 description: |-
                   Nics is the list of physical nics to move under the PERouter namespace to connect
-                  to external routers.
+                  to external routers. This field is optional when using Multus networks for TOR connectivity.
                 items:
                   type: string
-                minItems: 1
                 type: array
               vtepcidr:
                 description: VTEPCIDR is CIDR to be used to assign IPs to the local

--- a/config/crd/bases/openpe.openperouter.github.io_underlays.yaml
+++ b/config/crd/bases/openpe.openperouter.github.io_underlays.yaml
@@ -115,10 +115,9 @@ spec:
               nics:
                 description: |-
                   Nics is the list of physical nics to move under the PERouter namespace to connect
-                  to external routers.
+                  to external routers. This field is optional when using Multus networks for TOR connectivity.
                 items:
                   type: string
-                minItems: 1
                 type: array
               vtepcidr:
                 description: VTEPCIDR is CIDR to be used to assign IPs to the local

--- a/internal/conversion/validate_underlay.go
+++ b/internal/conversion/validate_underlay.go
@@ -24,9 +24,6 @@ func ValidateUnderlays(underlays []v1alpha1.Underlay) error {
 			return fmt.Errorf("invalid vtep CIDR format for underlay %s: %s - %w", underlay.Name, underlay.Spec.VTEPCIDR, err)
 		}
 
-		if len(underlay.Spec.Nics) == 0 {
-			return fmt.Errorf("underlay %s must have at least one nic", underlay.Name)
-		}
 		if len(underlay.Spec.Nics) > 1 {
 			return fmt.Errorf("underlay %s can only have one nic, found %d", underlay.Name, len(underlay.Spec.Nics))
 		}

--- a/internal/conversion/validate_underlay_test.go
+++ b/internal/conversion/validate_underlay_test.go
@@ -67,7 +67,18 @@ func TestValidateUnderlay(t *testing.T) {
 					ASN:      65001,
 				},
 			},
-			wantErr: true,
+			wantErr: false,
+		},
+		{
+			name: "valid underlay with no nics",
+			underlay: v1alpha1.Underlay{
+				Spec: v1alpha1.UnderlaySpec{
+					VTEPCIDR: "192.168.1.0/24",
+					Nics:     nil,
+					ASN:      65001,
+				},
+			},
+			wantErr: false,
 		},
 		{
 			name: "more than one nic",

--- a/operator/api/v1alpha1/openperouter_types.go
+++ b/operator/api/v1alpha1/openperouter_types.go
@@ -39,6 +39,9 @@ type OpenPERouterSpec struct {
 	// +optional
 	// +kubebuilder:validation:Enum=all;debug;info;warn;error;none
 	LogLevel LogLevel `json:"logLevel,omitempty"`
+	// MultusNetworkAnnotation specifies the Multus network annotation to be added to the router pod.
+	// +optional
+	MultusNetworkAnnotation string `json:"multusNetworkAnnotation,omitempty"`
 }
 
 // OpenPERouterStatus defines the observed state of OpenPERouter

--- a/operator/bindata/deployment/openperouter/README.md
+++ b/operator/bindata/deployment/openperouter/README.md
@@ -39,6 +39,7 @@ Kubernetes: `>= 1.19.0-0`
 | openperouter.image.tag | string | `""` |  |
 | openperouter.labels | object | `{}` |  |
 | openperouter.logLevel | string | `"info"` | Controller log level. Must be one of: `debug`, `info`, `warn` or `error`. |
+| openperouter.multusNetworkAnnotation | string | `""` | Multus network annotation to be added to router pods |
 | openperouter.nodemarker.resources | object | `{}` |  |
 | openperouter.podAnnotations | object | `{}` |  |
 | openperouter.priorityClassName | string | `""` |  |

--- a/operator/bindata/deployment/openperouter/templates/router.yaml
+++ b/operator/bindata/deployment/openperouter/templates/router.yaml
@@ -119,6 +119,9 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: router
+        {{- if .Values.openperouter.multusNetworkAnnotation }}
+        k8s.v1.cni.cncf.io/networks: {{ .Values.openperouter.multusNetworkAnnotation | quote }}
+        {{- end }}
       labels:
         {{- include "openperouter.selectorLabels" . | nindent 8 }}
         component: router

--- a/operator/bindata/deployment/openperouter/values.yaml
+++ b/operator/bindata/deployment/openperouter/values.yaml
@@ -13,6 +13,8 @@ openperouter:
   # -- Controller log level. Must be one of: `debug`, `info`, `warn` or `error`.
   logLevel: info
   tolerateMaster: true
+  # -- Multus network annotation to be added to router pods
+  multusNetworkAnnotation: ""
   image:
     repository: quay.io/openperouter/router
     tag: ""

--- a/operator/bundle/manifests/openpe.openperouter.github.io_openperouters.yaml
+++ b/operator/bundle/manifests/openpe.openperouter.github.io_openperouters.yaml
@@ -51,6 +51,10 @@ spec:
                 - error
                 - none
                 type: string
+              multusNetworkAnnotation:
+                description: MultusNetworkAnnotation specifies the Multus network
+                  annotation to be added to the router pod.
+                type: string
             type: object
           status:
             description: OpenPERouterStatus defines the observed state of OpenPERouter

--- a/operator/bundle/manifests/openpe.openperouter.github.io_underlays.yaml
+++ b/operator/bundle/manifests/openpe.openperouter.github.io_underlays.yaml
@@ -115,10 +115,9 @@ spec:
               nics:
                 description: |-
                   Nics is the list of physical nics to move under the PERouter namespace to connect
-                  to external routers.
+                  to external routers. This field is optional when using Multus networks for TOR connectivity.
                 items:
                   type: string
-                minItems: 1
                 type: array
               vtepcidr:
                 description: VTEPCIDR is CIDR to be used to assign IPs to the local

--- a/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2025-07-05T15:13:21Z"
+    createdAt: "2025-07-16T07:42:10Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: openperouter-operator.v0.0.0

--- a/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2025-07-16T07:42:10Z"
+    createdAt: "2025-07-16T07:47:04Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: openperouter-operator.v0.0.0

--- a/operator/config/crd/bases/openpe.openperouter.github.io_openperouters.yaml
+++ b/operator/config/crd/bases/openpe.openperouter.github.io_openperouters.yaml
@@ -51,6 +51,10 @@ spec:
                 - error
                 - none
                 type: string
+              multusNetworkAnnotation:
+                description: MultusNetworkAnnotation specifies the Multus network
+                  annotation to be added to the router pod.
+                type: string
             type: object
           status:
             description: OpenPERouterStatus defines the observed state of OpenPERouter

--- a/operator/internal/helm/chart.go
+++ b/operator/internal/helm/chart.go
@@ -86,7 +86,8 @@ func (h *Chart) Objects(envConfig envconfig.EnvConfig, crdConfig *operatorapi.Op
 
 func patchChartValues(envConfig envconfig.EnvConfig, crdConfig *operatorapi.OpenPERouter, valuesMap map[string]interface{}) {
 	valuesMap["openperouter"] = map[string]interface{}{
-		"logLevel": logLevelValue(crdConfig),
+		"logLevel":                logLevelValue(crdConfig),
+		"multusNetworkAnnotation": crdConfig.Spec.MultusNetworkAnnotation,
 		"image": map[string]interface{}{
 			"repository": envConfig.ControllerImage.Repo,
 			"tag":        envConfig.ControllerImage.Tag,

--- a/website/content/docs/api-reference.md
+++ b/website/content/docs/api-reference.md
@@ -207,7 +207,7 @@ _Appears in:_
 | `asn` _integer_ | ASN is the local AS number to use for the session with the TOR switch. |  | Maximum: 4.294967295e+09 <br />Minimum: 1 <br /> |
 | `vtepcidr` _string_ | VTEPCIDR is CIDR to be used to assign IPs to the local VTEP on each node. |  |  |
 | `neighbors` _[Neighbor](#neighbor) array_ | Neighbors is the list of external neighbors to peer with. |  | MinItems: 1 <br /> |
-| `nics` _string array_ | Nics is the list of physical nics to move under the PERouter namespace to connect<br />to external routers. |  | MinItems: 1 <br /> |
+| `nics` _string array_ | Nics is the list of physical nics to move under the PERouter namespace to connect<br />to external routers. This field is optional when using Multus networks for TOR connectivity. |  |  |
 
 
 #### UnderlayStatus

--- a/website/content/docs/configuration.md
+++ b/website/content/docs/configuration.md
@@ -52,6 +52,48 @@ The `vtepcidr` field defines the IP range used for VTEP (Virtual Tunnel End Poin
 - Node 3: `100.65.0.3`
 - etc.
 
+### Alternative: Multus Network for Top of Rack Connectivity
+
+Instead of declaring physical network interfaces in the underlay configuration, you can use Multus networks to provide connectivity to top of rack switches. In this case, the `nics` field in the underlay configuration can be omitted.
+
+When using this approach, ensure that the router pods are configured with the appropriate Multus network annotation to connect to your top of rack switches.
+
+#### Using Helm Values
+
+You can specify the Multus network annotation using Helm values:
+
+```yaml
+# values.yaml
+openperouter:
+  multusNetworkAnnotation: "macvlan-conf"
+```
+
+Or when installing with Helm:
+
+```bash
+helm install openperouter ./charts/openperouter \
+  --set openperouter.multusNetworkAnnotation="macvlan-conf"
+```
+
+This will add the annotation `k8s.v1.cni.cncf.io/networks: macvlan-conf` to the router pods.
+
+#### Using Kustomize
+
+Alternatively, you can use kustomize to add the annotation to the router pod:
+
+```yaml
+# kustomization.yaml
+patches:
+- target:
+    kind: DaemonSet
+    name: router
+  patch: |-
+    - op: add
+      path: /spec/template/metadata/annotations
+      value:
+        k8s.v1.cni.cncf.io/networks: macvlan-conf
+```
+
 ## L3 VNI Configuration
 
 L3 VNI (Virtual Network Identifier) configurations define EVPN L3 overlays. Each L3VNI creates a separate routing domain and BGP session with the host.


### PR DESCRIPTION
We allow the user to leverage a multus network for the underlay connectivity with the TOR>