### PR TITLE
e2etests: return error inside eventually block

### DIFF
--- a/e2etests/tests/evpn_routes.go
+++ b/e2etests/tests/evpn_routes.go
@@ -139,7 +139,9 @@ var _ = Describe("Routes between bgp and the fabric", Ordered, func() {
 				Eventually(func() error {
 					for exec := range routers.GetExecutors() {
 						evpn, err := frr.EVPNInfo(exec)
-						Expect(err).NotTo(HaveOccurred())
+						if err != nil {
+							return fmt.Errorf("failed to get EVPN info from %s: %w", exec.Name(), err)
+						}
 						for _, prefix := range prefixes {
 							if mustContain && !evpn.ContainsType5RouteForVNI(prefix, leaf.VTEPIP, int(vni.Spec.VNI)) {
 								return fmt.Errorf("type5 route for %s - %s not found in %v in router %s", prefix, leaf.VTEPIP, evpn, exec.Name())


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>

/kind bug

> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

The Expect inside Eventually prevents retries when bgpd isn't ready;
this change returns the error instead, which will enable the retry
logic.

Another option would be to receive `ginkgo` as an input parameter in
eventually, and run that `ginkgo` instance expectations. This would
allow the eventually block to be re-tried. I chose to follow the pattern
in place in this function, which is to return the errors.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
