### PR TITLE
Allow the user to specify the name of the bridge in case of autocreation

### DIFF
--- a/api/v1alpha1/l2vni_types.go
+++ b/api/v1alpha1/l2vni_types.go
@@ -54,10 +54,11 @@ type L2VNISpec struct {
 }
 
 // +kubebuilder:validation:Required
-// +kubebuilder:validation:xvalidation:rule="(self.name != '' && self.autocreate == false) || (self.name == '' && self.autocreate == true)",message="either name must be set or autocreate must be true, but not both."
+// +kubebuilder:validation:xvalidation:rule="(self.name != '' && self.autocreate == false) || (self.name == '' && self.autocreate == true) || (self.name != '' && self.autocreate == true)",message="either name must be set, autocreate must be true, or both can be set together."
 
 type HostMaster struct {
 	// Name of the host interface. Must match VRF name validation if set.
+	// When both name and autocreate are set, the bridge will be created with the provided name.
 	// +kubebuilder:validation:Pattern=`^[a-zA-Z][a-zA-Z0-9_-]*$`
 	// +kubebuilder:validation:MaxLength=15
 	// +optional
@@ -68,7 +69,8 @@ type HostMaster struct {
 	Type string `json:"type,omitempty"`
 
 	// If true, the interface will be created automatically if not present.
-	// The name of the bridge is of the form br-hs-<VNI>.
+	// If name is also set, the bridge will be created with the provided name.
+	// Otherwise, the name of the bridge is of the form br-hs-<VNI>.
 	// +kubebuilder:default:=false
 	AutoCreate bool `json:"autocreate,omitempty"`
 }

--- a/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_l2vnis.yaml
+++ b/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_l2vnis.yaml
@@ -52,11 +52,13 @@ spec:
                     default: false
                     description: |-
                       If true, the interface will be created automatically if not present.
-                      The name of the bridge is of the form br-hs-<VNI>.
+                      If name is also set, the bridge will be created with the provided name.
+                      Otherwise, the name of the bridge is of the form br-hs-<VNI>.
                     type: boolean
                   name:
-                    description: Name of the host interface. Must match VRF name validation
-                      if set.
+                    description: |-
+                      Name of the host interface. Must match VRF name validation if set.
+                      When both name and autocreate are set, the bridge will be created with the provided name.
                     maxLength: 15
                     pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
                     type: string

--- a/config/all-in-one/crio.yaml
+++ b/config/all-in-one/crio.yaml
@@ -61,11 +61,13 @@ spec:
                     default: false
                     description: |-
                       If true, the interface will be created automatically if not present.
-                      The name of the bridge is of the form br-hs-<VNI>.
+                      If name is also set, the bridge will be created with the provided name.
+                      Otherwise, the name of the bridge is of the form br-hs-<VNI>.
                     type: boolean
                   name:
-                    description: Name of the host interface. Must match VRF name validation
-                      if set.
+                    description: |-
+                      Name of the host interface. Must match VRF name validation if set.
+                      When both name and autocreate are set, the bridge will be created with the provided name.
                     maxLength: 15
                     pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
                     type: string

--- a/config/all-in-one/openpe.yaml
+++ b/config/all-in-one/openpe.yaml
@@ -61,11 +61,13 @@ spec:
                     default: false
                     description: |-
                       If true, the interface will be created automatically if not present.
-                      The name of the bridge is of the form br-hs-<VNI>.
+                      If name is also set, the bridge will be created with the provided name.
+                      Otherwise, the name of the bridge is of the form br-hs-<VNI>.
                     type: boolean
                   name:
-                    description: Name of the host interface. Must match VRF name validation
-                      if set.
+                    description: |-
+                      Name of the host interface. Must match VRF name validation if set.
+                      When both name and autocreate are set, the bridge will be created with the provided name.
                     maxLength: 15
                     pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
                     type: string

--- a/config/crd/bases/openpe.openperouter.github.io_l2vnis.yaml
+++ b/config/crd/bases/openpe.openperouter.github.io_l2vnis.yaml
@@ -52,11 +52,13 @@ spec:
                     default: false
                     description: |-
                       If true, the interface will be created automatically if not present.
-                      The name of the bridge is of the form br-hs-<VNI>.
+                      If name is also set, the bridge will be created with the provided name.
+                      Otherwise, the name of the bridge is of the form br-hs-<VNI>.
                     type: boolean
                   name:
-                    description: Name of the host interface. Must match VRF name validation
-                      if set.
+                    description: |-
+                      Name of the host interface. Must match VRF name validation if set.
+                      When both name and autocreate are set, the bridge will be created with the provided name.
                     maxLength: 15
                     pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
                     type: string

--- a/internal/hostnetwork/host_bridge.go
+++ b/internal/hostnetwork/host_bridge.go
@@ -12,10 +12,9 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-// createHostBridge creates a bridge on the host namespace named after the
-// provided vni. If the bridge already exists, it will return the existing one.
-func createHostBridge(vni int) (netlink.Link, error) {
-	name := hostBridgeName(vni)
+// createHostBridge creates a bridge on the host namespace with the provided name.
+// If the bridge already exists, it will return the existing one.
+func createHostBridge(name string) (netlink.Link, error) {
 	_, err := netlink.LinkByName(name)
 	// link does not exist, let's create it
 	if errors.As(err, &netlink.LinkNotFoundError{}) {

--- a/internal/hostnetwork/link_properties.go
+++ b/internal/hostnetwork/link_properties.go
@@ -57,10 +57,10 @@ func interfaceHasIP(link netlink.Link, address string) (bool, error) {
 	return false, nil
 }
 
-// interfaceHasIP tells if the given link does not have
-// ips of the given family.
-func interfaceHasNoIP(link netlink.Link, family int) (bool, error) {
-	addresses, err := netlink.AddrList(link, family)
+// interfaceHasNoIPv4 tells if the given link does not have
+// an ipv4 address.
+func interfaceHasNoIPv4(link netlink.Link) (bool, error) {
+	addresses, err := netlink.AddrList(link, netlink.FAMILY_V4)
 	if err != nil {
 		return false, fmt.Errorf("interfaceHasNoIP: failed to list addresses for interface %s: %w", link.Attrs().Name, err)
 	}

--- a/internal/hostnetwork/vni.go
+++ b/internal/hostnetwork/vni.go
@@ -378,9 +378,14 @@ func hostMaster(vni int, m HostMaster) (netlink.Link, error) {
 		}
 		return hostMaster, nil
 	}
-	bridge, err := createHostBridge(vni)
+
+	bridgeName := m.Name
+	if bridgeName == "" {
+		bridgeName = hostBridgeName(vni)
+	}
+	bridge, err := createHostBridge(bridgeName)
 	if err != nil {
-		return nil, fmt.Errorf("getHostMaster: failed to create host bridge %d: %w", vni, err)
+		return nil, fmt.Errorf("getHostMaster: failed to create host bridge %s: %w", bridgeName, err)
 	}
 	return bridge, nil
 }

--- a/internal/hostnetwork/vni_test.go
+++ b/internal/hostnetwork/vni_test.go
@@ -460,7 +460,7 @@ func validateL2HostLeg(g Gomega, params L2VNIParams) {
 	g.Expect(err).NotTo(HaveOccurred(), "host side not found", hostSide)
 
 	g.Expect(hostLegLink.Attrs().OperState).To(BeEquivalentTo(netlink.OperUp))
-	hasNoIP, err := interfaceHasNoIP(hostLegLink, netlink.FAMILY_V4)
+	hasNoIP, err := interfaceHasNoIPv4(hostLegLink)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(hasNoIP).To(BeTrue(), "host leg does have ip")
 	if params.HostMaster != nil {
@@ -512,7 +512,7 @@ func validateL2VNI(g Gomega, params L2VNIParams) {
 	g.Expect(err).NotTo(HaveOccurred(), "veth pe side not found", peSide)
 	g.Expect(peLegLink.Attrs().OperState).To(BeEquivalentTo(netlink.OperUp))
 
-	hasNoIP, err := interfaceHasNoIP(peLegLink, netlink.FAMILY_V4)
+	hasNoIP, err := interfaceHasNoIPv4(peLegLink)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(hasNoIP).To(BeTrue(), "host leg does have ip")
 
@@ -527,7 +527,7 @@ func validateL2VNI(g Gomega, params L2VNIParams) {
 		validateBridgeMacAddress(g, bridgeLink, params.VNI)
 		return
 	} else {
-		hasNoIP, err := interfaceHasNoIP(bridgeLink, netlink.FAMILY_V4)
+		hasNoIP, err := interfaceHasNoIPv4(bridgeLink)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(hasNoIP).To(BeTrue(), "bridge does have ip")
 	}
@@ -653,7 +653,7 @@ func validateL2HostLegWithCustomBridge(g Gomega, params L2VNIParams, customBridg
 	g.Expect(err).NotTo(HaveOccurred(), "host side not found", hostSide)
 
 	g.Expect(hostLegLink.Attrs().OperState).To(BeEquivalentTo(netlink.OperUp))
-	hasNoIP, err := interfaceHasNoIP(hostLegLink, netlink.FAMILY_V4)
+	hasNoIP, err := interfaceHasNoIPv4(hostLegLink)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(hasNoIP).To(BeTrue(), "host leg does have ip")
 

--- a/operator/bundle/manifests/openpe.openperouter.github.io_l2vnis.yaml
+++ b/operator/bundle/manifests/openpe.openperouter.github.io_l2vnis.yaml
@@ -52,11 +52,13 @@ spec:
                     default: false
                     description: |-
                       If true, the interface will be created automatically if not present.
-                      The name of the bridge is of the form br-hs-<VNI>.
+                      If name is also set, the bridge will be created with the provided name.
+                      Otherwise, the name of the bridge is of the form br-hs-<VNI>.
                     type: boolean
                   name:
-                    description: Name of the host interface. Must match VRF name validation
-                      if set.
+                    description: |-
+                      Name of the host interface. Must match VRF name validation if set.
+                      When both name and autocreate are set, the bridge will be created with the provided name.
                     maxLength: 15
                     pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
                     type: string

--- a/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2025-07-05T15:13:21Z"
+    createdAt: "2025-07-15T19:05:31Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: openperouter-operator.v0.0.0

--- a/website/content/docs/configuration.md
+++ b/website/content/docs/configuration.md
@@ -133,7 +133,7 @@ L2VNIs provide Layer 2 connectivity across nodes using EVPN tunnels. Unlike L3VN
 | `vrf` | string | Name of the VRF to associate with this L2VNI | Yes |
 | `hostmaster.type` | string | Type of host interface management (`bridge` or `direct`) | Yes |
 | `hostmaster.autocreate` | boolean | Whether to automatically create a bridge if type is `bridge` | No |
-| `hostmaster.bridgeName` | string | Name of the bridge to attach to (if not auto-creating) | No |
+| `hostmaster.bridgeName` | string | Name of the bridge to attach to. In case of autocreate, the bridge is created with this name. Otherwise, it assumes the bridge is already existing | No |
 
 ### L2VNI Example
 


### PR DESCRIPTION
If autocreate=true, let's use the bridge name to choose a valid name