### PR TITLE
underlay: allow vlan sub-interfaces

### DIFF
--- a/api/v1alpha1/underlay_types.go
+++ b/api/v1alpha1/underlay_types.go
@@ -39,7 +39,7 @@ type UnderlaySpec struct {
 
 	// Nics is the list of physical nics to move under the PERouter namespace to connect
 	// to external routers. This field is optional when using Multus networks for TOR connectivity.
-	// +kubebuilder:validation:items:Pattern=`^[a-zA-Z][a-zA-Z0-9_-]*$`
+	// +kubebuilder:validation:items:Pattern=`^[a-zA-Z][a-zA-Z0-9._-]*$`
 	// +kubebuilder:validation:items:MaxLength=15
 	Nics []string `json:"nics,omitempty"`
 

--- a/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_underlays.yaml
+++ b/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_underlays.yaml
@@ -198,7 +198,7 @@ spec:
                   to external routers. This field is optional when using Multus networks for TOR connectivity.
                 items:
                   maxLength: 15
-                  pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
+                  pattern: ^[a-zA-Z][a-zA-Z0-9._-]*$
                   type: string
                 type: array
               routeridcidr:

--- a/config/all-in-one/crio.yaml
+++ b/config/all-in-one/crio.yaml
@@ -532,7 +532,7 @@ spec:
                   to external routers. This field is optional when using Multus networks for TOR connectivity.
                 items:
                   maxLength: 15
-                  pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
+                  pattern: ^[a-zA-Z][a-zA-Z0-9._-]*$
                   type: string
                 type: array
               routeridcidr:

--- a/config/all-in-one/openpe.yaml
+++ b/config/all-in-one/openpe.yaml
@@ -532,7 +532,7 @@ spec:
                   to external routers. This field is optional when using Multus networks for TOR connectivity.
                 items:
                   maxLength: 15
-                  pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
+                  pattern: ^[a-zA-Z][a-zA-Z0-9._-]*$
                   type: string
                 type: array
               routeridcidr:

--- a/config/crd/bases/openpe.openperouter.github.io_underlays.yaml
+++ b/config/crd/bases/openpe.openperouter.github.io_underlays.yaml
@@ -198,7 +198,7 @@ spec:
                   to external routers. This field is optional when using Multus networks for TOR connectivity.
                 items:
                   maxLength: 15
-                  pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
+                  pattern: ^[a-zA-Z][a-zA-Z0-9._-]*$
                   type: string
                 type: array
               routeridcidr:

--- a/internal/conversion/validate_underlay_test.go
+++ b/internal/conversion/validate_underlay_test.go
@@ -132,6 +132,57 @@ func TestValidateUnderlay(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "underlay NIC is a vlan sub-interface",
+			underlay: v1alpha1.Underlay{
+				Spec: v1alpha1.UnderlaySpec{
+					EVPN: &v1alpha1.EVPNConfig{
+						VTEPCIDR: "192.168.1.0/24",
+					},
+					Nics: []string{"eno2.161"},
+					ASN:  65001,
+				},
+			},
+		},
+		{
+			name: "underlay NIC starts with dot",
+			underlay: v1alpha1.Underlay{
+				Spec: v1alpha1.UnderlaySpec{
+					EVPN: &v1alpha1.EVPNConfig{
+						VTEPCIDR: "192.168.1.0/24",
+					},
+					Nics: []string{".eth0"},
+					ASN:  65001,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "a vlan sub interface whose name is too long",
+			underlay: v1alpha1.Underlay{
+				Spec: v1alpha1.UnderlaySpec{
+					EVPN: &v1alpha1.EVPNConfig{
+						VTEPCIDR: "192.168.1.0/24",
+					},
+					Nics: []string{"verylongname.123"},
+					ASN:  65001,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "underlay NIC with invalid characters after dot",
+			underlay: v1alpha1.Underlay{
+				Spec: v1alpha1.UnderlaySpec{
+					EVPN: &v1alpha1.EVPNConfig{
+						VTEPCIDR: "192.168.1.0/24",
+					},
+					Nics: []string{"eth0.100!"},
+					ASN:  65001,
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/conversion/validate_vni.go
+++ b/internal/conversion/validate_vni.go
@@ -13,7 +13,7 @@ import (
 var interfaceNameRegexp *regexp.Regexp
 
 func init() {
-	interfaceNameRegexp = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]*$`)
+	interfaceNameRegexp = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9._-]*$`)
 }
 
 func ValidateL3VNIs(l3Vnis []v1alpha1.L3VNI) error {

--- a/operator/bundle/manifests/openpe.openperouter.github.io_underlays.yaml
+++ b/operator/bundle/manifests/openpe.openperouter.github.io_underlays.yaml
@@ -198,7 +198,7 @@ spec:
                   to external routers. This field is optional when using Multus networks for TOR connectivity.
                 items:
                   maxLength: 15
-                  pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
+                  pattern: ^[a-zA-Z][a-zA-Z0-9._-]*$
                   type: string
                 type: array
               routeridcidr:

--- a/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2025-10-13T15:54:17Z"
+    createdAt: "2025-10-14T10:07:35Z"
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: openperouter-operator.v0.0.0


### PR DESCRIPTION

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>

/kind bug

> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:
This commit allows vlan sub-interfaces to be selected as underlay NICs.

Prior to this commit, attempting to use a vlan as underlay NIC would fail with the following error:
```
error: underlays.openpe.openperouter.github.io "underlay" could not be patched: admission webhook "underlayvalidationwebhook.openperouter.io" denied the request: validation failed: invalid nic name for underlay underlay: eth0.123 - interface name eth0.123 contains invalid characters
```

**Special notes for your reviewer**:
Fixes: #125
Depends-on: #130 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Vlan sub-interfaces can now be selected as underlay NICs.
```
