### PR TITLE
Have a different routerid per node

### DIFF
--- a/api/v1alpha1/underlay_types.go
+++ b/api/v1alpha1/underlay_types.go
@@ -33,6 +33,11 @@ type UnderlaySpec struct {
 	// +required
 	VTEPCIDR string `json:"vtepcidr,omitempty"`
 
+	// RouterIDCIDR is the ipv4 cidr to be used to assign a different routerID on each node.
+	// +kubebuilder:default="10.0.0.0/24"
+	// +optional
+	RouterIDCIDR string `json:"routeridcidr,omitempty"`
+
 	// Neighbors is the list of external neighbors to peer with.
 	// +kubebuilder:validation:MinItems=1
 	Neighbors []Neighbor `json:"neighbors,omitempty"`

--- a/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_underlays.yaml
+++ b/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_underlays.yaml
@@ -191,6 +191,11 @@ spec:
                 items:
                   type: string
                 type: array
+              routeridcidr:
+                default: 10.0.0.0/24
+                description: RouterIDCIDR is the ipv4 cidr to be used to assign a
+                  different routerID on each node.
+                type: string
               vtepcidr:
                 description: VTEPCIDR is CIDR to be used to assign IPs to the local
                   VTEP on each node.

--- a/config/all-in-one/crio.yaml
+++ b/config/all-in-one/crio.yaml
@@ -425,6 +425,11 @@ spec:
                 items:
                   type: string
                 type: array
+              routeridcidr:
+                default: 10.0.0.0/24
+                description: RouterIDCIDR is the ipv4 cidr to be used to assign a
+                  different routerID on each node.
+                type: string
               vtepcidr:
                 description: VTEPCIDR is CIDR to be used to assign IPs to the local
                   VTEP on each node.

--- a/config/all-in-one/openpe.yaml
+++ b/config/all-in-one/openpe.yaml
@@ -425,6 +425,11 @@ spec:
                 items:
                   type: string
                 type: array
+              routeridcidr:
+                default: 10.0.0.0/24
+                description: RouterIDCIDR is the ipv4 cidr to be used to assign a
+                  different routerID on each node.
+                type: string
               vtepcidr:
                 description: VTEPCIDR is CIDR to be used to assign IPs to the local
                   VTEP on each node.

--- a/config/crd/bases/openpe.openperouter.github.io_underlays.yaml
+++ b/config/crd/bases/openpe.openperouter.github.io_underlays.yaml
@@ -191,6 +191,11 @@ spec:
                 items:
                   type: string
                 type: array
+              routeridcidr:
+                default: 10.0.0.0/24
+                description: RouterIDCIDR is the ipv4 cidr to be used to assign a
+                  different routerID on each node.
+                type: string
               vtepcidr:
                 description: VTEPCIDR is CIDR to be used to assign IPs to the local
                   VTEP on each node.

--- a/internal/conversion/frr_conversion_test.go
+++ b/internal/conversion/frr_conversion_test.go
@@ -37,9 +37,10 @@ func TestAPItoFRR(t *testing.T) {
 			underlays: []v1alpha1.Underlay{
 				{
 					Spec: v1alpha1.UnderlaySpec{
-						ASN:       65000,
-						VTEPCIDR:  "192.168.1.0/24",
-						Neighbors: []v1alpha1.Neighbor{{Address: "192.168.1.1", ASN: 65001}},
+						ASN:          65000,
+						VTEPCIDR:     "192.168.1.0/24",
+						RouterIDCIDR: "10.0.0.0/24",
+						Neighbors:    []v1alpha1.Neighbor{{Address: "192.168.1.1", ASN: 65001}},
 					},
 				},
 			},
@@ -47,8 +48,9 @@ func TestAPItoFRR(t *testing.T) {
 			logLevel: "debug",
 			want: frr.Config{
 				Underlay: frr.UnderlayConfig{
-					MyASN: 65000,
-					VTEP:  "192.168.1.0/32",
+					MyASN:    65000,
+					VTEP:     "192.168.1.0/32",
+					RouterID: "10.0.0.1",
 					Neighbors: []frr.NeighborConfig{
 						{
 							Name:         "65001@192.168.1.1",
@@ -71,9 +73,10 @@ func TestAPItoFRR(t *testing.T) {
 			underlays: []v1alpha1.Underlay{
 				{
 					Spec: v1alpha1.UnderlaySpec{
-						ASN:       65000,
-						VTEPCIDR:  "192.168.1.0/24",
-						Neighbors: []v1alpha1.Neighbor{{Address: "192.168.1.1", ASN: 65001}},
+						ASN:          65000,
+						VTEPCIDR:     "192.168.1.0/24",
+						RouterIDCIDR: "10.0.0.0/24",
+						Neighbors:    []v1alpha1.Neighbor{{Address: "192.168.1.1", ASN: 65001}},
 					},
 				},
 			},
@@ -96,8 +99,9 @@ func TestAPItoFRR(t *testing.T) {
 			logLevel: "debug",
 			want: frr.Config{
 				Underlay: frr.UnderlayConfig{
-					MyASN: 65000,
-					VTEP:  "192.168.1.0/32",
+					MyASN:    65000,
+					VTEP:     "192.168.1.0/32",
+					RouterID: "10.0.0.1",
 					Neighbors: []frr.NeighborConfig{
 						{
 							Name:         "65001@192.168.1.1",
@@ -110,9 +114,10 @@ func TestAPItoFRR(t *testing.T) {
 				},
 				VNIs: []frr.L3VNIConfig{
 					{
-						ASN: 65000,
-						VNI: 200,
-						VRF: "vrf1",
+						ASN:      65000,
+						VNI:      200,
+						VRF:      "vrf1",
+						RouterID: "10.0.0.1",
 						LocalNeighbor: &frr.NeighborConfig{
 							Addr: "192.168.2.2",
 							ASN:  65001,
@@ -132,9 +137,10 @@ func TestAPItoFRR(t *testing.T) {
 			underlays: []v1alpha1.Underlay{
 				{
 					Spec: v1alpha1.UnderlaySpec{
-						ASN:       65000,
-						VTEPCIDR:  "192.168.1.0/24",
-						Neighbors: []v1alpha1.Neighbor{{Address: "192.168.1.1", ASN: 65001}},
+						ASN:          65000,
+						VTEPCIDR:     "192.168.1.0/24",
+						RouterIDCIDR: "10.0.0.0/24",
+						Neighbors:    []v1alpha1.Neighbor{{Address: "192.168.1.1", ASN: 65001}},
 					},
 				},
 			},
@@ -157,8 +163,9 @@ func TestAPItoFRR(t *testing.T) {
 			logLevel: "debug",
 			want: frr.Config{
 				Underlay: frr.UnderlayConfig{
-					MyASN: 65000,
-					VTEP:  "192.168.1.0/32",
+					MyASN:    65000,
+					VTEP:     "192.168.1.0/32",
+					RouterID: "10.0.0.1",
 					Neighbors: []frr.NeighborConfig{
 						{
 							Name:         "65001@192.168.1.1",
@@ -171,9 +178,10 @@ func TestAPItoFRR(t *testing.T) {
 				},
 				VNIs: []frr.L3VNIConfig{
 					{
-						ASN: 65000,
-						VNI: 200,
-						VRF: "vrf1",
+						ASN:      65000,
+						VNI:      200,
+						VRF:      "vrf1",
+						RouterID: "10.0.0.1",
 						LocalNeighbor: &frr.NeighborConfig{
 							Addr: "2001:db8::2",
 							ASN:  65001,
@@ -193,9 +201,10 @@ func TestAPItoFRR(t *testing.T) {
 			underlays: []v1alpha1.Underlay{
 				{
 					Spec: v1alpha1.UnderlaySpec{
-						ASN:       65000,
-						VTEPCIDR:  "192.168.1.0/24",
-						Neighbors: []v1alpha1.Neighbor{{Address: "192.168.1.1", ASN: 65001}},
+						ASN:          65000,
+						VTEPCIDR:     "192.168.1.0/24",
+						RouterIDCIDR: "10.0.0.0/24",
+						Neighbors:    []v1alpha1.Neighbor{{Address: "192.168.1.1", ASN: 65001}},
 					},
 				},
 			},
@@ -219,8 +228,9 @@ func TestAPItoFRR(t *testing.T) {
 			logLevel: "debug",
 			want: frr.Config{
 				Underlay: frr.UnderlayConfig{
-					MyASN: 65000,
-					VTEP:  "192.168.1.0/32",
+					MyASN:    65000,
+					VTEP:     "192.168.1.0/32",
+					RouterID: "10.0.0.1",
 					Neighbors: []frr.NeighborConfig{
 						{
 							Name:         "65001@192.168.1.1",
@@ -233,9 +243,10 @@ func TestAPItoFRR(t *testing.T) {
 				},
 				VNIs: []frr.L3VNIConfig{
 					{
-						ASN: 65000,
-						VNI: 200,
-						VRF: "vrf1",
+						ASN:      65000,
+						VNI:      200,
+						VRF:      "vrf1",
+						RouterID: "10.0.0.1",
 						LocalNeighbor: &frr.NeighborConfig{
 							Addr: "192.168.2.2",
 							ASN:  65001,
@@ -244,9 +255,10 @@ func TestAPItoFRR(t *testing.T) {
 						ToAdvertiseIPv6: []string{},
 					},
 					{
-						ASN: 65000,
-						VNI: 200,
-						VRF: "vrf1",
+						ASN:      65000,
+						VNI:      200,
+						VRF:      "vrf1",
+						RouterID: "10.0.0.1",
 						LocalNeighbor: &frr.NeighborConfig{
 							Addr: "2001:db8::2",
 							ASN:  65001,
@@ -266,8 +278,9 @@ func TestAPItoFRR(t *testing.T) {
 			underlays: []v1alpha1.Underlay{
 				{
 					Spec: v1alpha1.UnderlaySpec{
-						ASN:      65000,
-						VTEPCIDR: "192.168.1.0/24",
+						ASN:          65000,
+						VTEPCIDR:     "192.168.1.0/24",
+						RouterIDCIDR: "10.0.0.0/24",
 						Neighbors: []v1alpha1.Neighbor{
 							{
 								Address: "192.168.1.100",
@@ -288,8 +301,9 @@ func TestAPItoFRR(t *testing.T) {
 			logLevel: "debug",
 			want: frr.Config{
 				Underlay: frr.UnderlayConfig{
-					MyASN: 65000,
-					VTEP:  "192.168.1.0/32",
+					MyASN:    65000,
+					VTEP:     "192.168.1.0/32",
+					RouterID: "10.0.0.1",
 					Neighbors: []frr.NeighborConfig{
 						{
 							Name:         "65001@192.168.1.100",
@@ -321,8 +335,9 @@ func TestAPItoFRR(t *testing.T) {
 			underlays: []v1alpha1.Underlay{
 				{
 					Spec: v1alpha1.UnderlaySpec{
-						ASN:      65000,
-						VTEPCIDR: "192.168.1.0/24",
+						ASN:          65000,
+						VTEPCIDR:     "192.168.1.0/24",
+						RouterIDCIDR: "10.0.0.0/24",
 						Neighbors: []v1alpha1.Neighbor{
 							{
 								Address: "192.168.1.100",
@@ -337,8 +352,9 @@ func TestAPItoFRR(t *testing.T) {
 			logLevel: "debug",
 			want: frr.Config{
 				Underlay: frr.UnderlayConfig{
-					MyASN: 65000,
-					VTEP:  "192.168.1.0/32",
+					MyASN:    65000,
+					VTEP:     "192.168.1.0/32",
+					RouterID: "10.0.0.1",
 					Neighbors: []frr.NeighborConfig{
 						{
 							Name:         "65001@192.168.1.100",
@@ -363,9 +379,10 @@ func TestAPItoFRR(t *testing.T) {
 			underlays: []v1alpha1.Underlay{
 				{
 					Spec: v1alpha1.UnderlaySpec{
-						ASN:       65000,
-						VTEPCIDR:  "192.168.1.0/24",
-						Neighbors: []v1alpha1.Neighbor{{Address: "192.168.1.1", ASN: 65001}},
+						ASN:          65000,
+						VTEPCIDR:     "192.168.1.0/24",
+						RouterIDCIDR: "10.0.0.0/24",
+						Neighbors:    []v1alpha1.Neighbor{{Address: "192.168.1.1", ASN: 65001}},
 					},
 				},
 			},
@@ -381,8 +398,9 @@ func TestAPItoFRR(t *testing.T) {
 			logLevel: "debug",
 			want: frr.Config{
 				Underlay: frr.UnderlayConfig{
-					MyASN: 65000,
-					VTEP:  "192.168.1.0/32",
+					MyASN:    65000,
+					VTEP:     "192.168.1.0/32",
+					RouterID: "10.0.0.1",
 					Neighbors: []frr.NeighborConfig{
 						{
 							Name:         "65001@192.168.1.1",
@@ -395,9 +413,73 @@ func TestAPItoFRR(t *testing.T) {
 				},
 				VNIs: []frr.L3VNIConfig{
 					{
+						ASN:      65000,
+						VNI:      200,
+						VRF:      "vrf1",
+						RouterID: "10.0.0.1",
+					},
+				},
+				BFDProfiles: []frr.BFDProfile{},
+				Loglevel:    "debug",
+			},
+			wantErr: false,
+		},
+		{
+			name:      "empty routeridcidr uses default",
+			nodeIndex: 0,
+			underlays: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						ASN:          65000,
+						VTEPCIDR:     "192.168.1.0/24",
+						RouterIDCIDR: "",
+						Neighbors:    []v1alpha1.Neighbor{{Address: "192.168.1.1", ASN: 65001}},
+					},
+				},
+			},
+			vnis: []v1alpha1.L3VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni1"},
+					Spec: v1alpha1.L3VNISpec{
+						HostSession: &v1alpha1.HostSession{
+							ASN: 65000,
+							LocalCIDR: v1alpha1.LocalCIDRConfig{
+								IPv4: "192.168.2.0/24",
+							},
+							HostASN: 65001,
+						},
 						VNI: 200,
-						VRF: "vrf1",
-						ASN: 65000,
+					},
+				},
+			},
+			logLevel: "debug",
+			want: frr.Config{
+				Underlay: frr.UnderlayConfig{
+					MyASN:    65000,
+					VTEP:     "192.168.1.0/32",
+					RouterID: "10.0.0.1",
+					Neighbors: []frr.NeighborConfig{
+						{
+							Name:         "65001@192.168.1.1",
+							ASN:          65001,
+							Addr:         "192.168.1.1",
+							IPFamily:     ipfamily.IPv4,
+							EBGPMultiHop: false,
+						},
+					},
+				},
+				VNIs: []frr.L3VNIConfig{
+					{
+						ASN:      65000,
+						VNI:      200,
+						VRF:      "vni1",
+						RouterID: "10.0.0.1",
+						LocalNeighbor: &frr.NeighborConfig{
+							Addr: "192.168.2.2",
+							ASN:  65001,
+						},
+						ToAdvertiseIPv4: []string{"192.168.2.2/32"},
+						ToAdvertiseIPv6: []string{},
 					},
 				},
 				BFDProfiles: []frr.BFDProfile{},

--- a/internal/frr/config.go
+++ b/internal/frr/config.go
@@ -30,6 +30,7 @@ type Config struct {
 type UnderlayConfig struct {
 	MyASN     uint32
 	VTEP      string
+	RouterID  string
 	Neighbors []NeighborConfig
 }
 
@@ -40,6 +41,7 @@ type L3VNIConfig struct {
 	LocalNeighbor   *NeighborConfig
 	VRF             string
 	VNI             int
+	RouterID        string
 }
 
 type BFDProfile struct {

--- a/internal/frr/frr_test.go
+++ b/internal/frr/frr_test.go
@@ -28,8 +28,9 @@ func TestBasic(t *testing.T) {
 
 	config := Config{
 		Underlay: UnderlayConfig{
-			MyASN: 64512,
-			VTEP:  "100.64.0.1/32",
+			MyASN:    64512,
+			VTEP:     "100.64.0.1/32",
+			RouterID: "10.0.0.1",
 			Neighbors: []NeighborConfig{
 				{
 					ASN:      64512,
@@ -40,9 +41,10 @@ func TestBasic(t *testing.T) {
 		},
 		VNIs: []L3VNIConfig{
 			{
-				VRF: "red",
-				ASN: 64512,
-				VNI: 100,
+				VRF:      "red",
+				ASN:      64512,
+				VNI:      100,
+				RouterID: "10.0.0.1",
 				LocalNeighbor: &NeighborConfig{
 					ASN:      64512,
 					Addr:     "192.168.1.2",
@@ -67,8 +69,9 @@ func TestDualStack(t *testing.T) {
 
 	config := Config{
 		Underlay: UnderlayConfig{
-			MyASN: 64512,
-			VTEP:  "100.64.0.1/32",
+			MyASN:    64512,
+			VTEP:     "100.64.0.1/32",
+			RouterID: "10.0.0.1",
 			Neighbors: []NeighborConfig{
 				{
 					ASN:      64512,
@@ -79,9 +82,10 @@ func TestDualStack(t *testing.T) {
 		},
 		VNIs: []L3VNIConfig{
 			{
-				VRF: "red",
-				ASN: 64512,
-				VNI: 100,
+				VRF:      "red",
+				ASN:      64512,
+				VNI:      100,
+				RouterID: "10.0.0.1",
 				LocalNeighbor: &NeighborConfig{
 					ASN:      64512,
 					Addr:     "192.168.1.2",
@@ -109,8 +113,9 @@ func TestIPv6Only(t *testing.T) {
 
 	config := Config{
 		Underlay: UnderlayConfig{
-			MyASN: 64512,
-			VTEP:  "100.64.0.1/32",
+			MyASN:    64512,
+			VTEP:     "100.64.0.1/32",
+			RouterID: "10.0.0.1",
 			Neighbors: []NeighborConfig{
 				{
 					ASN:      64512,
@@ -121,9 +126,10 @@ func TestIPv6Only(t *testing.T) {
 		},
 		VNIs: []L3VNIConfig{
 			{
-				VRF: "red",
-				ASN: 64512,
-				VNI: 100,
+				VRF:      "red",
+				ASN:      64512,
+				VNI:      100,
+				RouterID: "10.0.0.1",
 				LocalNeighbor: &NeighborConfig{
 					ASN:      64512,
 					Addr:     "2001:db8::2",
@@ -160,8 +166,9 @@ func TestNoVNIs(t *testing.T) {
 
 	config := Config{
 		Underlay: UnderlayConfig{
-			MyASN: 64512,
-			VTEP:  "100.64.0.1/32",
+			MyASN:    64512,
+			VTEP:     "100.64.0.1/32",
+			RouterID: "10.0.0.1",
 			Neighbors: []NeighborConfig{
 				{
 					ASN:      64512,
@@ -184,8 +191,9 @@ func TestBFDEnabled(t *testing.T) {
 
 	config := Config{
 		Underlay: UnderlayConfig{
-			MyASN: 64512,
-			VTEP:  "100.64.0.1/32",
+			MyASN:    64512,
+			VTEP:     "100.64.0.1/32",
+			RouterID: "10.0.0.1",
 			Neighbors: []NeighborConfig{
 				{
 					ASN:        64512,
@@ -209,8 +217,9 @@ func TestBFDProfile(t *testing.T) {
 
 	config := Config{
 		Underlay: UnderlayConfig{
-			MyASN: 64512,
-			VTEP:  "100.64.0.1/32",
+			MyASN:    64512,
+			VTEP:     "100.64.0.1/32",
+			RouterID: "10.0.0.1",
 			Neighbors: []NeighborConfig{
 				{
 					ASN:        64512,
@@ -241,8 +250,9 @@ func TestL3VNIWithoutLocalNeighborAndAdvertise(t *testing.T) {
 
 	config := Config{
 		Underlay: UnderlayConfig{
-			MyASN: 64512,
-			VTEP:  "100.64.0.1/32",
+			MyASN:    64512,
+			VTEP:     "100.64.0.1/32",
+			RouterID: "10.0.0.1",
 			Neighbors: []NeighborConfig{
 				{
 					ASN:      64512,
@@ -253,9 +263,10 @@ func TestL3VNIWithoutLocalNeighborAndAdvertise(t *testing.T) {
 		},
 		VNIs: []L3VNIConfig{
 			{
-				VRF: "red",
-				VNI: 100,
-				ASN: 64512,
+				RouterID: "10.0.0.1",
+				VRF:      "red",
+				VNI:      100,
+				ASN:      64512,
 			},
 		},
 	}

--- a/internal/frr/templates/frr.tmpl
+++ b/internal/frr/templates/frr.tmpl
@@ -40,6 +40,7 @@ router bgp {{ .Underlay.MyASN }}
   no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast
+  bgp router-id {{ .Underlay.RouterID }}
 
 {{- range $n := .Underlay.Neighbors }}
 {{- template "neighborsession" dict "neighbor" $n "routerASN" $.Underlay.MyASN -}}
@@ -66,6 +67,7 @@ router bgp {{ .ASN }} vrf {{ .VRF }}
   no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast
+  bgp router-id {{ .RouterID }}
 
   {{- if .LocalNeighbor }}
   {{ template "localneighbor" . }}

--- a/internal/frr/testdata/TestBFDEnabled.golden
+++ b/internal/frr/testdata/TestBFDEnabled.golden
@@ -9,6 +9,7 @@ router bgp 64512
   no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast
+  bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64512
   
   

--- a/internal/frr/testdata/TestBFDProfile.golden
+++ b/internal/frr/testdata/TestBFDProfile.golden
@@ -14,6 +14,7 @@ router bgp 64512
   no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast
+  bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64512
   
   

--- a/internal/frr/testdata/TestBasic.golden
+++ b/internal/frr/testdata/TestBasic.golden
@@ -12,6 +12,7 @@ router bgp 64512
   no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast
+  bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64512
   
   
@@ -35,6 +36,7 @@ router bgp 64512 vrf red
   no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast
+  bgp router-id 10.0.0.1
   
   neighbor 192.168.1.2 remote-as 64512
 

--- a/internal/frr/testdata/TestDualStack.golden
+++ b/internal/frr/testdata/TestDualStack.golden
@@ -12,6 +12,7 @@ router bgp 64512
   no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast
+  bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64512
   
   
@@ -35,6 +36,7 @@ router bgp 64512 vrf red
   no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast
+  bgp router-id 10.0.0.1
   
   neighbor 192.168.1.2 remote-as 64512
 

--- a/internal/frr/testdata/TestIPv6Only.golden
+++ b/internal/frr/testdata/TestIPv6Only.golden
@@ -12,6 +12,7 @@ router bgp 64512
   no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast
+  bgp router-id 10.0.0.1
   neighbor 2001:db8::2 remote-as 64512
   
   
@@ -35,6 +36,7 @@ router bgp 64512 vrf red
   no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast
+  bgp router-id 10.0.0.1
   
   neighbor 2001:db8::2 remote-as 64512
 

--- a/internal/frr/testdata/TestL3VNIWithoutLocalNeighborAndAdvertise.golden
+++ b/internal/frr/testdata/TestL3VNIWithoutLocalNeighborAndAdvertise.golden
@@ -12,6 +12,7 @@ router bgp 64512
   no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast
+  bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64512
   
   
@@ -35,6 +36,7 @@ router bgp 64512 vrf red
   no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast
+  bgp router-id 10.0.0.1
 
   address-family l2vpn evpn
     advertise ipv4 unicast

--- a/internal/frr/testdata/TestNoVNIs.golden
+++ b/internal/frr/testdata/TestNoVNIs.golden
@@ -9,6 +9,7 @@ router bgp 64512
   no bgp ebgp-requires-policy
   no bgp network import-check
   no bgp default ipv4-unicast
+  bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64512
   
   

--- a/internal/ipam/ipam.go
+++ b/internal/ipam/ipam.go
@@ -72,6 +72,21 @@ func VTEPIp(pool string, index int) (net.IPNet, error) {
 	return res, nil
 }
 
+// RouterID returns the IP to be used for the router ID on the ith node.
+func RouterID(pool string, index int) (string, error) {
+	_, cidr, err := net.ParseCIDR(pool)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse pool %s: %w", pool, err)
+	}
+
+	ip, err := gocidr.Host(cidr, index+1)
+	if err != nil {
+		return "", fmt.Errorf("failed to get router id for node %d from cidr %s: %w", index, cidr, err)
+	}
+
+	return ip.String(), nil
+}
+
 // cidrElem returns the ith elem of len size for the given cidr.
 func cidrElem(pool *net.IPNet, index int) (*net.IPNet, error) {
 	ip, err := gocidr.Host(pool, index)

--- a/internal/webhooks/l3vni_webhook.go
+++ b/internal/webhooks/l3vni_webhook.go
@@ -89,12 +89,18 @@ func validateL3VNIUpdate(l3vni *v1alpha1.L3VNI, oldL3VNI *v1alpha1.L3VNI) error 
 	Logger.Debug("webhook l3vni", "action", "update", "name", l3vni.Name, "namespace", l3vni.Namespace)
 	defer Logger.Debug("webhook l3vni", "action", "end update", "name", l3vni.Name, "namespace", l3vni.Namespace)
 
-	if oldL3VNI.Spec.HostSession != nil && l3vni.Spec.HostSession != nil &&
-		oldL3VNI.Spec.HostSession.LocalCIDR != l3vni.Spec.HostSession.LocalCIDR {
+	if localCIDR(oldL3VNI.Spec.HostSession) != localCIDR(l3vni.Spec.HostSession) {
 		return errors.New("LocalCIDR cannot be changed")
 	}
 
 	return validateL3VNI(l3vni)
+}
+
+func localCIDR(hostSession *v1alpha1.HostSession) v1alpha1.LocalCIDRConfig {
+	if hostSession == nil {
+		return v1alpha1.LocalCIDRConfig{}
+	}
+	return hostSession.LocalCIDR
 }
 
 func validateL3VNIDelete(_ *v1alpha1.L3VNI) error {

--- a/operator/bundle/manifests/openpe.openperouter.github.io_underlays.yaml
+++ b/operator/bundle/manifests/openpe.openperouter.github.io_underlays.yaml
@@ -191,6 +191,11 @@ spec:
                 items:
                   type: string
                 type: array
+              routeridcidr:
+                default: 10.0.0.0/24
+                description: RouterIDCIDR is the ipv4 cidr to be used to assign a
+                  different routerID on each node.
+                type: string
               vtepcidr:
                 description: VTEPCIDR is CIDR to be used to assign IPs to the local
                   VTEP on each node.

--- a/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2025-08-19T13:51:28Z"
+    createdAt: "2025-09-02T10:35:34Z"
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: openperouter-operator.v0.0.0


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

We should have a different routerid per node. Normally FRR picks the lowest ipv4 of the interfaces of the nodes,
but it makes sense to be deterministic and know which node is which (also, it's gonna be useful for route distinguishers).

**Special notes for your reviewer**:

Built on top of https://github.com/openperouter/openperouter/pull/102

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Set explicitly the routerid of each node, defaulting to use the 10.0.0.0/24 CIDR.
```
