### PR TITLE
docs, multi-cluster: fix broken link

### DIFF
--- a/website/content/docs/examples/evpnexamples/kubevirt-multi-cluster.md
+++ b/website/content/docs/examples/evpnexamples/kubevirt-multi-cluster.md
@@ -42,7 +42,7 @@ machines are connected to this bridge via Multus secondary interfaces of type
 > ```
 
 The full example can be found in the
-[project repository](https://github.com/openperouter/openperouter/examples/evpn/multi-cluster)
+[project repository](https://github.com/openperouter/openperouter/tree/main/examples/evpn/multi-cluster)
 and can be deployed by running:
 
 ```bash


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing

/kind documentation

> /kind regression
> /kind example

**What this PR does / why we need it**:
This commit fixes a broken link in the multi-cluster example.

Kudos to @jpeimer for spotting it.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
