### PR TITLE
e2etests: add VNI scale tests with metrics collection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,7 @@ name: CI
 on:
   merge_group:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths-ignore:
       - 'DCO'
       - 'LICENSE'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -292,3 +292,124 @@ jobs:
         uses: ./.github/workflows/composite/collectlogs
         with:
           artifact-name: kind-logs-${{ matrix.deployment }}
+
+  scale-tests:
+    if: contains(github.event.pull_request.labels.*.name, 'run-scale-tests')
+    runs-on: ubuntu-22.04
+    env:
+      NODE_IMAGE: quay.io/openperouter/kind-node-openperouter:v1.32.2
+    needs:
+      - unit-tests
+      - build-test-images
+
+    steps:
+      - name: Free Disk Space
+        working-directory: ${{ github.workspace }}
+        run: |
+          echo "Disk space before cleanup:"
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          sudo apt-get clean
+          echo "Disk space after cleanup:"
+          df -h
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: Install kernel modules
+        run: |
+          sudo apt-get update
+          sudo apt-get install linux-modules-extra-$(uname -r)
+
+      - name: Disable containerd image store
+        run: |
+          sudo bash -c 'cat > /etc/docker/daemon.json << EOF
+          {
+            "features": {
+              "containerd-snapshotter": false
+            }
+          }
+          EOF'
+          sudo systemctl restart docker
+          docker info -f '{{ .DriverStatus }}'
+
+      - name: Setup docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build kind-node-openperouter image
+        uses: docker/build-push-action@v5
+        with:
+          context: hack/kind-node-image
+          file: hack/kind-node-image/Dockerfile
+          build-args: |
+            KIND_NODE_VERSION=v1.32.2
+          tags: quay.io/openperouter/kind-node-openperouter:v1.32.2
+          load: true
+          cache-from: type=gha,scope=kind-node-openperouter
+          cache-to: type=gha,mode=max,scope=kind-node-openperouter
+
+      - name: Download openperouter image
+        uses: actions/download-artifact@v4
+        with:
+          path: image
+
+      - name: Load image
+        working-directory: image
+        run: |
+          docker load -i image-tar-openperouter/openperouter.tar
+
+      - name: Deploy the cluster
+        run: |
+          make deploy-scale
+
+      - name: Install metrics-server
+        env:
+          KUBECONFIG: bin/kubeconfig
+        run: |
+          kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+          kubectl patch -n kube-system deployment metrics-server --type=json \
+            -p='[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--kubelet-insecure-tls"}]'
+          # Wait for deployment rollout to complete (not just any pod ready)
+          # This ensures the patched pod is fully running, not the original pre-patch pod
+          kubectl -n kube-system rollout status deployment/metrics-server --timeout=300s
+          # Give metrics-server time to collect initial metrics
+          sleep 60
+
+      - name: Run scale tests
+        run: |
+          make scale-tests
+
+      - name: Parse scale test report
+        if: ${{ always() }}
+        run: |
+          python3 hack/parse-scale-report.py /tmp/kind_logs/e2etests_scale_suite_scale-report.json \
+            | tee /tmp/kind_logs/scale-test-summary.txt
+
+      - name: Upload scale test report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          retention-days: 30
+          name: scale-test-report
+          path: |
+            /tmp/kind_logs/e2etests_scale_suite_scale-report.json
+            /tmp/kind_logs/scale-test-summary.txt
+
+      - name: Export kind logs
+        if: ${{ failure() }}
+        run:
+          make kind-export-logs
+
+      - name: Collect Logs
+        if: ${{ failure() }}
+        uses: ./.github/workflows/composite/collectlogs
+        with:
+          artifact-name: kind-logs-scale-tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -381,8 +381,7 @@ jobs:
       - name: Parse scale test report
         if: ${{ always() }}
         run: |
