### PR TITLE
e2e tests: remove printf arg

### DIFF
--- a/e2etests/tests/dump.go
+++ b/e2etests/tests/dump.go
@@ -89,7 +89,7 @@ func logFileFor(base string, kind string) (*os.File, error) {
 }
 
 func DumpPods(name string, pods []*corev1.Pod) {
-	ginkgo.GinkgoWriter.Printf("%s pods are: %s", name)
+	ginkgo.GinkgoWriter.Printf("%s pods are:", name)
 	for _, pod := range pods {
 		ginkgo.GinkgoWriter.Printf("Pod %s/%s: %s", pod.Namespace, pod.Name, pod.Status.Phase)
 		ginkgo.GinkgoWriter.Printf("  Node: %s", pod.Spec.NodeName)


### PR DESCRIPTION
This is causing the following print:
"""
  router pods are: %!s(MISSING)Pod openperouter-system/router-fhcn5: Running  Node: pe-kind-control-plane  IPs: [{10.244.0.5} {fd00:10:244::5}]  Containers:    - frr: quay.io/frrouting/frr:10.2.1    - reloader: quay.io/frrouting/frr:10.2.1
  Pod openperouter-system/router-sq5x4: Running  Node: pe-kind-worker  IPs: [{10.244.1.4} {fd00:10:244:1::4}]  Containers:    - frr: quay.io/frrouting/frr:10.2.1    - reloader: quay.io/frrouting/frr:10.2.1
  frrk8s pods are: %!s(MISSING)Pod frr-k8s-system/frr-k8s-daemon-cvwbk: Running  Node: pe-kind-worker  IPs: [{172.18.0.3} {fc00:f853:ccd:e793::3}]  Containers:    - frr-k8s: quay.io/metallb/frr-k8s:v0.0.18    - kube-rbac-proxy: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1    - kube-rbac-proxy-frr: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1    - frr: quay.io/frrouting/frr:9.1.0    - frr-metrics: quay.io/frrouting/frr:9.1.0    - frr-status: quay.io/frrouting/frr:9.1.0    - reloader: quay.io/frrouting/frr:9.1.0
  Pod frr-k8s-system/frr-k8s-daemon-rc29d: Running  Node: pe-kind-control-plane  IPs: [{172.18.0.4} {fc00:f853:ccd:e793::4}]  Containers:    - frr-k8s: quay.io/metallb/frr-k8s:v0.0.18    - kube-rbac-proxy: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1    - kube-rbac-proxy-frr: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1    - frr: quay.io/frrouting/frr:9.1.0    - frr-metrics: quay.io/frrouting/frr:9.1.0    - frr-status: quay.io/frrouting/frr:9.1.0    - reloader: quay.io/frrouting/frr:9.1.0
"""

We can at least remove the `%!s(MISSING)` part.
Maybe some extra \n wouldn't hurt .

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug

/kind cleanup

> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
