### PR TITLE
Improve informer caching strategy

### DIFF
--- a/cmd/hostcontroller/main.go
+++ b/cmd/hostcontroller/main.go
@@ -168,7 +168,8 @@ func main() {
 		Cache: cache.Options{
 			ByObject: map[client.Object]cache.ByObject{
 				&corev1.Node{}: {
-					Field: fields.Set{"metadata.name": k8sModeParams.nodeName}.AsSelector(),
+					Field:     fields.Set{"metadata.name": k8sModeParams.nodeName}.AsSelector(),
+					Transform: cache.TransformStripManagedFields(),
 				},
 				&corev1.Pod{}: {
 					Label: labels.SelectorFromSet(labels.Set{"app": "router"}),


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup

/kind feature

> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
This PR improves the memory usage of the controller pod, by only caching the required data. 
What we are caching now (after this change):
- the router pod co-located with the controller pod
- we strip the cached node's data of its `ManagedField` attribute
- we strip the pod of all unnecessary data

**Special notes for your reviewer**:
Fixes: #179 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Be more memory efficient, by only caching the required data for the controller operation
```
