### PR TITLE
Add the design proposal for running the router directly on the host

### DIFF
--- a/enhancements/running-on-the-host.md
+++ b/enhancements/running-on-the-host.md
@@ -19,6 +19,7 @@ To solve this chicken-egg problem we need an operating mode where the router is 
 ## Non Goals
 
 - Having an alternative way to provide the static configuration that involves distritbuting the configuration to the routers
+- Dinamically change the static configuration from the kubernetes API
 
 ## Proposal
 
@@ -72,6 +73,8 @@ The static configuration must be provided to the OpenPERouter as files in a know
 
 - A static configuration with the same structure of the CRDs (ie underlays, vnis) to be used for bringing up the basic connectivity
 - An extra configuration to fill the requirements of running on the host. At the time of writing, the only extra configuration required seem to be a node index, to be associated manually (or by automation) to be different per each node.
+- Additionally, it must be possible to set the relevant parameters of the controller / router via a configuration file. This will make the distribution of the systemd unit easier, as the
+binaries will expect their own configuration in a canonical place
 
 #### Consuming the Kubernetes API
 
@@ -82,6 +85,11 @@ Running the controller on the host while it's still be able to access the kubern
 The static configuration must be treated exactly as configuration coming from the CRs. In this sense it must be validated, and the static configuration must be merged with the configuration read by CRs.
 
 This would allow a scenario where the UNDERLAY and a VNI is provided via static configuration, and extra VNIs are provided as day 2 configuration.
+
+#### Modifying the static configuration
+
+The static configuration will be visible as Kubernetes resource (see the part below about observability). However, it will only be a mirror of what is configured locally. Any change of the
+mirror won't have effect and the controller will reconcile it back.
 
 ### Challenges
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
/kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

As the proposal explains, we might want to run the router as a systemd unit BEFORE k8s starts. Here we explaing how and why. Creating backwards to provide the context / discussion space for https://github.com/openperouter/openperouter/pull/158 , which I started working on when there was not much room for discussing with others.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
