### PR TITLE
flake, e2etests, l3vni: generate FRRConfigurations on all nodes

### DIFF
--- a/e2etests/tests/evpn_routes.go
+++ b/e2etests/tests/evpn_routes.go
@@ -293,6 +293,18 @@ var _ = Describe("Routes between bgp and the fabric", Ordered, func() {
 			podNode, err = cs.CoreV1().Nodes().Get(context.Background(), testPod.Spec.NodeName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
+			frrk8sPods, err := frrk8s.Pods(cs)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Create FRRConfigurations for ALL nodes
+			// Container mode: configs without nodeSelector (apply to all pods)
+			// Systemd mode: per-node configs with nodeSelector (each pod connects to local router)
+			frrK8sConfigRed, err := frrk8s.ConfigFromHostSessionForAllNodes(cs, *vniRed.Spec.HostSession, vniRed.Name, HostMode)
+			Expect(err).NotTo(HaveOccurred())
+			frrK8sConfigBlue, err := frrk8s.ConfigFromHostSessionForAllNodes(cs, *vniBlue.Spec.HostSession, vniBlue.Name, HostMode)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Create ADDITIONAL configs for pod's node that advertise pod IPs
 			nodeSelector := k8s.NodeSelectorForPod(testPod)
 
 			advertisePodToVNI := func(pod *corev1.Pod, vni v1alpha1.L3VNI) []frrk8sapi.FRRConfiguration {
@@ -305,31 +317,41 @@ var _ = Describe("Routes between bgp and the fabric", Ordered, func() {
 						cidrSuffix = "/128"
 					}
 
-					config, err := frrk8s.ConfigFromHostSessionForIPFamily(*vni.Spec.HostSession, vni.Name, ipFamily, frrk8s.WithNodeSelector(nodeSelector), frrk8s.AdvertisePrefixes(podIP.IP+cidrSuffix))
+					// Use different name to avoid conflict with base config
+					config, err := frrk8s.ConfigFromHostSessionForIPFamily(
+						*vni.Spec.HostSession,
+						vni.Name+"-pod",
+						ipFamily,
+						frrk8s.WithNodeSelector(nodeSelector),
+						frrk8s.AdvertisePrefixes(podIP.IP+cidrSuffix),
+					)
 					Expect(err).NotTo(HaveOccurred())
 					res = append(res, *config)
 				}
 				return res
 			}
 
-			By("Creating the frr-k8s configuration for the node where the test pod runs and advertising all pod ips")
+			By("Creating frr-k8s configuration for all nodes and advertising pod ips from pod's node")
 
 			frrK8sConfigRedForPod := advertisePodToVNI(testPod, vniRed)
 			frrK8sConfigBlueForPod := advertisePodToVNI(testPod, vniBlue)
+
+			baseConfigs := append(frrK8sConfigRed, frrK8sConfigBlue...)
+			podConfigs := append(frrK8sConfigRedForPod, frrK8sConfigBlueForPod...)
+			allFRRConfigs := append(baseConfigs, podConfigs...)
 
 			err = Updater.Update(config.Resources{
 				L3VNIs: []v1alpha1.L3VNI{
 					vniRed,
 					vniBlue,
 				},
-				FRRConfigurations: append(frrK8sConfigRedForPod, frrK8sConfigBlueForPod...),
+				FRRConfigurations: allFRRConfigs,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			frrK8sPodOnNode, err := frrk8s.PodForNode(cs, testPod.Spec.NodeName)
-			Expect(err).NotTo(HaveOccurred())
-			validateFRRK8sSessionForHostSession(vniRed.Name, *vniRed.Spec.HostSession, Established, frrK8sPodOnNode)
-			validateFRRK8sSessionForHostSession(vniBlue.Name, *vniBlue.Spec.HostSession, Established, frrK8sPodOnNode)
+			// Validate sessions on ALL frr-k8s pods
+			validateFRRK8sSessionForHostSession(vniRed.Name, *vniRed.Spec.HostSession, Established, frrk8sPods...)
+			validateFRRK8sSessionForHostSession(vniBlue.Name, *vniBlue.Spec.HostSession, Established, frrk8sPods...)
 		})
 
 		AfterAll(func() {


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE?**:

/kind flake

**What this PR does / why we need it**:

Fixes a flaky e2e test: "Routes between bgp and the fabric testing e2e integration between a pod and the blue / red hosts - should be able to reach the hosts from the test pod and vice versa vni red host A ipv4"

**Root Cause:** The test was creating FRRConfigurations only for the node where the test pod runs (using `WithNodeSelector`), but traffic may be routed through other nodes that don't have BGP configured. When router pods on those nodes try to establish BGP sessions with their host interfaces, they get "Connection refused" because no BGP daemon is listening.

**Fix:** Create base FRRConfigurations for ALL nodes (without `nodeSelector`) to ensure all router pods can establish BGP sessions with their respective host interfaces. Pod-specific configs (with prefix advertisement) are still created only for the pod's node.

Changes:
- `evpn_routes.go`: Create base FRRConfigs for all nodes, validate BGP sessions on all frr-k8s pods
- `passthrough_routes.go`: Apply the same fix pattern

**Special notes for your reviewer**:

The same issue pattern existed in both `evpn_routes.go` and `passthrough_routes.go`. Both files have been updated with the same fix.

The pod-specific FRRConfigurations now use a different name (`<vni>-pod` instead of `<vni>`) to avoid naming conflicts with the base configurations.

**Release note**:
```release-note
NONE
```
