### PR TITLE
Improve the generation of the release notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,14 +79,6 @@ test: fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v e2etest) -coverprofile cover.out
 	sudo -E sh -c "umask 0; PATH=${GOPATH}/bin:$(pwd)/bin:${PATH} go test -tags=runasroot -v -race ./internal/hostnetwork"
 
-.PHONY: release-notes
-release-notes: ## Generate release notes
-	@if [ -z "$(OPENPE_VERSION)" ]; then \
-		echo "Usage: make release-notes OPENPE_VERSION=<version>"; \
-		exit 1; \
-	fi
-	hack/release/prepare_release.sh $(OPENPE_VERSION)
-
 ##@ Build
 
 .PHONY: build

--- a/hack/release/release-notes-template.md
+++ b/hack/release/release-notes-template.md
@@ -1,0 +1,44 @@
+{{- $hasFeature := false -}}
+{{- $hasBug := false -}}
+{{- $hasCleanup := false -}}
+{{- range .Notes -}}
+  {{- if eq .Kind "feature" -}}{{- $hasFeature = true -}}{{- end -}}
+  {{- if eq .Kind "bug" -}}{{- $hasBug = true -}}{{- end -}}
+  {{- if eq .Kind "Other (Cleanup or Flake)" -}}{{- $hasCleanup = true -}}{{- end -}}
+{{- end }}
+{{- if $hasFeature }}
+
+### New Features
+
+{{- range .Notes }}
+{{- if eq .Kind "feature" }}
+{{- range .NoteEntries }}
+- {{.}}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if $hasBug }}
+
+### Bug fixes
+
+{{- range .Notes }}
+{{- if eq .Kind "bug" }}
+{{- range .NoteEntries }}
+- {{.}}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if $hasCleanup }}
+
+### Other (Cleanup or Flake)
+
+{{- range .Notes }}
+{{- if eq .Kind "Other (Cleanup or Flake)" }}
+{{- range .NoteEntries }}
+- {{.}}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/hack/release/release_notes.sh
+++ b/hack/release/release_notes.sh
@@ -1,101 +1,141 @@
-#!/bin/bash
+#!/bin/bash -e
 
-# SPDX-License-Identifier: Apache-2.0
+# Script to automate generation and committing of release notes
+# Usage:
+#   ./hack/gen_relnotes.sh           # Automates entire release notes workflow (auto-increments version)
+#   ./hack/gen_relnotes.sh <version> # Automates workflow with custom version (e.g., 1.2.3)
 
-set -euo pipefail
+set -e
 
-# Function to generate release notes
-# It takes two arguments:
-# $1: start commit
-# $2: end commit (or branch)
-generate_release_notes() {
-    local start_commit=$1
-    local end_commit=$2
-    local branch=$2
-
-    local release_notes
-    release_notes=$(mktemp)
-
-    trap 'rm -f "$release_notes"' RETURN
-
-    GOFLAGS=-mod=mod go run k8s.io/release/cmd/release-notes@v0.16.5 \
-        --branch "$branch" \
-        --required-author "" \
-        --org metallb \
-        --dependencies=false \
-        --repo frr-k8s \
-        --start-sha "$start_commit" \
-        --end-sha "$end_commit" \
-        --output "$release_notes"
-
-    cat "$release_notes"
-}
-
-# Function to compare semantic versions
-version_gt() {
-    test "$(printf '%s\n' "$1" "$2" | sort -V | head -n 1)" != "$1" || [ "$1" == "$2" ]
-}
-
-if [ -z "$1" ]; then
-    echo "Usage: $0 <version>"
-    echo "Example: $0 1.2.3"
+if [[ ! -v GITHUB_TOKEN ]]; then
+    echo "GITHUB_TOKEN is not set, please set it with a token with read permissions on commits and PRs"
     exit 1
 fi
 
-NEW_VERSION=$1
+script_dir=$(dirname "$(readlink -f "$0")")
+repo_root=$(cd "$script_dir/../.." && pwd)
 
-# Check for GITHUB_TOKEN
-if [ -z "$GITHUB_TOKEN" ]; then
-    echo "Error: GITHUB_TOKEN environment variable is not set."
-    exit 1
-fi
+get_latest_version() {
+    grep -m 1 "^## Release v" "$repo_root/RELEASE_NOTES.md" | sed 's/## Release v//'
+}
 
