### PR TITLE
fix: allow empty list of NICs for Underlay setup if Multus is used

### DIFF
--- a/charts/openperouter/templates/controller.yaml
+++ b/charts/openperouter/templates/controller.yaml
@@ -51,6 +51,9 @@ spec:
         {{- if eq .Values.openperouter.cri "crio" }}
         - --crisocket=/crio.sock
         {{- end }}
+        {{- if .Values.openperouter.multusNetworkAnnotation }}
+        - --underlay-from-multus=true
+        {{- end }}
         command:
         - /controller
         env:

--- a/cmd/hostcontroller/main.go
+++ b/cmd/hostcontroller/main.go
@@ -57,17 +57,18 @@ func init() {
 
 func main() {
 	args := struct {
-		metricsAddr   string
-		probeAddr     string
-		secureMetrics bool
-		enableHTTP2   bool
-		tlsOpts       []func(*tls.Config)
-		nodeName      string
-		namespace     string
-		logLevel      string
-		frrConfigPath string
-		reloadPort    int
-		criSocket     string
+		metricsAddr        string
+		probeAddr          string
+		secureMetrics      bool
+		enableHTTP2        bool
+		tlsOpts            []func(*tls.Config)
+		nodeName           string
+		namespace          string
+		logLevel           string
+		frrConfigPath      string
+		reloadPort         int
+		criSocket          string
+		underlayFromMultus bool
 	}{}
 	flag.StringVar(&args.metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -83,6 +84,7 @@ func main() {
 		"the location of the frr configuration file")
 	flag.IntVar(&args.reloadPort, "reloadport", 9080, "the port of the reloader process")
 	flag.StringVar(&args.criSocket, "crisocket", "/containerd.sock", "the location of the cri socket")
+	flag.BoolVar(&args.underlayFromMultus, "underlay-from-multus", false, "Whether underlay access is built with Multus")
 
 	flag.Parse()
 
@@ -124,15 +126,16 @@ func main() {
 	}
 
 	if err = (&routerconfiguration.PERouterReconciler{
-		Client:      mgr.GetClient(),
-		Scheme:      mgr.GetScheme(),
-		MyNode:      args.nodeName,
-		FRRConfig:   args.frrConfigPath,
-		ReloadPort:  args.reloadPort,
-		PodRuntime:  podRuntime,
-		LogLevel:    args.logLevel,
-		Logger:      logger,
-		MyNamespace: args.namespace,
+		Client:             mgr.GetClient(),
+		Scheme:             mgr.GetScheme(),
+		MyNode:             args.nodeName,
+		FRRConfig:          args.frrConfigPath,
+		ReloadPort:         args.reloadPort,
+		PodRuntime:         podRuntime,
+		LogLevel:           args.logLevel,
+		Logger:             logger,
+		MyNamespace:        args.namespace,
+		UnderlayFromMultus: args.underlayFromMultus,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Underlay")
 		os.Exit(1)

--- a/internal/controller/routerconfiguration/host_config.go
+++ b/internal/controller/routerconfiguration/host_config.go
@@ -46,11 +46,12 @@ func configureInterfaces(ctx context.Context, config interfacesConfiguration) er
 	slog.InfoContext(ctx, "configure interface start", "namespace", targetNS)
 	defer slog.InfoContext(ctx, "configure interface end", "namespace", targetNS)
 	apiConfig := conversion.ApiConfigData{
-		NodeIndex:     config.NodeIndex,
-		Underlays:     config.Underlays,
-		L3VNIs:        config.L3VNIs,
-		L2VNIs:        config.L2VNIs,
-		L3Passthrough: config.L3Passthrough,
+		UnderlayFromMultus: config.UnderlayFromMultus,
+		NodeIndex:          config.NodeIndex,
+		Underlays:          config.Underlays,
+		L3VNIs:             config.L3VNIs,
+		L2VNIs:             config.L2VNIs,
+		L3Passthrough:      config.L3Passthrough,
 	}
 	hostConfig, err := conversion.APItoHostConfig(config.NodeIndex, targetNS, apiConfig)
 	if err != nil {

--- a/internal/controller/routerconfiguration/underlay_vni_controller.go
+++ b/internal/controller/routerconfiguration/underlay_vni_controller.go
@@ -37,14 +37,15 @@ import (
 
 type PERouterReconciler struct {
 	client.Client
-	Scheme      *runtime.Scheme
-	MyNode      string
-	MyNamespace string
-	FRRConfig   string
-	ReloadPort  int
-	PodRuntime  *pods.Runtime
-	LogLevel    string
-	Logger      *slog.Logger
+	Scheme             *runtime.Scheme
+	MyNode             string
+	MyNamespace        string
+	FRRConfig          string
+	UnderlayFromMultus bool
+	ReloadPort         int
+	PodRuntime         *pods.Runtime
+	LogLevel           string
+	Logger             *slog.Logger
 }
 
 type requestKey string
@@ -132,12 +133,13 @@ func (r *PERouterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	logger.Debug("using config", "l3vnis", l3vnis.Items, "l2vnis", l2vnis.Items, "underlays", underlays.Items, "l3passthrough", l3passthrough.Items)
 	apiConfig := conversion.ApiConfigData{
-		NodeIndex:     nodeIndex,
-		Underlays:     underlays.Items,
-		LogLevel:      r.LogLevel,
-		L3VNIs:        l3vnis.Items,
-		L2VNIs:        l2vnis.Items,
-		L3Passthrough: l3passthrough.Items,
+		NodeIndex:          nodeIndex,
+		UnderlayFromMultus: r.UnderlayFromMultus,
+		Underlays:          underlays.Items,
+		LogLevel:           r.LogLevel,
+		L3VNIs:             l3vnis.Items,
+		L2VNIs:             l2vnis.Items,
+		L3Passthrough:      l3passthrough.Items,
 	}
 
 	if err := configureFRR(ctx, frrConfigData{

--- a/internal/conversion/api.go
+++ b/internal/conversion/api.go
@@ -8,12 +8,13 @@ import (
 )
 
 type ApiConfigData struct {
-	NodeIndex     int
-	Underlays     []v1alpha1.Underlay
-	L3VNIs        []v1alpha1.L3VNI
-	L2VNIs        []v1alpha1.L2VNI
-	L3Passthrough []v1alpha1.L3Passthrough
-	LogLevel      string
+	NodeIndex          int
+	UnderlayFromMultus bool
+	Underlays          []v1alpha1.Underlay
+	L3VNIs             []v1alpha1.L3VNI
+	L2VNIs             []v1alpha1.L2VNI
+	L3Passthrough      []v1alpha1.L3Passthrough
+	LogLevel           string
 }
 
 type HostConfigData struct {

--- a/internal/conversion/host_conversion.go
+++ b/internal/conversion/host_conversion.go
@@ -27,9 +27,15 @@ func APItoHostConfig(nodeIndex int, targetNS string, apiConfig ApiConfigData) (H
 
 	underlay := apiConfig.Underlays[0]
 
+	if len(underlay.Spec.Nics) == 0 && !apiConfig.UnderlayFromMultus {
+		return res, fmt.Errorf("underlay interface must be specified when Multus is not enabled")
+	}
+
 	res.Underlay = hostnetwork.UnderlayParams{
-		UnderlayInterface: underlay.Spec.Nics[0],
-		TargetNS:          targetNS,
+		TargetNS: targetNS,
+	}
+	if len(underlay.Spec.Nics) > 0 {
+		res.Underlay.UnderlayInterface = underlay.Spec.Nics[0]
 	}
 
 	if len(apiConfig.L3Passthrough) == 1 {

--- a/internal/hostnetwork/underlay.go
+++ b/internal/hostnetwork/underlay.go
@@ -43,8 +43,10 @@ func SetupUnderlay(ctx context.Context, params UnderlayParams) error {
 		}
 	}()
 
-	if err := moveUnderlayInterface(ctx, params.UnderlayInterface, ns); err != nil {
-		return err
+	if params.UnderlayInterface != "" {
+		if err := moveUnderlayInterface(ctx, params.UnderlayInterface, ns); err != nil {
+			return err
+		}
 	}
 
 	if params.EVPN == nil {

--- a/operator/bindata/deployment/openperouter/templates/controller.yaml
+++ b/operator/bindata/deployment/openperouter/templates/controller.yaml
@@ -51,6 +51,9 @@ spec:
         {{- if eq .Values.openperouter.cri "crio" }}
         - --crisocket=/crio.sock
         {{- end }}
+        {{- if .Values.openperouter.multusNetworkAnnotation }}
+        - --underlay-from-multus=true
+        {{- end }}
         command:
         - /controller
         env:


### PR DESCRIPTION
* specifying a NIC in the Underlay configuration was incorrectly mandatory, which prevented users from leveraging Multus to establish connectivity to the ToR.
* we now detect if the Router Pod has a `k8s.v1.cni.cncf.io/networks` annotation and propagate that information to subsequent calls.
* if no underlay NIC is specified and the multusEnabled flag is true, the logic for retrieving or moving the underlay interface into the router's netns is skipped, assuming that Multus has already handled the necessary setup.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
Fixes #150 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix: allow omitting underlay NIC configuration when using Multus.
```
