### PR TITLE
Deploy CNI plugins on L2 demo cluster

### DIFF
--- a/examples/layer2/cni-plugins.yaml
+++ b/examples/layer2/cni-plugins.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cni-plugins-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cni-plugins-installer
+  namespace: cni-plugins-system
+spec:
+  selector:
+    matchLabels:
+      name: cni-plugins-installer
+  template:
+    metadata:
+      labels:
+        name: cni-plugins-installer
+    spec:
+      containers:
+      - name: pause
+        image: gcr.io/google-containers/pause:3.1
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+      initContainers:
+      - name: install-cni-plugins
+        image: busybox:1.36
+        command:
+          - sh
+          - -c
+          - |
+            set -ex
+            wget -O /tmp/cni-plugins.tgz https://github.com/containernetworking/plugins/releases/download/v1.7.1/cni-plugins-linux-amd64-v1.7.1.tgz
+            tar -xzvf /tmp/cni-plugins.tgz -C /host/opt/cni/bin
+            rm /tmp/cni-plugins.tgz
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-bin
+      volumes:
+      - name: cni-bin
+        hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate

--- a/examples/layer2/prepare.sh
+++ b/examples/layer2/prepare.sh
@@ -8,5 +8,4 @@ source "${CURRENT_PATH}/../common.sh"
 DEMO_MODE=true make deploy
 export KUBECONFIG=$(pwd)/bin/kubeconfig
 
-apply_manifests_with_retries openpe.yaml workload.yaml
-
+apply_manifests_with_retries openpe.yaml workload.yaml cni-plugins.yaml


### PR DESCRIPTION


<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

Without this patch, the demo Pods fail to start due to missing macvlan CNI.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