-          python3 hack/parse-scale-report.py /tmp/kind_logs/e2etests_scale_suite_scale-report.json \
-            | tee /tmp/kind_logs/scale-test-summary.txt
+          make parse-scale-report | tee /tmp/kind_logs/scale-test-summary.txt
 
       - name: Upload scale test report
         if: ${{ always() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -371,18 +371,8 @@ jobs:
         run: |
           make deploy-scale
 
-      - name: Install metrics-server
-        env:
-          KUBECONFIG: bin/kubeconfig
-        run: |
-          kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
-          kubectl patch -n kube-system deployment metrics-server --type=json \
-            -p='[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--kubelet-insecure-tls"}]'
-          # Wait for deployment rollout to complete (not just any pod ready)
-          # This ensures the patched pod is fully running, not the original pre-patch pod
-          kubectl -n kube-system rollout status deployment/metrics-server --timeout=300s
-          # Give metrics-server time to collect initial metrics
-          sleep 60
+      - name: Wait for metrics-server to collect initial metrics
+        run: sleep 60
 
       - name: Run scale tests
         run: |

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,14 @@ deploy: kind deploy-cluster deploy-controller ## Deploy cluster and controller.
 
 .PHONY: deploy-scale
 deploy-scale: export KUSTOMIZE_LAYER=scale
-deploy-scale: kind deploy-cluster deploy-controller ## Deploy cluster and controller without resource limits for scale testing.
+deploy-scale: kind deploy-cluster deploy-controller deploy-metrics-server ## Deploy cluster and controller without resource limits for scale testing.
+
+.PHONY: deploy-metrics-server
+deploy-metrics-server: kubectl ## Install metrics-server for scale testing (requires --kubelet-insecure-tls for kind clusters).
+	$(KUBECTL) apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+	$(KUBECTL) patch -n kube-system deployment metrics-server --type=json \
+		-p='[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--kubelet-insecure-tls"}]'
+	$(KUBECTL) -n kube-system rollout status deployment/metrics-server --timeout=300s
 
 .PHONY: setup-hostmode
 setup-hostmode: ## Setup node configuration for hostmode.

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,8 @@ docker-build: ## Build docker image with the manager.
 	else \
 		$(CONTAINER_ENGINE) build -t ${IMG} .; \
 	fi
+
+
 TLS_VERIFY ?= "true"
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
@@ -131,6 +133,8 @@ docker-push: ## Push docker image with the manager.
 ifndef ignore-not-found
   ignore-not-found = false
 endif
+
+
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin
 $(LOCALBIN):
@@ -343,6 +347,12 @@ scale-tests: ginkgo kubectl create-export-logs ## Run VNI scale tests
 		--json-report=scale-report.json --output-dir=${KIND_EXPORT_LOGS} --keep-separate-reports \
 		./e2etests/scale_suite -- \
 		--kubectl=$(KUBECTL) $(TEST_ARGS)
+
+SCALE_REPORT ?= ${KIND_EXPORT_LOGS}/e2etests_scale_suite_scale-report.json
+
+.PHONY: parse-scale-report
+parse-scale-report: ## Parse scale test JSON report and print summary tables.
+	python3 hack/parse-scale-report.py $(SCALE_REPORT)
 
 .PHONY: clab-cluster
 clab-cluster: kind-node-image-build
@@ -610,6 +620,8 @@ catalog-build: opm ## Build a catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+
+
 deploy-operator-with-olm: export VERSION=dev
 deploy-operator-with-olm: export CSV_VERSION=0.0.0
 deploy-operator-with-olm: export KIND_WITH_REGISTRY=true

--- a/Makefile
+++ b/Makefile
@@ -117,8 +117,6 @@ docker-build: ## Build docker image with the manager.
 	else \
 		$(CONTAINER_ENGINE) build -t ${IMG} .; \
 	fi
-
-
 TLS_VERIFY ?= "true"
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
@@ -133,8 +131,6 @@ docker-push: ## Push docker image with the manager.
 ifndef ignore-not-found
   ignore-not-found = false
 endif
-
-
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin
 $(LOCALBIN):
@@ -184,6 +180,10 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: kind deploy-cluster deploy-controller ## Deploy cluster and controller.
+
+.PHONY: deploy-scale
+deploy-scale: export KUSTOMIZE_LAYER=scale
+deploy-scale: kind deploy-cluster deploy-controller ## Deploy cluster and controller without resource limits for scale testing.
 
 .PHONY: setup-hostmode
 setup-hostmode: ## Setup node configuration for hostmode.
@@ -319,7 +319,7 @@ $(APIDOCSGEN): $(LOCALBIN)
 
 .PHONY: e2etests
 e2etests: ginkgo kubectl build-validator create-export-logs
-	$(GINKGO) -v $(GINKGO_ARGS) --timeout=3h ./e2etests/suite -- --kubectl=$(KUBECTL) $(TEST_ARGS) --hostvalidator $(VALIDATOR_PATH) --reporterpath=${KIND_EXPORT_LOGS}
+	$(GINKGO) -v $(GINKGO_ARGS) --label-filter="!systemdmode" --timeout=3h ./e2etests/suite -- --kubectl=$(KUBECTL) $(TEST_ARGS) --hostvalidator $(VALIDATOR_PATH) --reporterpath=${KIND_EXPORT_LOGS}
 
 .PHONY: e2etests-hostmode-boot
 e2etests-hostmode-boot: ginkgo kubectl build-validator create-export-logs ## Run e2e tests for hostmode boot scenario (static config first, then K8s API).
@@ -328,8 +328,14 @@ e2etests-hostmode-boot: ginkgo kubectl build-validator create-export-logs ## Run
 	@echo "=== Deploying controller to enable K8s API ==="
 	$(MAKE) deploy-controller KUSTOMIZE_LAYER=hostmode
 	@echo "=== Running passthrough tests (with K8s API available) ==="
-	$(GINKGO) -v $(GINKGO_ARGS) --timeout=3h --label-filter='passthrough' ./e2etests/suite -- --kubectl=$(KUBECTL) $(TEST_ARGS) --skip-underlay-passthrough --systemdmode --hostvalidator $(VALIDATOR_PATH) --reporterpath=${KIND_EXPORT_LOGS} 
+	$(GINKGO) -v $(GINKGO_ARGS) --label-filter="passthrough" --timeout=3h ./e2etests/suite -- --kubectl=$(KUBECTL) $(TEST_ARGS) --skip-underlay-passthrough --systemdmode --hostvalidator $(VALIDATOR_PATH) --reporterpath=${KIND_EXPORT_LOGS}
 
+.PHONY: scale-tests
+scale-tests: ginkgo kubectl create-export-logs ## Run VNI scale tests
+	$(GINKGO) -v --timeout=3h \
+		--json-report=scale-report.json --output-dir=${KIND_EXPORT_LOGS} --keep-separate-reports \
+		./e2etests/scale_suite -- \
+		--kubectl=$(KUBECTL) $(TEST_ARGS)
 
 .PHONY: clab-cluster
 clab-cluster: kind-node-image-build
@@ -597,8 +603,6 @@ catalog-build: opm ## Build a catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
-
-
 deploy-operator-with-olm: export VERSION=dev
 deploy-operator-with-olm: export CSV_VERSION=0.0.0
 deploy-operator-with-olm: export KIND_WITH_REGISTRY=true

--- a/charts/openperouter/README.md
+++ b/charts/openperouter/README.md
@@ -34,6 +34,7 @@ Kubernetes: `>= 1.19.0-0`
 | openperouter.frr.image.repository | string | `"quay.io/openperouter/openperouter"` |  |
 | openperouter.frr.image.tag | string | `""` |  |
 | openperouter.frr.reloader.resources | object | `{}` |  |
+| openperouter.frr.reloader.vtyshTimeout | string | `""` | Timeout for vtysh commands used in health checks. Increase under heavy VNI load. Defaults to 10s. |
 | openperouter.frr.resources | object | `{}` |  |
 | openperouter.hostmode | bool | `false` | If true, enables host mode deployment: deploys hostbridge DaemonSet instead of router and controller, and configures nodemarker to run in webhook-only mode |
 | openperouter.image.pullPolicy | string | `""` |  |

--- a/charts/openperouter/templates/router.yaml
+++ b/charts/openperouter/templates/router.yaml
@@ -177,7 +177,10 @@ spec:
         {{- with .Values.openperouter.logLevel }}
         - --loglevel={{ . }}
         {{- end }}
-        securityContext: 
+        {{- with .Values.openperouter.frr.reloader.vtyshTimeout }}
+        - --vtysh-timeout={{ . }}
+        {{- end }}
+        securityContext:
           seLinuxOptions:
             type: spc_t
         volumeMounts:

--- a/charts/openperouter/values.yaml
+++ b/charts/openperouter/values.yaml
@@ -63,6 +63,8 @@ openperouter:
     resources: {}
     reloader:
       resources: {}
+      # -- Timeout for vtysh commands used in health checks. Increase under heavy VNI load. Defaults to 10s.
+      vtyshTimeout: ""
   cri: "containerd" # cri to bind its socket, can be containerd or crio.
   # -- OVS database socket path. Defaults to standard OVS location if not specified.
   ovsSocketPath: ""

--- a/cmd/reloader/main.go
+++ b/cmd/reloader/main.go
@@ -44,6 +44,7 @@ type Args struct {
 	frrConfigPath string
 	logLevel      string
 	unixSocket    string
+	vtyshTimeout  time.Duration
 }
 
 func main() {
@@ -52,6 +53,8 @@ func main() {
 	flag.StringVar(&args.unixSocket, "unixsocket", "", "Unix socket path to listen on")
 	flag.StringVar(&args.logLevel, "loglevel", "info", "The log level of the process")
 	flag.StringVar(&args.frrConfigPath, "frrconfig", "/etc/frr/frr.conf", "The path the frr configuration is at")
+	flag.DurationVar(&args.vtyshTimeout, "vtysh-timeout", vtysh.DefaultTimeout,
+		"Timeout for vtysh commands used in health checks")
 	flag.Parse()
 
 	_, err := logging.New(args.logLevel)
@@ -87,10 +90,11 @@ func serveReload(args Args) error {
 		[]handlerConfig{{pattern: "/", handler: reloadHandler(args.frrConfigPath)}},
 	)
 
+	healthHandler := health(vtysh.NewCLIWithTimeout(args.vtyshTimeout))
 	healthServer := newServer(
 		[]handlerConfig{
-			{pattern: "/healthz", handler: health()},
-			{pattern: "/readyz", handler: health()},
+			{pattern: "/healthz", handler: healthHandler},
+			{pattern: "/readyz", handler: healthHandler},
 		},
 		withEndpoint(args.bindAddress),
 	)
@@ -157,14 +161,14 @@ func reloadHandler(frrConfigPath string) func(w http.ResponseWriter, req *http.R
 	}
 }
 
-func health() func(w http.ResponseWriter, req *http.Request) {
+func health(frrCli vtysh.Cli) func(w http.ResponseWriter, req *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
 		if req.Method != http.MethodGet {
 			http.Error(w, "invalid method", http.StatusMethodNotAllowed)
 			return
 		}
 
-		if err := liveness.PingFrr(vtysh.Run); err != nil {
+		if err := liveness.PingFrr(frrCli); err != nil {
 			slog.Error("health check ping frr", "error", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/config/scale/kustomization.yaml
+++ b/config/scale/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../default
+
+patches:
+- target:
+    kind: DaemonSet
+    name: controller
+  patch: |-
+    - op: remove
+      path: /spec/template/spec/containers/0/resources
+- target:
+    kind: Deployment
+    name: nodemarker
+  patch: |-
+    - op: remove
+      path: /spec/template/spec/containers/0/resources

--- a/e2etests/pkg/k8s/nad.go
+++ b/e2etests/pkg/k8s/nad.go
@@ -17,16 +17,25 @@ import (
 
 var nadClient *nadclientset.Clientset
 
-func init() {
-	var err error
-	config := ctrl.GetConfigOrDie()
+func initNADClient() error {
+	if nadClient != nil {
+		return nil
+	}
+	config, err := ctrl.GetConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load kubeconfig for NAD client: %w", err)
+	}
 	nadClient, err = nadclientset.NewForConfig(config)
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("failed to create NAD client: %w", err)
 	}
+	return nil
 }
 
 func CreateMacvlanNad(name, namespace, master string, gatewayIPs []string) (nad.NetworkAttachmentDefinition, error) {
+	if err := initNADClient(); err != nil {
+		return nad.NetworkAttachmentDefinition{}, err
+	}
 	// Build routes based on gateway IPs (IPv4 and/or IPv6)
 	var routes []string
 	for _, gwIP := range gatewayIPs {

--- a/e2etests/pkg/k8s/reporter.go
+++ b/e2etests/pkg/k8s/reporter.go
@@ -3,7 +3,7 @@
 package k8s
 
 import (
-	"log"
+	"fmt"
 	"regexp"
 	"time"
 
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func InitReporter(kubeconfig, path string, namespaces ...string) *k8sreporter.KubernetesReporter {
+func InitReporter(kubeconfig, path string, namespaces ...string) (*k8sreporter.KubernetesReporter, error) {
 	// When using custom crds, we need to add them to the scheme
 	addToScheme := func(s *runtime.Scheme) error {
 		err := v1alpha1.AddToScheme(s)
@@ -48,9 +48,9 @@ func InitReporter(kubeconfig, path string, namespaces ...string) *k8sreporter.Ku
 
 	reporter, err := k8sreporter.New(kubeconfig, addToScheme, dumpNamespace, path, crds...)
 	if err != nil {
-		log.Fatalf("Failed to initialize the reporter %s", err)
+		return nil, fmt.Errorf("failed to initialize k8s reporter: %w", err)
 	}
-	return reporter
+	return reporter, nil
 }
 
 func DumpInfo(reporter *k8sreporter.KubernetesReporter, testName string) {

--- a/e2etests/pkg/k8sclient/client.go
+++ b/e2etests/pkg/k8sclient/client.go
@@ -18,6 +18,6 @@ func New() *clientset.Clientset {
 	return res
 }
 
-func RestConfig() *restclient.Config {
-	return ctrl.GetConfigOrDie()
+func RestConfig() (*restclient.Config, error) {
+	return ctrl.GetConfig()
 }

--- a/e2etests/pkg/metrics/metrics.go
+++ b/e2etests/pkg/metrics/metrics.go
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package metrics
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/url"
+	"os/exec"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// Aggregated contains aggregate statistics for a set of pods.
+type Aggregated struct {
+	TotalCPU float64
+	TotalMem float64
+	AvgCPU   float64
+	AvgMem   float64
+}
+
+// MemoryConvergenceConfig controls the polling behavior of FetchMetricsAggregation.
+type MemoryConvergenceConfig struct {
+	PollInterval time.Duration
+	Timeout      time.Duration
+	ToleranceMB  float64
+}
+
+func DefaultMemoryConvergenceConfig() MemoryConvergenceConfig {
+	return MemoryConvergenceConfig{
+		PollInterval: 5 * time.Second,
+		Timeout:      90 * time.Second,
+		ToleranceMB:  1.0,
+	}
+}
+
+// CheckAvailability verifies that metrics-server is running by attempting
+// to collect pod metrics for the given label selector.
+func CheckAvailability(kubectl, namespace, labelSelector string) error {
+	_, err := forPod(kubectl, namespace, labelSelector)
+	return err
+}
+
+// FetchMetricsAggregation polls kubectl top until two consecutive total-memory
+// readings are within ToleranceMB of each other, ensuring at least one
+// metrics-server refresh has been observed.
+func FetchMetricsAggregation(
+	kubectl, namespace, labelSelector string,
+	cfg MemoryConvergenceConfig,
+) (Aggregated, error) {
+	fetchAggregation := func() (Aggregated, error) {
+		pods, err := forPod(kubectl, namespace, labelSelector)
+		if err != nil {
+			return Aggregated{}, err
+		}
+		return summarize(pods), nil
+	}
+
+	prev, err := fetchAggregation()
+	if err != nil {
+		return Aggregated{}, fmt.Errorf("initial metrics poll failed: %w", err)
+	}
+
+	ticker := time.NewTicker(cfg.PollInterval)
+	defer ticker.Stop()
+	deadline := time.After(cfg.Timeout)
+
+	for {
+		select {
+		case <-deadline:
+			return prev, fmt.Errorf("metrics did not stabilize within %s (last two readings: %.2f MB, %.2f MB)",
+				cfg.Timeout, prev.TotalMem, prev.TotalMem)
+		case <-ticker.C:
+			curr, err := fetchAggregation()
+			if err != nil {
+				return Aggregated{}, fmt.Errorf("metrics poll failed: %w", err)
+			}
+			if math.Abs(curr.TotalMem-prev.TotalMem) <= cfg.ToleranceMB {
+				return curr, nil
+			}
+			prev = curr
+		}
+	}
+}
+
+func summarize(podsMetrics []podMetrics) Aggregated {
+	if len(podsMetrics) == 0 {
+		return Aggregated{}
+	}
+
+	var result Aggregated
+	for _, p := range podsMetrics {
+		result.TotalCPU += p.cpuMillicores
+		result.TotalMem += p.memoryMB
+	}
+
+	result.AvgCPU = result.TotalCPU / float64(len(podsMetrics))
+	result.AvgMem = result.TotalMem / float64(len(podsMetrics))
+	return result
+}
+
+type podMetrics struct {
+	podName       string
+	namespace     string
+	cpuMillicores float64
+	memoryMB      float64
+	timestamp     time.Time
+}
+
+type podMetricsList struct {
+	Items []podMetricsItem `json:"items"`
+}
+
+type podMetricsItem struct {
+	Metadata   podMetricsMetadata   `json:"metadata"`
+	Containers []containerMetrics   `json:"containers"`
+}
+
+type podMetricsMetadata struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+type containerMetrics struct {
+	Usage map[string]string `json:"usage"`
+}
+
+func forPod(kubectl, namespace, labelSelector string) ([]podMetrics, error) {
+	path := fmt.Sprintf("/apis/metrics.k8s.io/v1beta1/namespaces/%s/pods?labelSelector=%s",
+		namespace, url.QueryEscape(labelSelector))
+	out, err := exec.Command(kubectl, "get", "--raw", path).CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("metrics API request failed (is metrics-server running?): %s: %w", string(out), err)
+	}
+
+	return parseMetricsAPIResponse(out)
+}
+
+func parseMetricsAPIResponse(data []byte) ([]podMetrics, error) {
+	var list podMetricsList
+	if err := json.Unmarshal(data, &list); err != nil {
+		return nil, fmt.Errorf("failed to parse metrics API response: %w", err)
+	}
+
+	result := make([]podMetrics, 0, len(list.Items))
+	for _, item := range list.Items {
+		var totalCPUMilli int64
+		var totalMemBytes int64
+
+		for _, c := range item.Containers {
+			if cpuStr, ok := c.Usage["cpu"]; ok {
+				q, err := resource.ParseQuantity(cpuStr)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse CPU quantity %q for pod %s: %w", cpuStr, item.Metadata.Name, err)
+				}
+				totalCPUMilli += q.MilliValue()
+			}
+			if memStr, ok := c.Usage["memory"]; ok {
+				q, err := resource.ParseQuantity(memStr)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse memory quantity %q for pod %s: %w", memStr, item.Metadata.Name, err)
+				}
+				totalMemBytes += q.Value()
+			}
+		}
+
+		result = append(result, podMetrics{
+			podName:       item.Metadata.Name,
+			namespace:     item.Metadata.Namespace,
+			cpuMillicores: float64(totalCPUMilli),
+			memoryMB:      float64(totalMemBytes) / (1024 * 1024),
+			timestamp:     time.Now(),
+		})
+	}
+
+	return result, nil
+}

--- a/e2etests/pkg/metrics/metrics_test.go
+++ b/e2etests/pkg/metrics/metrics_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package metrics
+
+import (
+	"math"
+	"testing"
+)
+
+func TestParseMetricsAPIResponse(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantPods  int
+		wantCPU   []float64
+		wantMemMB []float64
+		wantErr   bool
+	}{
+		{
+			name: "single pod single container",
+			input: `{
+				"items": [{
+					"metadata": {"name": "router-abc", "namespace": "openperouter-system"},
+					"containers": [{
+						"usage": {"cpu": "50m", "memory": "131072Ki"}
+					}]
+				}]
+			}`,
+			wantPods:  1,
+			wantCPU:   []float64{50},
+			wantMemMB: []float64{128},
+		},
+		{
+			name: "single pod multiple containers",
+			input: `{
+				"items": [{
+					"metadata": {"name": "router-abc", "namespace": "openperouter-system"},
+					"containers": [
+						{"usage": {"cpu": "30m", "memory": "64Mi"}},
+						{"usage": {"cpu": "20m", "memory": "64Mi"}}
+					]
+				}]
+			}`,
+			wantPods:  1,
+			wantCPU:   []float64{50},
+			wantMemMB: []float64{128},
+		},
+		{
+			name: "multiple pods",
+			input: `{
+				"items": [
+					{
+						"metadata": {"name": "router-abc", "namespace": "ns"},
+						"containers": [{"usage": {"cpu": "100m", "memory": "256Mi"}}]
+					},
+					{
+						"metadata": {"name": "router-def", "namespace": "ns"},
+						"containers": [{"usage": {"cpu": "200m", "memory": "512Mi"}}]
+					}
+				]
+			}`,
+			wantPods:  2,
+			wantCPU:   []float64{100, 200},
+			wantMemMB: []float64{256, 512},
+		},
+		{
+			name: "zero usage",
+			input: `{
+				"items": [{
+					"metadata": {"name": "idle-pod", "namespace": "ns"},
+					"containers": [{"usage": {"cpu": "0", "memory": "0"}}]
+				}]
+			}`,
+			wantPods:  1,
+			wantCPU:   []float64{0},
+			wantMemMB: []float64{0},
+		},
+		{
+			name: "empty items",
+			input: `{"items": []}`,
+			wantPods: 0,
+		},
+		{
+			name:    "invalid json",
+			input:   `not json`,
+			wantErr: true,
+		},
+		{
+			name: "invalid cpu quantity",
+			input: `{
+				"items": [{
+					"metadata": {"name": "pod", "namespace": "ns"},
+					"containers": [{"usage": {"cpu": "bogus-value", "memory": "128Mi"}}]
+				}]
+			}`,
+			wantErr: true,
+		},
+		{
+			name: "nanocores from metrics server",
+			input: `{
+				"items": [{
+					"metadata": {"name": "router-abc", "namespace": "ns"},
+					"containers": [{"usage": {"cpu": "3456789n", "memory": "134217728"}}]
+				}]
+			}`,
+			wantPods:  1,
+			wantCPU:   []float64{3},
+			wantMemMB: []float64{128},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseMetricsAPIResponse([]byte(tt.input))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseMetricsAPIResponse() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if len(got) != tt.wantPods {
+				t.Fatalf("got %d pods, want %d", len(got), tt.wantPods)
+			}
+			for i, pod := range got {
+				if math.Abs(pod.cpuMillicores-tt.wantCPU[i]) > 1 {
+					t.Errorf("pod[%d] cpuMillicores = %v, want %v", i, pod.cpuMillicores, tt.wantCPU[i])
+				}
+				if math.Abs(pod.memoryMB-tt.wantMemMB[i]) > 0.01 {
+					t.Errorf("pod[%d] memoryMB = %v, want %v", i, pod.memoryMB, tt.wantMemMB[i])
+				}
+			}
+		})
+	}
+}

--- a/e2etests/scale_suite/suite_test.go
+++ b/e2etests/scale_suite/suite_test.go
@@ -1,22 +1,19 @@
 // SPDX-License-Identifier:Apache-2.0
 
-package e2e
+package scale_e2e
 
 import (
 	"flag"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openperouter/openperouter/e2etests/pkg/config"
 	"github.com/openperouter/openperouter/e2etests/pkg/executor"
-	"github.com/openperouter/openperouter/e2etests/pkg/frrk8s"
-	"github.com/openperouter/openperouter/e2etests/pkg/k8s"
 	"github.com/openperouter/openperouter/e2etests/pkg/k8sclient"
 	"github.com/openperouter/openperouter/e2etests/pkg/openperouter"
-	"github.com/openperouter/openperouter/e2etests/tests"
+	"github.com/openperouter/openperouter/e2etests/scale_tests"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
@@ -25,18 +22,12 @@ var (
 	updater *config.Updater
 )
 
-// handleFlags sets up all flags and parses the command line.
 func handleFlags() {
 	flag.StringVar(&executor.Kubectl, "kubectl", "kubectl", "the path for the kubectl binary")
-	flag.StringVar(&tests.ValidatorPath, "hostvalidator", "hostvalidator", "the path for the hostvalidator binary")
-	flag.StringVar(&tests.ReportPath, "reporterpath", "/tmp", "the path for the reporter")
-	flag.BoolVar(&tests.HostMode, "systemdmode", false, "tells if openperouter is running on the host")
-	flag.BoolVar(&tests.SkipUnderlayPassthrough, "skip-underlay-passthrough", false, "skip creating underlay in passthrough tests")
 	flag.Parse()
 }
 
 func TestMain(m *testing.M) {
-	// Register test flags, then parse flags.
 	handleFlags()
 	if testing.Short() {
 		return
@@ -45,13 +36,13 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestE2E(t *testing.T) {
+func TestScaleE2E(t *testing.T) {
 	if testing.Short() {
 		return
 	}
 
 	RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "E2E Suite")
+	ginkgo.RunSpecs(t, "E2E Scale Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -60,14 +51,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred(), "failed to load kubeconfig (KUBECONFIG=%s)", os.Getenv("KUBECONFIG"))
 	updater, err = config.UpdaterForCRs(clientconfig, openperouter.Namespace)
 	Expect(err).NotTo(HaveOccurred())
-	tests.Updater = updater
-	kubeconfig := os.Getenv("KUBECONFIG")
-	if kubeconfig == "" {
-		kubeconfig = filepath.Join(os.Getenv("HOME"), ".kube", "config")
-	}
-	reporter, err := k8s.InitReporter(kubeconfig, tests.ReportPath, openperouter.Namespace, frrk8s.Namespace)
-	Expect(err).NotTo(HaveOccurred(), "failed to initialize k8s reporter (kubeconfig=%s)", kubeconfig)
-	tests.K8sReporter = reporter
+	scale_tests.Updater = updater
 })
 
 var _ = ginkgo.AfterSuite(func() {

--- a/e2etests/scale_tests/common.go
+++ b/e2etests/scale_tests/common.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package scale_tests
+
+import (
+	"github.com/openperouter/openperouter/e2etests/pkg/config"
+)
+
+var Updater *config.Updater

--- a/e2etests/scale_tests/scale.go
+++ b/e2etests/scale_tests/scale.go
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package scale_tests
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gmeasure"
+	"github.com/openperouter/openperouter/api/v1alpha1"
+	"github.com/openperouter/openperouter/e2etests/pkg/config"
+	"github.com/openperouter/openperouter/e2etests/pkg/executor"
+	"github.com/openperouter/openperouter/e2etests/pkg/infra"
+	"github.com/openperouter/openperouter/e2etests/pkg/metrics"
+	"github.com/openperouter/openperouter/e2etests/pkg/openperouter"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type scenarioUnderTest int
+
+const (
+	l2vni = iota
+	l3vni
+	l2l3vni
+)
+
+type scaleTestCase struct {
+	hostMaster string
+	scenario   scenarioUnderTest
+	vniCount   int
+}
+
+func (tc scaleTestCase) String() string {
+	if tc.scenario == l2l3vni {
+		return fmt.Sprintf("%d pairs", tc.vniCount)
+	}
+	return fmt.Sprintf("%d VNIs", tc.vniCount)
+}
+
+const (
+	routerLabelSelector     = "app=router"
+	controllerLabelSelector = "app=controller"
+)
+
+var _ = Describe("VNI Scale Tests", Ordered, func() {
+	var experiment *gmeasure.Experiment
+
+	BeforeAll(func() {
+		experiment = gmeasure.NewExperiment("VNI Scale")
+		AddReportEntry(experiment.Name, experiment)
+
+		By("Verifying metrics-server is available")
+		err := metrics.CheckAvailability(executor.Kubectl, openperouter.Namespace, routerLabelSelector)
+		Expect(err).NotTo(HaveOccurred(), "metrics-server must be running for scale tests")
+
+		By("Cleaning up any existing VNI resources")
+		Expect(Updater.CleanButUnderlay()).To(Succeed())
+
+		By("Ensuring underlay configuration exists")
+		err = Updater.Update(config.Resources{
+			Underlays: []v1alpha1.Underlay{infra.Underlay},
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		By("Cleaning up VNIs")
+		Expect(Updater.CleanButUnderlay()).To(Succeed())
+
+		By("Waiting for VNI resources to be fully removed")
+		waitForVNIsGone(Updater.Client())
+	})
+
+	AfterAll(func() {
+		By("Cleaning up all resources")
+		err := Updater.CleanAll()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Describe("L2VNI only - Linux Bridge", func() {
+		DescribeTable("VNI Scale Measurements",
+			func(tc scaleTestCase) {
+				runScaleTest(tc, experiment)
+			},
+			EntryDescription("%v"),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.LinuxBridge, scenario: l2vni, vniCount: 1}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.LinuxBridge, scenario: l2vni, vniCount: 50}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.LinuxBridge, scenario: l2vni, vniCount: 150}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.LinuxBridge, scenario: l2vni, vniCount: 200}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.LinuxBridge, scenario: l2vni, vniCount: 250}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.LinuxBridge, scenario: l2vni, vniCount: 300}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.LinuxBridge, scenario: l2vni, vniCount: 350}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.LinuxBridge, scenario: l2vni, vniCount: 400}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.LinuxBridge, scenario: l2vni, vniCount: 450}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.LinuxBridge, scenario: l2vni, vniCount: 500}),
+		)
+	})
+
+	Describe("L2VNI only - OVS Bridge", func() {
+		DescribeTable("VNI Scale Measurements",
+			func(tc scaleTestCase) {
+				runScaleTest(tc, experiment)
+			},
+			EntryDescription("%v"),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.OVSBridge, scenario: l2vni, vniCount: 1}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.OVSBridge, scenario: l2vni, vniCount: 50}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.OVSBridge, scenario: l2vni, vniCount: 150}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.OVSBridge, scenario: l2vni, vniCount: 200}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.OVSBridge, scenario: l2vni, vniCount: 250}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.OVSBridge, scenario: l2vni, vniCount: 300}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.OVSBridge, scenario: l2vni, vniCount: 350}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.OVSBridge, scenario: l2vni, vniCount: 400}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.OVSBridge, scenario: l2vni, vniCount: 450}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.OVSBridge, scenario: l2vni, vniCount: 500}),
+		)
+	})
+
+	Describe("L3VNI+L2VNI - Linux Bridge", func() {
+		DescribeTable("VNI Scale Measurements",
+			func(tc scaleTestCase) {
+				runScaleTest(tc, experiment)
+			},
+			EntryDescription("%v"),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.LinuxBridge, scenario: l2l3vni, vniCount: 1}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.LinuxBridge, scenario: l2l3vni, vniCount: 50}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.LinuxBridge, scenario: l2l3vni, vniCount: 150}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.LinuxBridge, scenario: l2l3vni, vniCount: 200}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.LinuxBridge, scenario: l2l3vni, vniCount: 250}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.LinuxBridge, scenario: l2l3vni, vniCount: 300}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.LinuxBridge, scenario: l2l3vni, vniCount: 350}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.LinuxBridge, scenario: l2l3vni, vniCount: 400}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.LinuxBridge, scenario: l2l3vni, vniCount: 450}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.LinuxBridge, scenario: l2l3vni, vniCount: 500}),
+		)
+	})
+
+	Describe("L3VNI+L2VNI - OVS Bridge", func() {
+		DescribeTable("VNI Scale Measurements",
+			func(tc scaleTestCase) {
+				runScaleTest(tc, experiment)
+			},
+			EntryDescription("%v"),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.OVSBridge, scenario: l2l3vni, vniCount: 1}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.OVSBridge, scenario: l2l3vni, vniCount: 50}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.OVSBridge, scenario: l2l3vni, vniCount: 150}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.OVSBridge, scenario: l2l3vni, vniCount: 200}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.OVSBridge, scenario: l2l3vni, vniCount: 250}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.OVSBridge, scenario: l2l3vni, vniCount: 300}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.OVSBridge, scenario: l2l3vni, vniCount: 350}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.OVSBridge, scenario: l2l3vni, vniCount: 400}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.OVSBridge, scenario: l2l3vni, vniCount: 450}),
+			Entry(nil, scaleTestCase{hostMaster: v1alpha1.OVSBridge, scenario: l2l3vni, vniCount: 500}),
+		)
+	})
+})
+
+func runScaleTest(tc scaleTestCase, experiment *gmeasure.Experiment) {
+	testLabel := CurrentSpecReport().FullText()
+
+	By("Creating " + testLabel)
+	resources := buildResources(tc)
+
+	experiment.MeasureDuration(testLabel+" reconcile", func() {
+		err := Updater.Update(resources)
+		Expect(err).NotTo(HaveOccurred())
+	}, gmeasure.Annotation(fmt.Sprintf("%d VNIs", tc.vniCount)))
+
+	By("Collecting stable memory metrics after reconcile")
+	routerMem := collectMetrics(routerLabelSelector)
+	ctrlMem := collectMetrics(controllerLabelSelector)
+
+	experiment.RecordValue(testLabel+" router memory",
+		routerMem.TotalMem,
+		gmeasure.Units("MB"), gmeasure.Precision(2),
+		gmeasure.Annotation(fmt.Sprintf("%d VNIs", tc.vniCount)),
+	)
+	experiment.RecordValue(testLabel+" controller memory",
+		ctrlMem.TotalMem,
+		gmeasure.Units("MB"), gmeasure.Precision(2),
+		gmeasure.Annotation(fmt.Sprintf("%d VNIs", tc.vniCount)),
+	)
+
+}
+
+func collectMetrics(labelSelector string) metrics.Aggregated {
+	result, err := metrics.FetchMetricsAggregation(
+		executor.Kubectl,
+		openperouter.Namespace,
+		labelSelector,
+		metrics.DefaultMemoryConvergenceConfig(),
+	)
+	Expect(err).NotTo(HaveOccurred(), "metrics did not stabilize for %s", labelSelector)
+	return result
+}
+
+func buildResources(tc scaleTestCase) config.Resources {
+	switch tc.scenario {
+	case l2l3vni:
+		l3vnis, l2vnis := generateL3VNIsWithL2VNIs(tc.vniCount, openperouter.Namespace, tc.hostMaster)
+		return config.Resources{
+			L3VNIs: l3vnis,
+			L2VNIs: l2vnis,
+		}
+	default:
+		return config.Resources{
+			L2VNIs: generateL2VNIs(tc.vniCount, openperouter.Namespace, tc.hostMaster),
+		}
+	}
+}
+
+func waitForVNIsGone(cli crclient.Client) {
+	Eventually(func(g Gomega) int {
+		l2list := &v1alpha1.L2VNIList{}
+		g.Expect(cli.List(context.Background(), l2list, crclient.InNamespace(openperouter.Namespace))).To(Succeed())
+		l3list := &v1alpha1.L3VNIList{}
+		g.Expect(cli.List(context.Background(), l3list, crclient.InNamespace(openperouter.Namespace))).To(Succeed())
+		return len(l2list.Items) + len(l3list.Items)
+	}, 3*time.Minute, time.Second).Should(BeZero())
+}
+
+func generateL2VNIs(count int, namespace, bridgeType string) []v1alpha1.L2VNI {
+	const baseVNI = 1000
+
+	vnis := make([]v1alpha1.L2VNI, count)
+	for i := 0; i < count; i++ {
+		vrfName := fmt.Sprintf("vrf%03d", i+1)
+		vnis[i] = v1alpha1.L2VNI{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("l2vni-%03d", i+1),
+				Namespace: namespace,
+			},
+			Spec: v1alpha1.L2VNISpec{
+				VRF:        ptr.To(vrfName),
+				VNI:        uint32(baseVNI + i + 1),
+				HostMaster: newHostMaster(bridgeType),
+			},
+		}
+	}
+	return vnis
+}
+
+func generateL3VNIsWithL2VNIs(count int, namespace, bridgeType string) ([]v1alpha1.L3VNI, []v1alpha1.L2VNI) {
+	const baseL3VNI = 2000
+	const baseL2VNI = 3000
+
+	l3vnis := make([]v1alpha1.L3VNI, count)
+	l2vnis := make([]v1alpha1.L2VNI, count)
+
+	for i := 0; i < count; i++ {
+		vrfName := fmt.Sprintf("vrf%03d", i+1)
+
+		l3vnis[i] = v1alpha1.L3VNI{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("l3vni-%03d", i+1),
+				Namespace: namespace,
+			},
+			Spec: v1alpha1.L3VNISpec{
+				VRF: vrfName,
+				VNI: uint32(baseL3VNI + i + 1),
+			},
+		}
+
+		l2vnis[i] = v1alpha1.L2VNI{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("l2vni-%03d", i+1),
+				Namespace: namespace,
+			},
+			Spec: v1alpha1.L2VNISpec{
+				VRF:        ptr.To(vrfName),
+				VNI:        uint32(baseL2VNI + i + 1),
+				HostMaster: newHostMaster(bridgeType),
+			},
+		}
+	}
+	return l3vnis, l2vnis
+}
+
+func newHostMaster(bridgeType string) *v1alpha1.HostMaster {
+	switch bridgeType {
+	case v1alpha1.LinuxBridge:
+		return &v1alpha1.HostMaster{
+			Type:        v1alpha1.LinuxBridge,
+			LinuxBridge: &v1alpha1.LinuxBridgeConfig{AutoCreate: true},
+		}
+	case v1alpha1.OVSBridge:
+		return &v1alpha1.HostMaster{
+			Type:      v1alpha1.OVSBridge,
+			OVSBridge: &v1alpha1.OVSBridgeConfig{AutoCreate: true},
+		}
+	default:
+		return nil
+	}
+}

