### PR TITLE
kubevirt, multi-cluster, website: fix broken links

### DIFF
--- a/website/content/docs/examples/evpnexamples/kubevirt-multi-cluster.md
+++ b/website/content/docs/examples/evpnexamples/kubevirt-multi-cluster.md
@@ -42,7 +42,7 @@ machines are connected to this bridge via Multus secondary interfaces of type
 > ```
 
 The full example can be found in the
-[project repository](https://github.com/openperouter/openperouter/examples/evpn/multi-cluster)
+[project repository](https://github.com/openperouter/openperouter/tree/main/examples/evpn/multi-cluster)
 and can be deployed by running:
 
 ```bash
@@ -333,8 +333,8 @@ in cluster B.
 It also has a dedicated migration network set up in both clusters, which
 happens to be implemented using an L2 VNI ! You can find links to the network
 manifests below:
-- [NAD](/examples/evpn/multi-cluster/cluster-a-migration-nad.yaml)
-- [L2VNI](/examples/evpn/multi-cluster/cluster-a-migration-l2vni.yaml)
+- [NAD](https://github.com/openperouter/openperouter/tree/main/examples/evpn/multi-cluster/cluster-a-migration-nad.yaml)
+- [L2VNI](https://github.com/openperouter/openperouter/tree/main/examples/evpn/multi-cluster/cluster-a-migration-l2vni.yaml)
 
 ### Preparing the VM to be migrated
 


### PR DESCRIPTION


<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>

/kind bug

> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
Update GitHub repository links to use the correct tree/main URL format for proper navigation:
- Fix project repository link for multi-cluster example
- Fix NAD and L2VNI manifest links for migration network setup

The changes fix three broken links in the documentation by:
1. Adding /tree/main/ to the project repository link
2. Converting relative paths to full GitHub URLs for the migration network manifest files (NAD and L2VNI)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
