### PR TITLE
api: rename l2vni hostmaster bridge to linux-bridge

### DIFF
--- a/api/v1alpha1/l2vni_types.go
+++ b/api/v1alpha1/l2vni_types.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	LinuxBridge = "bridge"
+	LinuxBridge = "linux-bridge"
 	OVSBridge   = "ovs-bridge"
 )
 
@@ -71,7 +71,7 @@ type HostMaster struct {
 	Name string `json:"name,omitempty"`
 
 	// Type of the host interface. Supports linux bridge or OVS bridge.
-	// +kubebuilder:validation:Enum=bridge;ovs-bridge
+	// +kubebuilder:validation:Enum=linux-bridge;ovs-bridge
 	Type string `json:"type,omitempty"`
 
 	// If true, the interface will be created automatically if not present.

--- a/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_l2vnis.yaml
+++ b/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_l2vnis.yaml
@@ -64,7 +64,7 @@ spec:
                     description: Type of the host interface. Supports linux bridge
                       or OVS bridge.
                     enum:
-                    - bridge
+                    - linux-bridge
                     - ovs-bridge
                     type: string
                 type: object

--- a/config/all-in-one/crio.yaml
+++ b/config/all-in-one/crio.yaml
@@ -73,7 +73,7 @@ spec:
                     description: Type of the host interface. Supports linux bridge
                       or OVS bridge.
                     enum:
-                    - bridge
+                    - linux-bridge
                     - ovs-bridge
                     type: string
                 type: object

--- a/config/all-in-one/openpe.yaml
+++ b/config/all-in-one/openpe.yaml
@@ -73,7 +73,7 @@ spec:
                     description: Type of the host interface. Supports linux bridge
                       or OVS bridge.
                     enum:
-                    - bridge
+                    - linux-bridge
                     - ovs-bridge
                     type: string
                 type: object

--- a/config/crd/bases/openpe.openperouter.github.io_l2vnis.yaml
+++ b/config/crd/bases/openpe.openperouter.github.io_l2vnis.yaml
@@ -64,7 +64,7 @@ spec:
                     description: Type of the host interface. Supports linux bridge
                       or OVS bridge.
                     enum:
-                    - bridge
+                    - linux-bridge
                     - ovs-bridge
                     type: string
                 type: object

--- a/config/samples/l2vni.yaml
+++ b/config/samples/l2vni.yaml
@@ -7,7 +7,7 @@ spec:
   vni: 210
   vrf: red
   hostmaster:
-    type: bridge
+    type: linux-bridge
     autocreate: true
 
 

--- a/e2etests/tests/evpn_l2.go
+++ b/e2etests/tests/evpn_l2.go
@@ -43,6 +43,7 @@ var _ = Describe("Routes between bgp and the fabric", Ordered, func() {
 		},
 	}
 
+	const linuxBridgeHostAttachment = "linux-bridge"
 	l2VniRed := v1alpha1.L2VNI{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "red110",
@@ -51,6 +52,10 @@ var _ = Describe("Routes between bgp and the fabric", Ordered, func() {
 		Spec: v1alpha1.L2VNISpec{
 			VRF: ptr.To("red"),
 			VNI: 110,
+			HostMaster: &v1alpha1.HostMaster{
+				AutoCreate: true,
+				Type:       linuxBridgeHostAttachment,
+			},
 		},
 	}
 
@@ -222,7 +227,7 @@ var _ = Describe("Routes between bgp and the fabric", Ordered, func() {
 			nadMaster:    "br-hs-110",
 			hostMaster: v1alpha1.HostMaster{
 				AutoCreate: true,
-				Type:       "bridge",
+				Type:       linuxBridgeHostAttachment,
 			},
 		}),
 		Entry("for dual stack", testCase{
@@ -234,7 +239,7 @@ var _ = Describe("Routes between bgp and the fabric", Ordered, func() {
 			nadMaster:    "br-hs-110",
 			hostMaster: v1alpha1.HostMaster{
 				AutoCreate: true,
-				Type:       "bridge",
+				Type:       linuxBridgeHostAttachment,
 			},
 		}),
 		Entry("for single stack ipv6", testCase{
@@ -246,7 +251,7 @@ var _ = Describe("Routes between bgp and the fabric", Ordered, func() {
 			nadMaster:    "br-hs-110",
 			hostMaster: v1alpha1.HostMaster{
 				AutoCreate: true,
-				Type:       "bridge",
+				Type:       linuxBridgeHostAttachment,
 			},
 		}),
 		Entry("OVS bridge autocreate for single stack ipv4", testCase{

--- a/examples/evpn/kubevirt/openpe.yaml
+++ b/examples/evpn/kubevirt/openpe.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   hostmaster:
     autocreate: true
-    type: bridge
+    type: linux-bridge
   l2gatewayip: 192.170.1.1/24
   vni: 110
   vrf: red

--- a/examples/evpn/layer2/openpe.yaml
+++ b/examples/evpn/layer2/openpe.yaml
@@ -21,7 +21,7 @@ spec:
   vni: 110
   vrf: red
   hostmaster:
-    type: bridge
+    type: linux-bridge
     autocreate: true
   l2gatewayip: 192.170.1.1/24
 ---

--- a/examples/evpn/multi-cluster/cluster-a-migration-l2vni.yaml
+++ b/examples/evpn/multi-cluster/cluster-a-migration-l2vni.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   hostmaster:
     autocreate: true
-    type: bridge
+    type: linux-bridge
   l2gatewayip: 192.170.10.1/24
   vni: 666
   vrf: rouge

--- a/examples/evpn/multi-cluster/cluster-a-openpe.yaml
+++ b/examples/evpn/multi-cluster/cluster-a-openpe.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   hostmaster:
     autocreate: true
-    type: bridge
+    type: linux-bridge
   l2gatewayip: 192.170.1.1/24
   vni: 110
   vrf: red

--- a/examples/evpn/multi-cluster/cluster-b-migration-l2vni.yaml
+++ b/examples/evpn/multi-cluster/cluster-b-migration-l2vni.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   hostmaster:
     autocreate: true
-    type: bridge
+    type: linux-bridge
   l2gatewayip: 192.170.10.1/24
   vni: 666
   vrf: rouge

--- a/examples/evpn/multi-cluster/cluster-b-openpe.yaml
+++ b/examples/evpn/multi-cluster/cluster-b-openpe.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   hostmaster:
     autocreate: true
-    type: bridge
+    type: linux-bridge
   l2gatewayip: 192.170.1.1/24
   vni: 110
   vrf: red

--- a/internal/hostnetwork/vni.go
+++ b/internal/hostnetwork/vni.go
@@ -55,7 +55,7 @@ type HostMaster struct {
 
 const (
 	VRFLinkType       = "vrf"
-	BridgeLinkType    = "bridge"
+	BridgeLinkType    = "linux-bridge"
 	VXLanLinkType     = "vxlan"
 	OVSBridgeLinkType = "ovs-bridge"
 )
@@ -368,7 +368,7 @@ func RemoveNonConfiguredVNIs(targetNS string, params []VNIParams) error {
 func deleteLinksForType(linkType string, vnis map[int]bool, links []netlink.Link, vniFromName func(string) (int, error)) error {
 	deleteErrors := []error{}
 	for _, l := range links {
-		if l.Type() != linkType {
+		if l.Type() != netlinkTypeFor(linkType) {
 			continue
 		}
 		vni, err := vniFromName(l.Attrs().Name)
@@ -390,6 +390,14 @@ func deleteLinksForType(linkType string, vnis map[int]bool, links []netlink.Link
 	}
 
 	return errors.Join(deleteErrors...)
+}
+
+// netlinkTypeFor maps API link type names to netlink link type names.
+func netlinkTypeFor(linkType string) string {
+	if linkType == BridgeLinkType {
+		return "bridge"
+	}
+	return linkType
 }
 
 // removeOVSBridgesForVNIs removes auto-created OVS bridges that are not in the configured VNIs list.

--- a/operator/bundle/manifests/openpe.openperouter.github.io_l2vnis.yaml
+++ b/operator/bundle/manifests/openpe.openperouter.github.io_l2vnis.yaml
@@ -64,7 +64,7 @@ spec:
                     description: Type of the host interface. Supports linux bridge
                       or OVS bridge.
                     enum:
-                    - bridge
+                    - linux-bridge
                     - ovs-bridge
                     type: string
                 type: object

--- a/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2025-12-11T14:19:18Z"
+    createdAt: "2025-12-12T15:08:19Z"
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: openperouter-operator.v0.0.0

--- a/website/content/docs/configuration/evpn.md
+++ b/website/content/docs/configuration/evpn.md
@@ -135,13 +135,13 @@ L2VNIs provide Layer 2 connectivity across nodes using EVPN tunnels. Unlike L3VN
 
 ### Configuration Fields
 
-| Field | Type | Description                                                                 | Required |
-|-------|------|-----------------------------------------------------------------------------|----------|
-| `vni` | integer | Virtual Network Identifier for the EVPN tunnel                              | Yes |
-| `vrf` | string | Name of the VRF to associate with this L2VNI                                | Yes |
-| `hostmaster.type` | string | Type of host interface management (`bridge`, `ovs-bridge`, or `direct`)     | Yes |
-| `hostmaster.autocreate` | boolean | Whether to automatically create a bridge if type is `bridge` or `ovs-bridge` | No |
-| `hostmaster.bridgeName` | string | Name of the bridge to attach to (if not auto-creating)                      | No |
+| Field | Type | Description                                                                        | Required |
+|-------|------|------------------------------------------------------------------------------------|----------|
+| `vni` | integer | Virtual Network Identifier for the EVPN tunnel                                     | Yes |
+| `vrf` | string | Name of the VRF to associate with this L2VNI                                       | Yes |
+| `hostmaster.type` | string | Type of host interface management (`linux-bridge`, `ovs-bridge`, or `direct`)      | Yes |
+| `hostmaster.autocreate` | boolean | Whether to automatically create a bridge if type is `linux-bridge` or `ovs-bridge` | No |
+| `hostmaster.bridgeName` | string | Name of the bridge to attach to (if not auto-creating)                             | No |
 
 ### L2VNI Example
 
@@ -155,7 +155,7 @@ spec:
   vni: 210
   vrf: red
   hostmaster:
-    type: bridge
+    type: linux-bridge
     autocreate: true
 ```
 

--- a/website/content/docs/examples/evpnexamples/kubevirt-multi-cluster.md
+++ b/website/content/docs/examples/evpnexamples/kubevirt-multi-cluster.md
@@ -78,7 +78,7 @@ metadata:
 spec:
   hostmaster:
     autocreate: true
-    type: bridge
+    type: linux-bridge
   l2gatewayip: 192.170.1.1/24
   vni: 110
   vrf: red

--- a/website/content/docs/examples/evpnexamples/kubevirt.md
+++ b/website/content/docs/examples/evpnexamples/kubevirt.md
@@ -74,7 +74,7 @@ metadata:
 spec:
   hostmaster:
     autocreate: true
-    type: bridge
+    type: linux-bridge
   l2gatewayip: 192.170.1.1/24
   vni: 110
   vrf: red

--- a/website/content/docs/examples/evpnexamples/layer2.md
+++ b/website/content/docs/examples/evpnexamples/layer2.md
@@ -64,7 +64,7 @@ spec:
   vni: 110
   vrf: red
   hostmaster:
-    type: bridge
+    type: linux-bridge
     autocreate: true
   l2gatewayip: 192.170.1.1/24
 ```


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>

/kind bug

> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

This PR renames the l2vni hostmaster type attribute from `bridge`to `linux-bridge`

**Special notes for your reviewer**:
Fixes: #173 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
api: rename l2vni hostmaster type from bridge to linux-bridge
```