-echo "Preparing release for version $NEW_VERSION"
+increment_version() {
+    local version=$1
+    # Split version into parts
+    local major=$(echo "$version" | cut -d. -f1)
+    local minor=$(echo "$version" | cut -d. -f2)
+    local patch=$(echo "$version" | cut -d. -f3)
 
-# Find the commit of the previous release notes generation
-LAST_RELEASE_COMMIT_INFO=$(git log --grep="^Generate release for version" --pretty=format:"%H %s" -n 1)
+    # Increment patch version
+    patch=$((patch + 1))
 
-if [ -z "$LAST_RELEASE_COMMIT_INFO" ]; then
-    echo "No previous release found. Using the first commit as the start of the range."
-    START_COMMIT=$(git rev-list --max-parents=0 HEAD)
-else
-    LAST_RELEASE_COMMIT=$(echo "$LAST_RELEASE_COMMIT_INFO" | cut -d' ' -f1)
-    LAST_RELEASE_MSG=$(echo "$LAST_RELEASE_COMMIT_INFO" | cut -d' ' -f2-)
-    PREVIOUS_VERSION=$(echo "$LAST_RELEASE_MSG" | awk '{print $5}')
-    
-    echo "Previous release version: $PREVIOUS_VERSION"
+    echo "${major}.${minor}.${patch}"
+}
 
