### PR TITLE
Ipv6 enable untracked na

### DIFF
--- a/internal/controller/routerconfiguration/host_config.go
+++ b/internal/controller/routerconfiguration/host_config.go
@@ -58,6 +58,8 @@ func configureInterfaces(ctx context.Context, config interfacesConfiguration) er
 		sysctl.IPv6Forwarding(),
 		sysctl.ArpAcceptAll(),
 		sysctl.ArpAcceptDefault(),
+		sysctl.AcceptUntrackedNADefault(),
+		sysctl.AcceptUntrackedNAAll(),
 	); err != nil {
 		return fmt.Errorf("failed to ensure sysctls: %w", err)
 	}

--- a/internal/sysctl/sysctl.go
+++ b/internal/sysctl/sysctl.go
@@ -83,3 +83,28 @@ func ArpAcceptDefault() Sysctl {
 		Description: "arp_accept on new interfaces",
 	}
 }
+
+// AcceptUntrackedNAAll returns the sysctl definition for enabling accept_untracked_na.
+// This is the IPv6 equivalent of arp_accept - it allows the kernel to create neighbor entries
+// from received unsolicited Neighbor Advertisement packets, which is critical for fast EVPN
+// MAC/IP route advertisement during VM migrations with IPv6.
+// Note: This sysctl is only available on kernels >= 5.18.
+func AcceptUntrackedNAAll() Sysctl {
+	return Sysctl{
+		Path:        "net/ipv6/conf/all/accept_untracked_na",
+		Description: "accept_untracked_na on all interfaces",
+	}
+}
+
+// AcceptUntrackedNADefault returns the sysctl definition for enabling accept_untracked_na on
+// newly created interfaces. This ensures that any new interface will inherit the setting.
+// This is the IPv6 equivalent of arp_accept - it allows the kernel to create neighbor entries
+// from received unsolicited Neighbor Advertisement packets, which is critical for fast EVPN
+// MAC/IP route advertisement during VM migrations with IPv6.
+// Note: This sysctl is only available on kernels >= 5.18.
+func AcceptUntrackedNADefault() Sysctl {
+	return Sysctl{
+		Path:        "net/ipv6/conf/default/accept_untracked_na",
+		Description: "accept_untracked_na on new interfaces",
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>

/kind bug

> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
Enables `accept_untracked_na` for IPv6 unsolicited NA handling. 
It is the IPv6 equivalent of the `arp_accept` fix in commit 55bd0f9.

During cross-cluster VM live migration with IPv6, FRR cannot advertise
MAC/IP routes until a kernel neighbor entry exists. The kernel's default
`accept_untracked_na=0` setting causes it to ignore unsolicited Neighbor
Advertisement packets, preventing neighbor entry creation.

This change enables `accept_untracked_na=1` on both 'all' and 'default'
interfaces in the router namespace at startup. This allows the kernel
to create neighbor entries from received unsolicited NA packets,
enabling FRR to immediately advertise MAC/IP routes when a VM migrates.

**Note:** This sysctl is only available on kernels >= 5.18.


**Special notes for your reviewer**:
Fixes: #205 
Depends-on: #202 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Enable the `accept_untracked_na` sysctl in the router network namespaces, to learn MAC mobility events from unsolicited NA messages.
```