--- a/hack/parse-scale-report.py
+++ b/hack/parse-scale-report.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Parse scale test JSON report and extract graph-ready data points.
+
+Reads the Ginkgo JSON report produced by `make scale-tests` and prints
+reconcile time and memory data grouped by scenario, suitable for plotting:
+  - X axis: number of VNIs
+  - Y axis: reconcile time (seconds) or memory (MB)
+
+Usage:
+    python3 hack/parse-scale-report.py [path/to/scale-report.json]
+
+Default path: /tmp/kind_logs/e2etests_suite_scale-report.json
+"""
+
+import argparse
+import json
+import re
+import sys
+
+DEFAULT_REPORT = "/tmp/kind_logs/e2etests_suite_scale-report.json"
+
+RECONCILE_RE = re.compile(
+    r"^VNI Scale Tests (?P<scenario>.+?) VNI Scale Measurements (?P<vnis>\d+) (?:VNIs|pairs) reconcile$"
+)
+MEMORY_RE = re.compile(
+    r"^VNI Scale Tests (?P<scenario>.+?) VNI Scale Measurements (?P<vnis>\d+) (?:VNIs|pairs) (?P<component>router|controller) memory$"
+)
+
+
+def load_measurements(path: str) -> list[dict]:
+    with open(path) as f:
+        suites = json.load(f)
+
+    measurements = []
+    for suite in suites:
+        for spec in suite.get("SpecReports", []):
+            for entry in spec.get("ReportEntries", []):
+                value = entry.get("Value", {})
+                as_json = value.get("AsJSON")
+                if not as_json:
+                    continue
+                experiment = json.loads(as_json)
+                measurements.extend(experiment.get("Measurements", []))
+    return measurements
+
+
+def extract_data(measurements: list[dict]):
+    reconcile: dict[str, list[tuple[int, float]]] = {}
+    memory: dict[str, list[tuple[int, float]]] = {}
+
+    for m in measurements:
+        name = m["Name"]
+
+        match = RECONCILE_RE.match(name)
+        if match:
+            scenario = match.group("scenario")
+            vnis = int(match.group("vnis"))
+            duration_ns = m["Durations"][0]
+            duration_s = duration_ns / 1e9
+            reconcile.setdefault(scenario, []).append((vnis, duration_s))
+            continue
+
+        match = MEMORY_RE.match(name)
+        if match:
+            scenario = match.group("scenario")
+            component = match.group("component")
+            vnis = int(match.group("vnis"))
+            value_mb = m["Values"][0]
+            key = f"{scenario} - {component}"
+            memory.setdefault(key, []).append((vnis, value_mb))
+
+    for points in reconcile.values():
+        points.sort()
+    for points in memory.values():
+        points.sort()
+
+    return reconcile, memory
+
+
+def print_table(title: str, headers: tuple[str, str], rows: list[tuple[int, float]]):
+    print(f"\n{title}")
+    print("-" * len(title))
+    col1, col2 = headers
+    print(f"  {col1:>8s}  {col2:>12s}")
+    for vnis, value in rows:
+        print(f"  {vnis:>8d}  {value:>12.2f}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Parse scale test JSON report and extract graph-ready data points.\n\n"
+        "Reads the Ginkgo JSON report produced by `make scale-tests` and prints\n"
+        "reconcile time and memory tables grouped by scenario, plus CSV output\n"
+        "suitable for plotting:\n"
+        "  - VNIs (X) vs reconcile time in seconds (Y)\n"
+        "  - VNIs (X) vs memory in MB (Y)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "report",
+        nargs="?",
+        default=DEFAULT_REPORT,
+        help=f"path to the scale-report.json file (default: {DEFAULT_REPORT})",
+    )
+    args = parser.parse_args()
+    path = args.report
+
+    try:
+        measurements = load_measurements(path)
+    except FileNotFoundError:
+        print(f"error: report not found: {path}", file=sys.stderr)
+        sys.exit(1)
+
+    if not measurements:
+        print(f"error: no measurements found in {path}", file=sys.stderr)
+        sys.exit(1)
+
+    reconcile, memory = extract_data(measurements)
+
+    print("=" * 60)
+    print("RECONCILE TIME")
+    print("=" * 60)
+    for scenario, rows in sorted(reconcile.items()):
+        print_table(scenario, ("VNIs", "Time (s)"), rows)
+
+    print()
+    print("=" * 60)
+    print("MEMORY USAGE")
+    print("=" * 60)
+    for key, rows in sorted(memory.items()):
+        print_table(key, ("VNIs", "Memory (MB)"), rows)
+
+    print()
+    print("=" * 60)
+    print("CSV (for plotting)")
+    print("=" * 60)
+
+    print("\n# Reconcile time")
+    scenarios = sorted(reconcile.keys())
+    print("VNIs," + ",".join(f"{s} (s)" for s in scenarios))
+    all_vnis = sorted({v for rows in reconcile.values() for v, _ in rows})
+    for vni in all_vnis:
+        vals = []
+        for s in scenarios:
+            lookup = {v: t for v, t in reconcile[s]}
+            vals.append(f"{lookup[vni]:.2f}" if vni in lookup else "")
+        print(f"{vni},{','.join(vals)}")
+
+    print("\n# Memory")
+    mem_keys = sorted(memory.keys())
+    print("VNIs," + ",".join(f"{k} (MB)" for k in mem_keys))
+    all_vnis = sorted({v for rows in memory.values() for v, _ in rows})
+    for vni in all_vnis:
+        vals = []
+        for k in mem_keys:
+            lookup = {v: m for v, m in memory[k]}
+            vals.append(f"{lookup[vni]:.2f}" if vni in lookup else "")
+        print(f"{vni},{','.join(vals)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/internal/frr/vtysh/vtysh.go
+++ b/internal/frr/vtysh/vtysh.go
@@ -3,14 +3,24 @@
 package vtysh
 
 import (
+	"context"
 	"os/exec"
+	"time"
 )
+
+const DefaultTimeout = 10 * time.Second
 
 type Cli func(args string) (string, error)
 
-func Run(args string) (string, error) {
-	out, err := exec.Command("/usr/bin/vtysh", "-c", args).CombinedOutput()
-	return string(out), err
+func NewCLIWithTimeout(timeout time.Duration) Cli {
+	return func(args string) (string, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		out, err := exec.CommandContext(ctx, "/usr/bin/vtysh", "-c", args).CombinedOutput()
+		return string(out), err
+	}
 }
 
-var _ Cli = Run
+func NewCLI() Cli {
+	return NewCLIWithTimeout(DefaultTimeout)
+}

--- a/operator/bindata/deployment/openperouter/README.md
+++ b/operator/bindata/deployment/openperouter/README.md
@@ -34,6 +34,7 @@ Kubernetes: `>= 1.19.0-0`
 | openperouter.frr.image.repository | string | `"quay.io/openperouter/openperouter"` |  |
 | openperouter.frr.image.tag | string | `""` |  |
 | openperouter.frr.reloader.resources | object | `{}` |  |
+| openperouter.frr.reloader.vtyshTimeout | string | `""` | Timeout for vtysh commands used in health checks. Increase under heavy VNI load. Defaults to 10s. |
 | openperouter.frr.resources | object | `{}` |  |
 | openperouter.hostmode | bool | `false` | If true, enables host mode deployment: deploys hostbridge DaemonSet instead of router and controller, and configures nodemarker to run in webhook-only mode |
 | openperouter.image.pullPolicy | string | `""` |  |

--- a/operator/bindata/deployment/openperouter/templates/router.yaml
+++ b/operator/bindata/deployment/openperouter/templates/router.yaml
@@ -177,7 +177,10 @@ spec:
         {{- with .Values.openperouter.logLevel }}
         - --loglevel={{ . }}
         {{- end }}
-        securityContext: 
+        {{- with .Values.openperouter.frr.reloader.vtyshTimeout }}
+        - --vtysh-timeout={{ . }}
+        {{- end }}
+        securityContext:
           seLinuxOptions:
             type: spc_t
         volumeMounts:

--- a/operator/bindata/deployment/openperouter/values.yaml
+++ b/operator/bindata/deployment/openperouter/values.yaml
@@ -63,6 +63,8 @@ openperouter:
     resources: {}
     reloader:
       resources: {}
+      # -- Timeout for vtysh commands used in health checks. Increase under heavy VNI load. Defaults to 10s.
+      vtyshTimeout: ""
   cri: "containerd" # cri to bind its socket, can be containerd or crio.
   # -- OVS database socket path. Defaults to standard OVS location if not specified.
   ovsSocketPath: ""

--- a/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2026-04-22T08:50:06Z"
+    createdAt: "2026-04-28T08:01:56Z"
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: openperouter-operator.v0.0.0


### PR DESCRIPTION
Add scale tests to measure resource consumption (memory) and reconcile time
of router and controller pods as the number of L2VNI and L3VNI resources
increases. This helps identify potential scaling bottlenecks and establish
baseline performance characteristics.

## Changes

### Scale test suite
- Dedicated `e2etests/scale_suite` with its own `scale_tests` package, decoupled from the main e2e suite
- Table-driven tests for 1, 50, 150, 200, 250, 300, 350, 400, 450, and 500 VNIs
- Four test groups: L2VNI-only and L2+L3VNI, each with linux-bridge and ovs-bridge host masters
- Uses Ginkgo's `gmeasure` experiment API to record reconcile duration and memory per scenario
- Metrics collection polls `kubectl top` until memory readings stabilize (convergence-based, not snapshot)
- Metrics-server availability is checked in `BeforeAll`; suite fails fast if unavailable

### Metrics package (`e2etests/pkg/metrics`)
- Parses `kubectl top pods` output into structured pod metrics
- `FetchMetricsAggregation` polls until two consecutive readings are within tolerance
- `CheckAvailability` verifies metrics-server is reachable
- Unit tests for `parseCPU` and `parseMemory`

### CI and Makefile
- `make scale-tests` runs the dedicated scale suite
- `make deploy-scale` deploys with scale-specific kustomize overlay (no resource limits) and installs metrics-server
- `make deploy-metrics-server` available as standalone target
- `make parse-scale-report` parses the JSON report into text tables and CSV
- CI workflow job runs on `run-scale-tests` label; uploads JSON report as artifact

### Configurable vtysh timeout
- `vtysh.NewCLIWithTimeout` / `vtysh.NewCLI` replace the old hardcoded timeout
- Reloader accepts `--vtysh-timeout` flag, wired through helm and operator

## Possible follow-ups
- Scale tests with pre-existing (shared) OVS bridge
- L3VNI-only scale tests (without associated L2VNIs)
- Graph/plot generation via Ginkgo Reporter on regression

**Is this a BUG FIX or a FEATURE ?**:

/kind feature

**What this PR does / why we need it**:
Add scale tests to measure memory consumption and reconcile time of
router and controller pods as VNI count increases, plus make the vtysh
command timeout configurable.

**Release note**:
```release-note
Have configurable vtysh timeout, defined from the helm / operator config.
```

---

Assisted-by: Claude Opus 4.5 <noreply@anthropic.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>