### PR TITLE
make: Add clean targets for single and multi-cluster teardown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,10 +316,7 @@ clab-multi-cluster: kind-node-image-build ## Deploy multi-cluster setup with 2 k
 
 .PHONY: clean
 clean: kind ## Shutdown and clean up kind cluster(s) and containerlab topology.
-	KUBECONFIG_PATH=$(KUBECONFIG_PATH) KIND=$(KIND) CLAB_TOPOLOGY=$(CLAB_TOPOLOGY_FILE) clab/clean.sh
-
-.PHONY: clean-multi
-clean-multi: kind ## Shutdown and clean up multi-cluster setup.
+	KUBECONFIG_PATH=$(KUBECONFIG_PATH) KIND=$(KIND) CLAB_TOPOLOGY=singlecluster/kind.clab.yml clab/clean.sh pe-kind
 	KUBECONFIG_PATH=$(KUBECONFIG_PATH) KIND=$(KIND) CLAB_TOPOLOGY=multicluster/kind.clab.yml clab/clean.sh pe-kind-a pe-kind-b
 
 .PHONY: load-on-kind

--- a/clab/clean.sh
+++ b/clab/clean.sh
@@ -4,23 +4,19 @@ set -euo pipefail
 pushd "$(dirname $(readlink -f $0))"
 source common.sh
 
-CLAB_TOPOLOGY="${CLAB_TOPOLOGY:-singlecluster/kind.clab.yml}"
-
-if [[ $# -gt 0 ]]; then
-    CLUSTER_ARRAY=("$@")
-elif [[ -n "${CLUSTER_NAMES:-}" ]]; then
-    read -ra CLUSTER_ARRAY <<< "$CLUSTER_NAMES"
-else
-    CLUSTER_ARRAY=("pe-kind")
+if [[ "${CLAB_TOPOLOGY}" == "" ]]; then 
+	echo "missing CLAB_TOPOLOGY env var to clean"
+	exit 1
 fi
 
-if [[ ${#CLUSTER_ARRAY[@]} -gt 1 ]]; then
-    CLUSTER_MODE="multi"
-else
-    CLUSTER_MODE="single"
+if [[ $# -lt 1 ]]; then
+	echo "missing cluster name arg to clean"
+	exit 1
 fi
 
-echo "=== Starting ${CLUSTER_MODE} cluster cleanup ==="
+CLUSTER_ARRAY=("$@")
+
+echo "=== Starting cluster cleanup ==="
 echo "CLAB_TOPOLOGY: $CLAB_TOPOLOGY"
 echo "CONTAINER_ENGINE: $CONTAINER_ENGINE"
 echo "CLUSTER_NAMES: ${CLUSTER_ARRAY[*]}"
@@ -53,44 +49,21 @@ for cluster_name in "${CLUSTER_ARRAY[@]}"; do
 done
 
 echo "=== Cleaning up bridge interfaces ==="
-if [[ "$CLUSTER_MODE" == "single" ]]; then
-    bridge_name="leafkind-switch"
-    if [[ -d "/sys/class/net/${bridge_name}" ]]; then
-        echo "Removing bridge: ${bridge_name}"
-        sudo ip link delete ${bridge_name} 2>/dev/null || true
+for iface in $(ip link show | awk -F': ' '/^[0-9]+: leafkind/ {print $2}' | cut -d'@' -f1); do
+    if [[ -d "/sys/class/net/${iface}" ]]; then
+        echo "Removing bridge: ${iface}"
+        sudo ip link delete ${iface} 2>/dev/null || true
     fi
-else
-    for cluster_name in "${CLUSTER_ARRAY[@]}"; do
-        suffix=$(echo "$cluster_name" | sed 's/pe-kind-//')
-        bridge_name="leafkind-sw-${suffix}"
-        if [[ -d "/sys/class/net/${bridge_name}" ]]; then
-            echo "Removing bridge: ${bridge_name}"
-            sudo ip link delete ${bridge_name} 2>/dev/null || true
-        fi
-    done
-fi
+done
 
 echo "=== Cleaning up kubeconfig files ==="
-if [[ "$CLUSTER_MODE" == "multi" ]]; then
-    for cluster_name in "${CLUSTER_ARRAY[@]}"; do
-        rm -f "${KUBECONFIG_PATH}-${cluster_name}" || true
-        echo "Removed: ${KUBECONFIG_PATH}-${cluster_name}"
-    done
-fi
-rm -f "${KUBECONFIG_PATH}" || true
-echo "Removed: ${KUBECONFIG_PATH}"
+rm -f "${KUBECONFIG_PATH}*" || true
 
 echo "=== Cleaning up local registry ==="
 ${CONTAINER_ENGINE_CLI} stop kind-registry 2>/dev/null || true
 ${CONTAINER_ENGINE_CLI} rm kind-registry 2>/dev/null || true
 
-echo "=== Cleaning up bin/ folder ==="
-popd
-rm -rf bin/ || true
-echo "Removed: bin/"
-pushd "$(dirname $(readlink -f $0))" >/dev/null
-
-echo "=== ${CLUSTER_MODE^} cluster cleanup completed ==="
+echo "=== cluster cleanup completed ==="
 echo "All resources have been cleaned up"
 
 popd


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit introduces cleanup targets in the Makefile to simplify the teardown of both single and multi-cluster containerlab environments:


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
