### PR TITLE
api, docs, ovs: document new opt for L2VNI attach

### DIFF
--- a/API-DOCS.md
+++ b/API-DOCS.md
@@ -68,7 +68,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `name` _string_ | Name of the host interface. Must match VRF name validation if set. |  | MaxLength: 15 <br />Pattern: `^[a-zA-Z][a-zA-Z0-9_-]*$` <br /> |
-| `type` _string_ | Type of the host interface. Currently only "bridge" is supported. |  | Enum: [bridge] <br /> |
+| `type` _string_ | Type of the host interface. Supports linux bridge or OVS bridge. |  | Enum: [bridge, ovs-bridge] <br /> |
 | `autocreate` _boolean_ | If true, the interface will be created automatically if not present.<br />The name of the bridge is of the form br-hs-<VNI>. | false |  |
 
 

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
 - underlay.yaml
 - vni.yaml
+- l2vni-ovs.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/l2vni-ovs.yaml
+++ b/config/samples/l2vni-ovs.yaml
@@ -1,0 +1,11 @@
+apiVersion: openpe.openperouter.github.io/v1alpha1
+kind: L2VNI
+metadata:
+  name: l2red-ovs
+  namespace: openperouter-system
+spec:
+  vni: 210
+  vrf: red
+  hostmaster:
+    type: ovs-bridge
+    autocreate: true

--- a/website/content/docs/configuration/evpn.md
+++ b/website/content/docs/configuration/evpn.md
@@ -135,13 +135,13 @@ L2VNIs provide Layer 2 connectivity across nodes using EVPN tunnels. Unlike L3VN
 
 ### Configuration Fields
 
-| Field | Type | Description | Required |
-|-------|------|-------------|----------|
-| `vni` | integer | Virtual Network Identifier for the EVPN tunnel | Yes |
-| `vrf` | string | Name of the VRF to associate with this L2VNI | Yes |
-| `hostmaster.type` | string | Type of host interface management (`bridge` or `direct`) | Yes |
-| `hostmaster.autocreate` | boolean | Whether to automatically create a bridge if type is `bridge` | No |
-| `hostmaster.bridgeName` | string | Name of the bridge to attach to (if not auto-creating) | No |
+| Field | Type | Description                                                                 | Required |
+|-------|------|-----------------------------------------------------------------------------|----------|
+| `vni` | integer | Virtual Network Identifier for the EVPN tunnel                              | Yes |
+| `vrf` | string | Name of the VRF to associate with this L2VNI                                | Yes |
+| `hostmaster.type` | string | Type of host interface management (`bridge`, `ovs-bridge`, or `direct`)     | Yes |
+| `hostmaster.autocreate` | boolean | Whether to automatically create a bridge if type is `bridge` or `ovs-bridge` | No |
+| `hostmaster.bridgeName` | string | Name of the bridge to attach to (if not auto-creating)                      | No |
 
 ### L2VNI Example
 


### PR DESCRIPTION


<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing

/kind documentation

> /kind regression
> /kind example

**What this PR does / why we need it**:
This commit documents OVS bridge as a new option when creating an L2 VNI. It can be specified as `l2vni.spec.hostmaster.type="ovs-bridge"`.

**Special notes for your reviewer**:
Fixes: #182 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
