### PR TITLE
fix(sysctl): enable ipv4 forward

### DIFF
--- a/internal/controller/routerconfiguration/host_config.go
+++ b/internal/controller/routerconfiguration/host_config.go
@@ -55,6 +55,7 @@ func configureInterfaces(ctx context.Context, config interfacesConfiguration) er
 	slog.InfoContext(ctx, "ensuring sysctls")
 	if err := sysctl.Ensure(
 		config.targetNamespace,
+		sysctl.IPv4Forwarding(),
 		sysctl.IPv6Forwarding(),
 		sysctl.ArpAcceptAll(),
 		sysctl.ArpAcceptDefault(),

--- a/internal/sysctl/sysctl.go
+++ b/internal/sysctl/sysctl.go
@@ -55,6 +55,14 @@ func Ensure(namespace string, sysctls ...Sysctl) error {
 	return nil
 }
 
+// IPv4Forwarding returns the sysctl definition for enabling IPv4 forwarding.
+func IPv4Forwarding() Sysctl {
+	return Sysctl{
+		Path:        "net/ipv4/conf/all/forwarding",
+		Description: "IPv4 forwarding",
+	}
+}
+
 // IPv6Forwarding returns the sysctl definition for enabling IPv6 forwarding.
 func IPv6Forwarding() Sysctl {
 	return Sysctl{

--- a/internal/sysctl/sysctl_test.go
+++ b/internal/sysctl/sysctl_test.go
@@ -81,6 +81,8 @@ var _ = Describe("Ensure", func() {
 				Expect(val).To(Equal("1"), "sysctl %s should be enabled", sysctlName)
 			}
 		},
+		Entry("IPv4 forwarding when disabled", "test-ipv4-fwd", []Sysctl{IPv4Forwarding()}, false),
+		Entry("IPv4 forwarding when already enabled", "test-ipv4-fwd-pre", []Sysctl{IPv4Forwarding()}, true),
 		Entry("IPv6 forwarding when disabled", "test-ipv6-fwd", []Sysctl{IPv6Forwarding()}, false),
 		Entry("IPv6 forwarding when already enabled", "test-ipv6-fwd-pre", []Sysctl{IPv6Forwarding()}, true),
 		Entry("arp_accept all when disabled", "test-arp-all", []Sysctl{ArpAcceptAll()}, false),


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:
Depending on the container runtime the ipv4 forwarding sysctl can be 1
or 0, for example containerd inherit the one from the node while CRI-O
enforces it to 0, to prevent this this change force ipv4 foward to be
always 1, this make L3VNI to work on CRI-O (openshift) environments.


**Special notes for your reviewer**:
Depends-on:
- https://github.com/openperouter/openperouter/pull/202

**Release note**:
<!--  Write your release note:
```release-note
Support L3VNI on CRI-O by enabling always ipv4 ip forwarding
```
