### PR TITLE
Fix MetalLB example

### DIFF
--- a/examples/common.sh
+++ b/examples/common.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+KIND_BIN="${KIND_BIN:-kind}"
+
 apply_manifests_with_retries() {
   local manifests=("$@")
   for manifest in "${manifests[@]}"; do

--- a/examples/evpn/metallb/metallb.yaml
+++ b/examples/evpn/metallb/metallb.yaml
@@ -76,12 +76,12 @@ spec:
     routers:
     - asn: 64515
       neighbors:
-      - address: 192.169.10.0
+      - address: 192.169.10.1
         asn: 64514
         toReceive:
           allowed:
             mode: all
-      - address: 192.169.11.0
+      - address: 192.169.11.1
         asn: 64514
         toReceive:
           allowed:

--- a/examples/evpn/metallb/prepare.sh
+++ b/examples/evpn/metallb/prepare.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 set -x
 CURRENT_PATH=$(dirname "$0")
 
-source "${CURRENT_PATH}/../common.sh"
+source "${CURRENT_PATH}/../../common.sh"
 
 DEMO_MODE=true make deploy
 export KUBECONFIG=$(pwd)/bin/kubeconfig
@@ -26,6 +26,8 @@ helm install metallb metallb/metallb --namespace metallb-system --set frrk8s.ext
 
 wait_for_pods metallb-system app.kubernetes.io/name=metallb
 
+docker image pull nginx:1.25
+${KIND_BIN} --name pe-kind load docker-image nginx:1.25
 
 apply_manifests_with_retries metallb.yaml openpe.yaml workload.yaml
 

--- a/examples/evpn/metallb/workload.yaml
+++ b/examples/evpn/metallb/workload.yaml
@@ -38,15 +38,15 @@ spec:
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: green
+  name: blue
   labels:
-    name: green
+    name: blue
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: nginx-service-green
-  namespace: green
+  name: nginx-service-blue
+  namespace: blue
   labels:
     app: nginx
 spec:
@@ -63,7 +63,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment
-  namespace: green
+  namespace: blue
   labels:
     app: nginx
 spec:


### PR DESCRIPTION



<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

Few fixes:

- the address of the perouter leg is now .1 , fixed in the frrconfiguration
- the namespace of the workload was "green" while the pool was assigned to blue
- preloading the nginx image on the kind cluster
- wrong common.sh path
- 
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix the metallb example not starting for wrong common.sh path.
```
