### PR TITLE
build: fix make build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,11 +83,11 @@ test: fmt vet envtest ## Run tests.
 
 .PHONY: build
 build: manifests generate fmt vet ## Build manager binary.
-	go build -o bin/reloader cmd/reloader/main.go
-	go build -o bin/controller cmd/hostcontroller/main.go
-	go build -o bin/hostbridge cmd/hostbridge/main.go
-	go build -o bin/nodemarker cmd/nodemarker/main.go
-	go build -o bin/cp-tool cmd/cp-tool/main.go
+	go build -o bin/reloader ./cmd/reloader
+	go build -o bin/controller ./cmd/hostcontroller
+	go build -o bin/hostbridge ./cmd/hostbridge
+	go build -o bin/nodemarker ./cmd/nodemarker
+	go build -o bin/cp-tool ./cmd/cp-tool
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>

/kind bug

> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
Before this PR, running `make` or `make build` would cause the following error:
```
go build -o bin/hostbridge cmd/hostbridge/main.go
cmd/hostbridge/main.go:52:12: undefined: annotateCurrentNode
```

This commit fixes this.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
