### PR TITLE
CIDR / gatewayip fields: make immutable

### DIFF
--- a/api/v1alpha1/l2vni_types.go
+++ b/api/v1alpha1/l2vni_types.go
@@ -50,6 +50,7 @@ type L2VNISpec struct {
 	// bridge the veths are enslaved to will be configured with this IP address, effectively
 	// acting as a distributed gateway for the VNI.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="L2GatewayIP can't be changed"
 	L2GatewayIP string `json:"l2gatewayip,omitempty"`
 }
 

--- a/api/v1alpha1/l3vni_types.go
+++ b/api/v1alpha1/l3vni_types.go
@@ -55,6 +55,7 @@ type L3VNISpec struct {
 	// the PERouter side is going to use the first IP of the cidr on all the nodes.
 	// At least one of IPv4 or IPv6 must be provided.
 	// +required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="LocalCIDR can't be changed"
 	LocalCIDR LocalCIDRConfig `json:"localcidr"`
 
 	// VXLanPort is the port to be used for VXLan encapsulation.

--- a/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_l2vnis.yaml
+++ b/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_l2vnis.yaml
@@ -73,6 +73,9 @@ spec:
                   bridge the veths are enslaved to will be configured with this IP address, effectively
                   acting as a distributed gateway for the VNI.
                 type: string
+                x-kubernetes-validations:
+                - message: L2GatewayIP can't be changed
+                  rule: self == oldSelf
               vni:
                 description: VNI is the VXLan VNI to be used
                 format: int32

--- a/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_l3vnis.yaml
+++ b/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_l3vnis.yaml
@@ -77,6 +77,9 @@ spec:
                       the PERouter side is going to use the first IP of the cidr on all the nodes.
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: LocalCIDR can't be changed
+                  rule: self == oldSelf
               vni:
                 description: VNI is the VXLan VNI to be used
                 format: int32

--- a/config/all-in-one/crio.yaml
+++ b/config/all-in-one/crio.yaml
@@ -82,6 +82,9 @@ spec:
                   bridge the veths are enslaved to will be configured with this IP address, effectively
                   acting as a distributed gateway for the VNI.
                 type: string
+                x-kubernetes-validations:
+                - message: L2GatewayIP can't be changed
+                  rule: self == oldSelf
               vni:
                 description: VNI is the VXLan VNI to be used
                 format: int32
@@ -190,6 +193,9 @@ spec:
                       the PERouter side is going to use the first IP of the cidr on all the nodes.
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: LocalCIDR can't be changed
+                  rule: self == oldSelf
               vni:
                 description: VNI is the VXLan VNI to be used
                 format: int32

--- a/config/all-in-one/openpe.yaml
+++ b/config/all-in-one/openpe.yaml
@@ -82,6 +82,9 @@ spec:
                   bridge the veths are enslaved to will be configured with this IP address, effectively
                   acting as a distributed gateway for the VNI.
                 type: string
+                x-kubernetes-validations:
+                - message: L2GatewayIP can't be changed
+                  rule: self == oldSelf
               vni:
                 description: VNI is the VXLan VNI to be used
                 format: int32
@@ -190,6 +193,9 @@ spec:
                       the PERouter side is going to use the first IP of the cidr on all the nodes.
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: LocalCIDR can't be changed
+                  rule: self == oldSelf
               vni:
                 description: VNI is the VXLan VNI to be used
                 format: int32

--- a/config/crd/bases/openpe.openperouter.github.io_l2vnis.yaml
+++ b/config/crd/bases/openpe.openperouter.github.io_l2vnis.yaml
@@ -73,6 +73,9 @@ spec:
                   bridge the veths are enslaved to will be configured with this IP address, effectively
                   acting as a distributed gateway for the VNI.
                 type: string
+                x-kubernetes-validations:
+                - message: L2GatewayIP can't be changed
+                  rule: self == oldSelf
               vni:
                 description: VNI is the VXLan VNI to be used
                 format: int32

--- a/config/crd/bases/openpe.openperouter.github.io_l3vnis.yaml
+++ b/config/crd/bases/openpe.openperouter.github.io_l3vnis.yaml
@@ -77,6 +77,9 @@ spec:
                       the PERouter side is going to use the first IP of the cidr on all the nodes.
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: LocalCIDR can't be changed
+                  rule: self == oldSelf
               vni:
                 description: VNI is the VXLan VNI to be used
                 format: int32

--- a/e2etests/tests/hostconfiguration.go
+++ b/e2etests/tests/hostconfiguration.go
@@ -312,7 +312,6 @@ var _ = ginkgo.Describe("Router Host configuration", func() {
 
 			resources.L3VNIs[0].Spec.ASN = 64515
 			resources.L3VNIs[0].Spec.VNI = 300
-			resources.L3VNIs[0].Spec.LocalCIDR.IPv4 = "192.171.10.0/24"
 			resources.L3VNIs[0].Spec.HostASN = ptr.To(uint32(64516))
 			err = Updater.Update(resources)
 			Expect(err).NotTo(HaveOccurred())

--- a/internal/webhooks/l2vni_webhook.go
+++ b/internal/webhooks/l2vni_webhook.go
@@ -67,7 +67,7 @@ func (v *L2VNIValidator) Handle(ctx context.Context, req admission.Request) (res
 			return admission.Denied(err.Error())
 		}
 	case v1.Update:
-		if err := validateL2VNIUpdate(&l2vni); err != nil {
+		if err := validateL2VNIUpdate(&l2vni, &oldL2VNI); err != nil {
 			return admission.Denied(err.Error())
 		}
 	case v1.Delete:
@@ -85,9 +85,13 @@ func validateL2VNICreate(l2vni *v1alpha1.L2VNI) error {
 	return validateL2VNI(l2vni)
 }
 
-func validateL2VNIUpdate(l2vni *v1alpha1.L2VNI) error {
+func validateL2VNIUpdate(l2vni *v1alpha1.L2VNI, oldL2VNI *v1alpha1.L2VNI) error {
 	Logger.Debug("webhook l2vni", "action", "update", "name", l2vni.Name, "namespace", l2vni.Namespace)
 	defer Logger.Debug("webhook l2vni", "action", "end update", "name", l2vni.Name, "namespace", l2vni.Namespace)
+
+	if oldL2VNI.Spec.L2GatewayIP != l2vni.Spec.L2GatewayIP {
+		return errors.New("L2GatewayIP cannot be changed")
+	}
 
 	return validateL2VNI(l2vni)
 }

--- a/internal/webhooks/l3vni_webhook.go
+++ b/internal/webhooks/l3vni_webhook.go
@@ -67,7 +67,7 @@ func (v *L3VNIValidator) Handle(ctx context.Context, req admission.Request) (res
 			return admission.Denied(err.Error())
 		}
 	case v1.Update:
-		if err := validateL3VNIUpdate(&l3vni); err != nil {
+		if err := validateL3VNIUpdate(&l3vni, &oldL3VNI); err != nil {
 			return admission.Denied(err.Error())
 		}
 	case v1.Delete:
@@ -85,9 +85,13 @@ func validateL3VNICreate(l3vni *v1alpha1.L3VNI) error {
 	return validateL3VNI(l3vni)
 }
 
-func validateL3VNIUpdate(l3vni *v1alpha1.L3VNI) error {
+func validateL3VNIUpdate(l3vni *v1alpha1.L3VNI, oldL3VNI *v1alpha1.L3VNI) error {
 	Logger.Debug("webhook l3vni", "action", "update", "name", l3vni.Name, "namespace", l3vni.Namespace)
 	defer Logger.Debug("webhook l3vni", "action", "end update", "name", l3vni.Name, "namespace", l3vni.Namespace)
+
+	if oldL3VNI.Spec.LocalCIDR != l3vni.Spec.LocalCIDR {
+		return errors.New("LocalCIDR cannot be changed")
+	}
 
 	return validateL3VNI(l3vni)
 }

--- a/operator/bundle/manifests/openpe.openperouter.github.io_l2vnis.yaml
+++ b/operator/bundle/manifests/openpe.openperouter.github.io_l2vnis.yaml
@@ -73,6 +73,9 @@ spec:
                   bridge the veths are enslaved to will be configured with this IP address, effectively
                   acting as a distributed gateway for the VNI.
                 type: string
+                x-kubernetes-validations:
+                - message: L2GatewayIP can't be changed
+                  rule: self == oldSelf
               vni:
                 description: VNI is the VXLan VNI to be used
                 format: int32

--- a/operator/bundle/manifests/openpe.openperouter.github.io_l3vnis.yaml
+++ b/operator/bundle/manifests/openpe.openperouter.github.io_l3vnis.yaml
@@ -77,6 +77,9 @@ spec:
                       the PERouter side is going to use the first IP of the cidr on all the nodes.
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: LocalCIDR can't be changed
+                  rule: self == oldSelf
               vni:
                 description: VNI is the VXLan VNI to be used
                 format: int32

--- a/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2025-08-16T16:45:17Z"
+    createdAt: "2025-08-16T17:45:22Z"
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: openperouter-operator.v0.0.0


### PR DESCRIPTION


<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

Editing the gateway ip resulted in appending the ip instead of deleting.
Changing those fields would result in a drop in the connectivity in any case, so it's easier to declare them immutable.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Make gateway ip and local cidrs immutable.
```
