### PR TITLE
ci, ovs: install OVS in the publish step

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,6 +28,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install linux-modules-extra-$(uname -r)
 
+      - name: Install Open vSwitch
+        # Required for L2VNI OVS bridge integration tests in internal/hostnetwork/vni_test.go
+        # Tests run on ubuntu-22.04 host with sudo, not in kind nodes
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y openvswitch-switch openvswitch-common
+          sudo systemctl start openvswitch-switch
+          sudo systemctl enable openvswitch-switch
+          sudo ovs-vsctl show
+          sudo test -S /var/run/openvswitch/db.sock
+
       - name: Unit Tests
         run: |
           make test


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>

/kind bug

> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
The unit tests are run in the `publish` github workflow; since the newly added OVS / L2VNI hostmaster integration, some unit tests require OVS to be installed in the hypervisor. This PR does that.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
