### PR TITLE
Claude: enforce helpers should go to the bottom

### DIFF
--- a/Claude.md
+++ b/Claude.md
@@ -84,7 +84,10 @@ func Process(data string) error {
 **File Structure:**
 - Name the primary file after the package (e.g., `network.go` in package `network`)
 - Place public APIs and important types at the top of files
-- Place internal helpers and implementation details at the bottom
+- **Place helper functions at the bottom of files, after where they are used**
+  - This applies to ALL files (production code and tests)
+  - Main/exported functions first, internal helpers last
+  - In test files: test functions first, helper functions at the bottom
 - Utility functions should be in separate files within the package
 
 ### Error Handling
@@ -134,7 +137,7 @@ When reviewing or writing code, verify:
 - [ ] Errors wrapped with context using `%w`
 - [ ] No environment variable reads outside main()
 - [ ] Package-named entry point file exists
-- [ ] Public APIs at top of file, helpers at bottom
+- [ ] Helper functions placed at bottom of file (after where they are used)
 - [ ] Switch used instead of long if-else chains
 - [ ] No named returns unless absolutely necessary
 - [ ] Goroutines in controllers are carefully managed


### PR DESCRIPTION


<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

Generated by claude after ignoring the previous suggestion a couple of times. Hopefully will improve the behavior.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