-    # Compare versions
-    if ! version_gt "$NEW_VERSION" "$PREVIOUS_VERSION"; then
-        echo "Error: New version ($NEW_VERSION) must be greater than the previous version ($PREVIOUS_VERSION)."
+if [ $# -eq 0 ] || [ $# -eq 1 ]; then
+    # Automated mode
+    echo "Running in automated mode..."
+
+    branch=${BRANCH:-main}
+
+    # Find the SHA of the most recent "Prepare the v*" commit
+    from=$(git log --all --grep="^Release notes for" --format="%H" | head -1)
+
+    if [ -z "$from" ]; then
+        echo "Error: Could not find a previous 'Prepare the v*' commit"
+        echo "This might be the first release."
         exit 1
     fi
-    START_COMMIT=$LAST_RELEASE_COMMIT
+
+    to=$(git ls-remote https://github.com/openperouter/openperouter.git refs/heads/main | cut -f1)
+
+    current_version=$(get_latest_version)
+
+    if [ $# -eq 1 ]; then
+        new_version=$1
+        echo "Found previous release commit: $from"
+        echo "Current HEAD: $to"
+        echo "Current version: v$current_version"
+        echo "Using provided version: v$new_version"
+    else
+        new_version=$(increment_version "$current_version")
+        echo "Found previous release commit: $from"
+        echo "Current HEAD: $to"
+        echo "Current version: v$current_version"
+        echo "Auto-incrementing to version: v$new_version"
+    fi
+else
+    echo "Usage: $0 [version]"
+    echo "  No arguments: Automated mode (auto-increments patch version)"
+    echo "  1 argument: Automated mode with custom version (e.g., $0 1.2.3)"
+    exit 1
 fi
 
-echo "Generating release notes from commit $START_COMMIT to main..."
+release_notes=$(mktemp)
 
-# Generate release notes content
-NOTES_CONTENT=$(generate_release_notes "$START_COMMIT" "main")
+end() {
+    rm -f "$release_notes"
+}
 
-if [ -z "$NOTES_CONTENT" ]; then
-    echo "No new pull requests found since the last release. No release notes to generate."
-    exit 0
+trap end EXIT SIGINT SIGTERM SIGSTOP
+
+echo "Generating release notes..."
+GOFLAGS=-mod=mod go run k8s.io/release/cmd/release-notes@v0.16.5 \
+    --branch "$branch" \
+    --required-author "" \
+    --org openperouter \
+    --dependencies=false \
+    --repo openperouter \
+    --start-sha "$from" \
+    --end-sha "$to" \
+    --go-template "go-template:$script_dir/release-notes-template.md" \
+    --output "$release_notes"
+
+# Update RELEASE_NOTES.md
+temp_notes=$(mktemp)
+
+echo "## Release v$new_version" > "$temp_notes"
+echo "" >> "$temp_notes"
+
+cat "$release_notes" >> "$temp_notes"
+echo "" >> "$temp_notes"
+echo "" >> "$temp_notes"
+
+tail -n +2 "$repo_root/RELEASE_NOTES.md" >> "$temp_notes"
+
+mv "$temp_notes" "$repo_root/RELEASE_NOTES.md"
+
+echo ""
+echo "Release notes have been updated in RELEASE_NOTES.md"
+echo ""
+
+# Update website release notes by combining frontmatter with RELEASE_NOTES.md
+website_release_notes="$repo_root/website/content/docs/release-notes.md"
+website_frontmatter="$repo_root/website/content/docs/.release-notes-frontmatter.md"
+temp_website_notes=$(mktemp)
+
+# Combine frontmatter with RELEASE_NOTES.md content
+cat "$website_frontmatter" > "$temp_website_notes"
+echo "" >> "$temp_website_notes"
+cat "$repo_root/RELEASE_NOTES.md" >> "$temp_website_notes"
+
+mv "$temp_website_notes" "$website_release_notes"
+
+echo "Release notes have been updated in website/content/docs/release-notes.md"
+echo ""
+
+echo "Changes to be committed:"
+git diff "$repo_root/RELEASE_NOTES.md"
+echo ""
+git diff "$website_release_notes"
+
+read -p "Do you want to commit these changes? (y/n) " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    git add "$repo_root/RELEASE_NOTES.md" "$website_release_notes"
+    git commit -m "Prepare the v$new_version release notes"
+    echo ""
+    echo "Committed: Prepare the v$new_version release notes"
+else
+    echo "Commit cancelled. Changes are staged but not committed."
 fi
-
-# Prepare the new release notes section
-NEW_RELEASE_SECTION="## Release $NEW_VERSION\n\n$NOTES_CONTENT"
-
-RELEASE_NOTES_FILE="website/content/docs/release-notes.md"
-TEMP_FILE=$(mktemp)
-
-awk -v new_section="$(echo -e "\n$NEW_RELEASE_SECTION")" '1;/^# Release Notes/ {printf "%s", new_section}' "$RELEASE_NOTES_FILE" > "$TEMP_FILE"
-mv "$TEMP_FILE" "$RELEASE_NOTES_FILE"
-
-echo "Updated $RELEASE_NOTES_FILE"
-
-# Commit the changes
-git add "$RELEASE_NOTES_FILE"
-git commit -m "Generate release for version $NEW_VERSION"
-
-echo "Committed release notes for version $NEW_VERSION"

--- a/website/content/docs/.release-notes-frontmatter.md
+++ b/website/content/docs/.release-notes-frontmatter.md
@@ -1,0 +1,12 @@
+---
+weight: 100
+title: "Release Notes"
+description: "OpenPERouter release notes"
+icon: "article"
+date: "2025-06-15T15:03:22+02:00"
+lastmod: "2025-06-15T15:03:22+02:00"
+toc: true
+---
+
+## Release Notes
+

--- a/website/content/docs/contributing/how-to-release.md
+++ b/website/content/docs/contributing/how-to-release.md
@@ -36,20 +36,35 @@ The release script only works if the Git working directory is completely clean: 
 
 The release script will abort if the working directory isn’t right.
 
+## Generate the release notes
+
+The `GITHUB_TOKEN` environment variable must be set with a GitHub token which has reading permissions.
+A convenience generator script is available at `hack/release/release_notes.sh`. The script can be run in two modes:
+
+### Automatic mode (recommended)
+
+```bash
+hack/release/release_notes.sh
+```
+
+This will automatically:
+- Find the previous release commit (searches for "Prepare the v*" commits)
+- Use the HEAD of `upstream/main` as the end point
+- Auto-increment the patch version from the current release
+- Generate categorized release notes based on PR labels (`kind/feature`, `kind/bug`, `kind/cleanup`)
+- Update `RELEASE_NOTES.md` with the new release section
+
+### Manual mode with custom version
+
+```bash
+hack/release/release_notes.sh 0.0.3
+```
+
+This will use the provided version number instead of auto-incrementing.
+
 ## Run the release script
+
 Run `OPENPE_VERSION="X.Y.Z" make cutrelease` from the main branch. This will create the appropriate branches, commits and tags in your local repository.
-
-Where branch is the branch being released, first and last commit is the interval
-we want to generate the release notes for.
-
-In order to prepare the release notes, the `GITHUB_TOKEN` environment variable must be set with a github token which has the following permissions:
-
-Read access to:
-
-- Contents
-- Pull requests
-- Commit statuses
-
 
 ## Push the new artifacts
 Run git push --tags origin main `vX.Y`. This will push all pending changes both in main and the release branch, as well as the new tag for the release.


### PR DESCRIPTION


<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
/kind documentation
> /kind regression

**What this PR does / why we need it**:

Generating the release notes involved a lot of manual steps, including finding the right commit to start from and the end. Here we simplify the workflow by finding the last time we added a release note and we fetch the PRs from then to the latest on main.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
