### PR TITLE
clab, demo, multi-cluster: redistribute from default

### DIFF
--- a/clab/scripts/02-leaf-configs.sh
+++ b/clab/scripts/02-leaf-configs.sh
@@ -12,7 +12,7 @@ generate_leaf_configs() {
     # Build the command with redistribute parameter (disabled by default)
     REDISTRIBUTE_FLAG=""
     if [[ "${DEMO_MODE:-false}" == "true" ]]; then
-        REDISTRIBUTE_FLAG="-redistribute-connected-from-vrfs"
+        REDISTRIBUTE_FLAG="-redistribute-connected-from-vrfs -redistribute-connected-from-default"
         echo "Enabling redistribute connected from VRFs (demo mode)"
     else
         echo "Disabling redistribute connected from VRFs (default)"


### PR DESCRIPTION
While adding the multi-cluster setup - [0] - one of the rebases was not properly done, which led me to drop this flag.

This is adding it back, thus enabling the default VRF passthrough demo to work as expected once again.

[0] - https://github.com/openperouter/openperouter/pull/126

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>

/kind bug

> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
While adding the multi-cluster setup - [0] - one of the rebases was not
properly done, which led me to drop this flag.

This is adding it back, thus enabling the default VRF passthrough demo
to work as expected once again.

[0] - https://github.com/openperouter/openperouter/pull/126

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Re-introduce the "redistribute-connected-from-default" flag when generating FRR configurations for the KinD leaves
```
