### PR TITLE
API: fix the nic name validation syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ export KUBECONFIG=$(KUBECONFIG_PATH)
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.0.0
-CONTROLLER_TOOLS_VERSION ?= v0.14.0
+CONTROLLER_TOOLS_VERSION ?= v0.19.0
 KUBECTL_VERSION ?= v1.27.0
 GINKGO_VERSION ?= $(shell go list -m -f '{{.Version}}' github.com/onsi/ginkgo/v2)
 KIND_VERSION ?= v0.27.0

--- a/api/v1alpha1/underlay_types.go
+++ b/api/v1alpha1/underlay_types.go
@@ -39,8 +39,8 @@ type UnderlaySpec struct {
 
 	// Nics is the list of physical nics to move under the PERouter namespace to connect
 	// to external routers. This field is optional when using Multus networks for TOR connectivity.
-	// +kubebuilder:validation:Items=Pattern=`^[a-zA-Z][a-zA-Z0-9_-]*$`
-	// +kubebuilder:validation:Items=MaxLength=15
+	// +kubebuilder:validation:items:Pattern=`^[a-zA-Z][a-zA-Z0-9_-]*$`
+	// +kubebuilder:validation:items:MaxLength=15
 	Nics []string `json:"nics,omitempty"`
 
 	EVPN *EVPNConfig `json:"evpn,omitempty"`

--- a/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_l2vnis.yaml
+++ b/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_l2vnis.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: l2vnis.openpe.openperouter.github.io
 spec:
   group: openpe.openperouter.github.io

--- a/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_l3passthroughs.yaml
+++ b/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_l3passthroughs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: l3passthroughs.openpe.openperouter.github.io
 spec:
   group: openpe.openperouter.github.io
@@ -83,6 +83,8 @@ spec:
                     - message: LocalCIDR can't be changed
                       rule: self == oldSelf
                 required:
+                - asn
+                - hostasn
                 - localcidr
                 type: object
             type: object

--- a/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_l3vnis.yaml
+++ b/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_l3vnis.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: l3vnis.openpe.openperouter.github.io
 spec:
   group: openpe.openperouter.github.io
@@ -84,6 +84,8 @@ spec:
                     - message: LocalCIDR can't be changed
                       rule: self == oldSelf
                 required:
+                - asn
+                - hostasn
                 - localcidr
                 type: object
               vni:

--- a/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_underlays.yaml
+++ b/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_underlays.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: underlays.openpe.openperouter.github.io
 spec:
   group: openpe.openperouter.github.io
@@ -52,6 +52,8 @@ spec:
                     description: VTEPCIDR is CIDR to be used to assign IPs to the
                       local VTEP on each node.
                     type: string
+                required:
+                - vtepcidr
                 type: object
               neighbors:
                 description: Neighbors is the list of external neighbors to peer with.
@@ -195,6 +197,8 @@ spec:
                   Nics is the list of physical nics to move under the PERouter namespace to connect
                   to external routers. This field is optional when using Multus networks for TOR connectivity.
                 items:
+                  maxLength: 15
+                  pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
                   type: string
                 type: array
               routeridcidr:
@@ -202,6 +206,8 @@ spec:
                 description: RouterIDCIDR is the ipv4 cidr to be used to assign a
                   different routerID on each node.
                 type: string
+            required:
+            - asn
             type: object
           status:
             description: UnderlayStatus defines the observed state of Underlay.

--- a/config/all-in-one/crio.yaml
+++ b/config/all-in-one/crio.yaml
@@ -12,7 +12,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: l2vnis.openpe.openperouter.github.io
 spec:
   group: openpe.openperouter.github.io
@@ -119,7 +119,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: l3passthroughs.openpe.openperouter.github.io
 spec:
   group: openpe.openperouter.github.io
@@ -199,6 +199,8 @@ spec:
                     - message: LocalCIDR can't be changed
                       rule: self == oldSelf
                 required:
+                - asn
+                - hostasn
                 - localcidr
                 type: object
             type: object
@@ -215,7 +217,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: l3vnis.openpe.openperouter.github.io
 spec:
   group: openpe.openperouter.github.io
@@ -296,6 +298,8 @@ spec:
                     - message: LocalCIDR can't be changed
                       rule: self == oldSelf
                 required:
+                - asn
+                - hostasn
                 - localcidr
                 type: object
               vni:
@@ -333,7 +337,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: underlays.openpe.openperouter.github.io
 spec:
   group: openpe.openperouter.github.io
@@ -382,6 +386,8 @@ spec:
                     description: VTEPCIDR is CIDR to be used to assign IPs to the
                       local VTEP on each node.
                     type: string
+                required:
+                - vtepcidr
                 type: object
               neighbors:
                 description: Neighbors is the list of external neighbors to peer with.
@@ -525,6 +531,8 @@ spec:
                   Nics is the list of physical nics to move under the PERouter namespace to connect
                   to external routers. This field is optional when using Multus networks for TOR connectivity.
                 items:
+                  maxLength: 15
+                  pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
                   type: string
                 type: array
               routeridcidr:
@@ -532,6 +540,8 @@ spec:
                 description: RouterIDCIDR is the ipv4 cidr to be used to assign a
                   different routerID on each node.
                 type: string
+            required:
+            - asn
             type: object
           status:
             description: UnderlayStatus defines the observed state of Underlay.
@@ -630,83 +640,8 @@ rules:
   - openpe.openperouter.github.io
   resources:
   - l2vnis
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
-  - l2vnis/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
-  - l2vnis/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
   - l3passthroughs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
-  - l3passthroughs/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
-  - l3passthroughs/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
   - l3vnis
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
-  - l3vnis/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
-  - l3vnis/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
   - underlays
   verbs:
   - create
@@ -719,12 +654,18 @@ rules:
 - apiGroups:
   - openpe.openperouter.github.io
   resources:
+  - l2vnis/finalizers
+  - l3passthroughs/finalizers
+  - l3vnis/finalizers
   - underlays/finalizers
   verbs:
   - update
 - apiGroups:
   - openpe.openperouter.github.io
   resources:
+  - l2vnis/status
+  - l3passthroughs/status
+  - l3vnis/status
   - underlays/status
   verbs:
   - get

--- a/config/all-in-one/openpe.yaml
+++ b/config/all-in-one/openpe.yaml
@@ -12,7 +12,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: l2vnis.openpe.openperouter.github.io
 spec:
   group: openpe.openperouter.github.io
@@ -119,7 +119,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: l3passthroughs.openpe.openperouter.github.io
 spec:
   group: openpe.openperouter.github.io
@@ -199,6 +199,8 @@ spec:
                     - message: LocalCIDR can't be changed
                       rule: self == oldSelf
                 required:
+                - asn
+                - hostasn
                 - localcidr
                 type: object
             type: object
@@ -215,7 +217,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: l3vnis.openpe.openperouter.github.io
 spec:
   group: openpe.openperouter.github.io
@@ -296,6 +298,8 @@ spec:
                     - message: LocalCIDR can't be changed
                       rule: self == oldSelf
                 required:
+                - asn
+                - hostasn
                 - localcidr
                 type: object
               vni:
@@ -333,7 +337,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: underlays.openpe.openperouter.github.io
 spec:
   group: openpe.openperouter.github.io
@@ -382,6 +386,8 @@ spec:
                     description: VTEPCIDR is CIDR to be used to assign IPs to the
                       local VTEP on each node.
                     type: string
+                required:
+                - vtepcidr
                 type: object
               neighbors:
                 description: Neighbors is the list of external neighbors to peer with.
@@ -525,6 +531,8 @@ spec:
                   Nics is the list of physical nics to move under the PERouter namespace to connect
                   to external routers. This field is optional when using Multus networks for TOR connectivity.
                 items:
+                  maxLength: 15
+                  pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
                   type: string
                 type: array
               routeridcidr:
@@ -532,6 +540,8 @@ spec:
                 description: RouterIDCIDR is the ipv4 cidr to be used to assign a
                   different routerID on each node.
                 type: string
+            required:
+            - asn
             type: object
           status:
             description: UnderlayStatus defines the observed state of Underlay.
@@ -630,83 +640,8 @@ rules:
   - openpe.openperouter.github.io
   resources:
   - l2vnis
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
-  - l2vnis/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
-  - l2vnis/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
   - l3passthroughs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
-  - l3passthroughs/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
-  - l3passthroughs/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
   - l3vnis
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
-  - l3vnis/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
-  - l3vnis/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
   - underlays
   verbs:
   - create
@@ -719,12 +654,18 @@ rules:
 - apiGroups:
   - openpe.openperouter.github.io
   resources:
+  - l2vnis/finalizers
+  - l3passthroughs/finalizers
+  - l3vnis/finalizers
   - underlays/finalizers
   verbs:
   - update
 - apiGroups:
   - openpe.openperouter.github.io
   resources:
+  - l2vnis/status
+  - l3passthroughs/status
+  - l3vnis/status
   - underlays/status
   verbs:
   - get

--- a/config/crd/bases/openpe.openperouter.github.io_l2vnis.yaml
+++ b/config/crd/bases/openpe.openperouter.github.io_l2vnis.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: l2vnis.openpe.openperouter.github.io
 spec:
   group: openpe.openperouter.github.io

--- a/config/crd/bases/openpe.openperouter.github.io_l3passthroughs.yaml
+++ b/config/crd/bases/openpe.openperouter.github.io_l3passthroughs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: l3passthroughs.openpe.openperouter.github.io
 spec:
   group: openpe.openperouter.github.io
@@ -83,6 +83,8 @@ spec:
                     - message: LocalCIDR can't be changed
                       rule: self == oldSelf
                 required:
+                - asn
+                - hostasn
                 - localcidr
                 type: object
             type: object

--- a/config/crd/bases/openpe.openperouter.github.io_l3vnis.yaml
+++ b/config/crd/bases/openpe.openperouter.github.io_l3vnis.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: l3vnis.openpe.openperouter.github.io
 spec:
   group: openpe.openperouter.github.io
@@ -84,6 +84,8 @@ spec:
                     - message: LocalCIDR can't be changed
                       rule: self == oldSelf
                 required:
+                - asn
+                - hostasn
                 - localcidr
                 type: object
               vni:

--- a/config/crd/bases/openpe.openperouter.github.io_underlays.yaml
+++ b/config/crd/bases/openpe.openperouter.github.io_underlays.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: underlays.openpe.openperouter.github.io
 spec:
   group: openpe.openperouter.github.io
@@ -52,6 +52,8 @@ spec:
                     description: VTEPCIDR is CIDR to be used to assign IPs to the
                       local VTEP on each node.
                     type: string
+                required:
+                - vtepcidr
                 type: object
               neighbors:
                 description: Neighbors is the list of external neighbors to peer with.
@@ -195,6 +197,8 @@ spec:
                   Nics is the list of physical nics to move under the PERouter namespace to connect
                   to external routers. This field is optional when using Multus networks for TOR connectivity.
                 items:
+                  maxLength: 15
+                  pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
                   type: string
                 type: array
               routeridcidr:
@@ -202,6 +206,8 @@ spec:
                 description: RouterIDCIDR is the ipv4 cidr to be used to assign a
                   different routerID on each node.
                 type: string
+            required:
+            - asn
             type: object
           status:
             description: UnderlayStatus defines the observed state of Underlay.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -42,83 +42,8 @@ rules:
   - openpe.openperouter.github.io
   resources:
   - l2vnis
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
-  - l2vnis/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
-  - l2vnis/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
   - l3passthroughs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
-  - l3passthroughs/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
-  - l3passthroughs/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
   - l3vnis
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
-  - l3vnis/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
-  - l3vnis/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
   - underlays
   verbs:
   - create
@@ -131,12 +56,18 @@ rules:
 - apiGroups:
   - openpe.openperouter.github.io
   resources:
+  - l2vnis/finalizers
+  - l3passthroughs/finalizers
+  - l3vnis/finalizers
   - underlays/finalizers
   verbs:
   - update
 - apiGroups:
   - openpe.openperouter.github.io
   resources:
+  - l2vnis/status
+  - l3passthroughs/status
+  - l3vnis/status
   - underlays/status
   verbs:
   - get

--- a/operator/bundle/manifests/openpe.openperouter.github.io_l2vnis.yaml
+++ b/operator/bundle/manifests/openpe.openperouter.github.io_l2vnis.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   creationTimestamp: null
   name: l2vnis.openpe.openperouter.github.io
 spec:

--- a/operator/bundle/manifests/openpe.openperouter.github.io_l3passthroughs.yaml
+++ b/operator/bundle/manifests/openpe.openperouter.github.io_l3passthroughs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   creationTimestamp: null
   name: l3passthroughs.openpe.openperouter.github.io
 spec:
@@ -83,6 +83,8 @@ spec:
                     - message: LocalCIDR can't be changed
                       rule: self == oldSelf
                 required:
+                - asn
+                - hostasn
                 - localcidr
                 type: object
             type: object

--- a/operator/bundle/manifests/openpe.openperouter.github.io_l3vnis.yaml
+++ b/operator/bundle/manifests/openpe.openperouter.github.io_l3vnis.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   creationTimestamp: null
   name: l3vnis.openpe.openperouter.github.io
 spec:
@@ -84,6 +84,8 @@ spec:
                     - message: LocalCIDR can't be changed
                       rule: self == oldSelf
                 required:
+                - asn
+                - hostasn
                 - localcidr
                 type: object
               vni:

--- a/operator/bundle/manifests/openpe.openperouter.github.io_openperouters.yaml
+++ b/operator/bundle/manifests/openpe.openperouter.github.io_openperouters.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   creationTimestamp: null
   name: openperouters.openpe.openperouter.github.io
 spec:

--- a/operator/bundle/manifests/openpe.openperouter.github.io_underlays.yaml
+++ b/operator/bundle/manifests/openpe.openperouter.github.io_underlays.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   creationTimestamp: null
   name: underlays.openpe.openperouter.github.io
 spec:
@@ -52,6 +52,8 @@ spec:
                     description: VTEPCIDR is CIDR to be used to assign IPs to the
                       local VTEP on each node.
                     type: string
+                required:
+                - vtepcidr
                 type: object
               neighbors:
                 description: Neighbors is the list of external neighbors to peer with.
@@ -195,6 +197,8 @@ spec:
                   Nics is the list of physical nics to move under the PERouter namespace to connect
                   to external routers. This field is optional when using Multus networks for TOR connectivity.
                 items:
+                  maxLength: 15
+                  pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
                   type: string
                 type: array
               routeridcidr:
@@ -202,6 +206,8 @@ spec:
                 description: RouterIDCIDR is the ipv4 cidr to be used to assign a
                   different routerID on each node.
                 type: string
+            required:
+            - asn
             type: object
           status:
             description: UnderlayStatus defines the observed state of Underlay.

--- a/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2025-09-16T08:45:24Z"
+    createdAt: "2025-10-13T15:54:17Z"
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: openperouter-operator.v0.0.0
@@ -83,83 +83,8 @@ spec:
           - openpe.openperouter.github.io
           resources:
           - l2vnis
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - openpe.openperouter.github.io
-          resources:
-          - l2vnis/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - openpe.openperouter.github.io
-          resources:
-          - l2vnis/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - openpe.openperouter.github.io
-          resources:
           - l3passthroughs
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - openpe.openperouter.github.io
-          resources:
-          - l3passthroughs/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - openpe.openperouter.github.io
-          resources:
-          - l3passthroughs/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - openpe.openperouter.github.io
-          resources:
           - l3vnis
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - openpe.openperouter.github.io
-          resources:
-          - l3vnis/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - openpe.openperouter.github.io
-          resources:
-          - l3vnis/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - openpe.openperouter.github.io
-          resources:
           - underlays
           verbs:
           - create
@@ -172,12 +97,18 @@ spec:
         - apiGroups:
           - openpe.openperouter.github.io
           resources:
+          - l2vnis/finalizers
+          - l3passthroughs/finalizers
+          - l3vnis/finalizers
           - underlays/finalizers
           verbs:
           - update
         - apiGroups:
           - openpe.openperouter.github.io
           resources:
+          - l2vnis/status
+          - l3passthroughs/status
+          - l3vnis/status
           - underlays/status
           verbs:
           - get

--- a/operator/config/crd/bases/openpe.openperouter.github.io_openperouters.yaml
+++ b/operator/config/crd/bases/openpe.openperouter.github.io_openperouters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: openperouters.openpe.openperouter.github.io
 spec:
   group: openpe.openperouter.github.io


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

Fixing a the validation syntax we had in the kubebuilder annotations.

This is done by:

- fixing the syntax
- updating controller-gen version to 0.19.0
- regenerating the manifests


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix cr based validation of the nic name in the underlay crd.
```
