### PR TITLE
evpn: Add vtepInterface as an alternative to vtepCIDR for VTEP source

### DIFF
--- a/api/v1alpha1/underlay_types.go
+++ b/api/v1alpha1/underlay_types.go
@@ -52,10 +52,25 @@ type UnderlaySpec struct {
 	EVPN *EVPNConfig `json:"evpn,omitempty"`
 }
 
+// EVPNConfig contains EVPN-VXLAN configuration for the underlay.
+// +kubebuilder:validation:XValidation:rule="(self.?vtepcidr.orValue(\"\") != \"\") != (self.?vtepInterface.orValue(\"\") != \"\")",message="exactly one of vtepcidr or vtepInterface must be specified"
 type EVPNConfig struct {
 	// VTEPCIDR is CIDR to be used to assign IPs to the local VTEP on each node.
-	// +required
+	// A loopback interface will be created with an IP derived from this CIDR.
+	// Mutually exclusive with VTEPInterface.
+	// +optional
 	VTEPCIDR string `json:"vtepcidr,omitempty"`
+
+	// VTEPInterface is the name of an existing interface to use as the VTEP source.
+	// The interface must already have an IP address configured that will be used
+	// as the VTEP IP. Mutually exclusive with VTEPCIDR.
+	// The ToR must advertise the interface IP into the fabric underlay
+	// (e.g. via redistribute connected) so that the VTEP address is reachable
+	// from other leaves.
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z][a-zA-Z0-9._-]*$`
+	// +kubebuilder:validation:MaxLength=15
+	// +optional
+	VTEPInterface string `json:"vtepInterface,omitempty"`
 }
 
 // UnderlayStatus defines the observed state of Underlay.

--- a/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_underlays.yaml
+++ b/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_underlays.yaml
@@ -47,14 +47,31 @@ spec:
                 minimum: 1
                 type: integer
               evpn:
+                description: EVPNConfig contains EVPN-VXLAN configuration for the
+                  underlay.
                 properties:
-                  vtepcidr:
-                    description: VTEPCIDR is CIDR to be used to assign IPs to the
-                      local VTEP on each node.
+                  vtepInterface:
+                    description: |-
+                      VTEPInterface is the name of an existing interface to use as the VTEP source.
+                      The interface must already have an IP address configured that will be used
+                      as the VTEP IP. Mutually exclusive with VTEPCIDR.
+                      The ToR must advertise the interface IP into the fabric underlay
+                      (e.g. via redistribute connected) so that the VTEP address is reachable
+                      from other leaves.
+                    maxLength: 15
+                    pattern: ^[a-zA-Z][a-zA-Z0-9._-]*$
                     type: string
-                required:
-                - vtepcidr
+                  vtepcidr:
+                    description: |-
+                      VTEPCIDR is CIDR to be used to assign IPs to the local VTEP on each node.
+                      A loopback interface will be created with an IP derived from this CIDR.
+                      Mutually exclusive with VTEPInterface.
+                    type: string
                 type: object
+                x-kubernetes-validations:
+                - message: exactly one of vtepcidr or vtepInterface must be specified
+                  rule: (self.?vtepcidr.orValue("") != "") != (self.?vtepInterface.orValue("")
+                    != "")
               neighbors:
                 description: Neighbors is the list of external neighbors to peer with.
                 items:

--- a/config/all-in-one/crio.yaml
+++ b/config/all-in-one/crio.yaml
@@ -569,14 +569,31 @@ spec:
                 minimum: 1
                 type: integer
               evpn:
+                description: EVPNConfig contains EVPN-VXLAN configuration for the
+                  underlay.
                 properties:
-                  vtepcidr:
-                    description: VTEPCIDR is CIDR to be used to assign IPs to the
-                      local VTEP on each node.
+                  vtepInterface:
+                    description: |-
+                      VTEPInterface is the name of an existing interface to use as the VTEP source.
+                      The interface must already have an IP address configured that will be used
+                      as the VTEP IP. Mutually exclusive with VTEPCIDR.
+                      The ToR must advertise the interface IP into the fabric underlay
+                      (e.g. via redistribute connected) so that the VTEP address is reachable
+                      from other leaves.
+                    maxLength: 15
+                    pattern: ^[a-zA-Z][a-zA-Z0-9._-]*$
                     type: string
-                required:
-                - vtepcidr
+                  vtepcidr:
+                    description: |-
+                      VTEPCIDR is CIDR to be used to assign IPs to the local VTEP on each node.
+                      A loopback interface will be created with an IP derived from this CIDR.
+                      Mutually exclusive with VTEPInterface.
+                    type: string
                 type: object
+                x-kubernetes-validations:
+                - message: exactly one of vtepcidr or vtepInterface must be specified
+                  rule: (self.?vtepcidr.orValue("") != "") != (self.?vtepInterface.orValue("")
+                    != "")
               neighbors:
                 description: Neighbors is the list of external neighbors to peer with.
                 items:

--- a/config/all-in-one/openpe.yaml
+++ b/config/all-in-one/openpe.yaml
@@ -569,14 +569,31 @@ spec:
                 minimum: 1
                 type: integer
               evpn:
+                description: EVPNConfig contains EVPN-VXLAN configuration for the
+                  underlay.
                 properties:
-                  vtepcidr:
-                    description: VTEPCIDR is CIDR to be used to assign IPs to the
-                      local VTEP on each node.
+                  vtepInterface:
+                    description: |-
+                      VTEPInterface is the name of an existing interface to use as the VTEP source.
+                      The interface must already have an IP address configured that will be used
+                      as the VTEP IP. Mutually exclusive with VTEPCIDR.
+                      The ToR must advertise the interface IP into the fabric underlay
+                      (e.g. via redistribute connected) so that the VTEP address is reachable
+                      from other leaves.
+                    maxLength: 15
+                    pattern: ^[a-zA-Z][a-zA-Z0-9._-]*$
                     type: string
-                required:
-                - vtepcidr
+                  vtepcidr:
+                    description: |-
+                      VTEPCIDR is CIDR to be used to assign IPs to the local VTEP on each node.
+                      A loopback interface will be created with an IP derived from this CIDR.
+                      Mutually exclusive with VTEPInterface.
+                    type: string
                 type: object
+                x-kubernetes-validations:
+                - message: exactly one of vtepcidr or vtepInterface must be specified
+                  rule: (self.?vtepcidr.orValue("") != "") != (self.?vtepInterface.orValue("")
+                    != "")
               neighbors:
                 description: Neighbors is the list of external neighbors to peer with.
                 items:

--- a/config/crd/bases/openpe.openperouter.github.io_underlays.yaml
+++ b/config/crd/bases/openpe.openperouter.github.io_underlays.yaml
@@ -47,14 +47,31 @@ spec:
                 minimum: 1
                 type: integer
               evpn:
+                description: EVPNConfig contains EVPN-VXLAN configuration for the
+                  underlay.
                 properties:
-                  vtepcidr:
-                    description: VTEPCIDR is CIDR to be used to assign IPs to the
-                      local VTEP on each node.
+                  vtepInterface:
+                    description: |-
+                      VTEPInterface is the name of an existing interface to use as the VTEP source.
+                      The interface must already have an IP address configured that will be used
+                      as the VTEP IP. Mutually exclusive with VTEPCIDR.
+                      The ToR must advertise the interface IP into the fabric underlay
+                      (e.g. via redistribute connected) so that the VTEP address is reachable
+                      from other leaves.
+                    maxLength: 15
+                    pattern: ^[a-zA-Z][a-zA-Z0-9._-]*$
                     type: string
-                required:
-                - vtepcidr
+                  vtepcidr:
+                    description: |-
+                      VTEPCIDR is CIDR to be used to assign IPs to the local VTEP on each node.
+                      A loopback interface will be created with an IP derived from this CIDR.
+                      Mutually exclusive with VTEPInterface.
+                    type: string
                 type: object
+                x-kubernetes-validations:
+                - message: exactly one of vtepcidr or vtepInterface must be specified
+                  rule: (self.?vtepcidr.orValue("") != "") != (self.?vtepInterface.orValue("")
+                    != "")
               neighbors:
                 description: Neighbors is the list of external neighbors to peer with.
                 items:

--- a/config/samples/underlay-vtepinterface.yaml
+++ b/config/samples/underlay-vtepinterface.yaml
@@ -1,0 +1,14 @@
+apiVersion: openpe.openperouter.github.io/v1alpha1
+kind: Underlay
+metadata:
+  name: underlay
+  namespace: openperouter-system
+spec:
+  asn: 64514
+  evpn:
+    vtepInterface: toswitch
+  nics:
+    - toswitch
+  neighbors:
+    - asn: 64512
+      address: 192.168.11.2

--- a/e2etests/pkg/infra/leaf.go
+++ b/e2etests/pkg/infra/leaf.go
@@ -51,8 +51,9 @@ type LeafConfiguration struct {
 }
 
 type LeafKindConfiguration struct {
-	EnableBFD bool
-	Neighbors []string
+	EnableBFD             bool
+	RedistributeConnected bool
+	Neighbors             []string
 }
 
 type Addresses struct {

--- a/e2etests/pkg/infra/testdata/leafkind.tmpl
+++ b/e2etests/pkg/infra/testdata/leafkind.tmpl
@@ -36,6 +36,9 @@ router bgp 64512
 
  !
  address-family ipv4 unicast
+{{- if .RedistributeConnected }}
+  redistribute connected
+{{- end }}
   neighbor 192.168.1.4 activate
 {{- range .Neighbors }}
   neighbor {{ . }} activate

--- a/e2etests/tests/leaf.go
+++ b/e2etests/tests/leaf.go
@@ -5,6 +5,7 @@ package tests
 import (
 	. "github.com/onsi/gomega"
 	"github.com/openperouter/openperouter/e2etests/pkg/infra"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func redistributeConnectedForLeaf(leaf infra.Leaf) {
@@ -23,5 +24,29 @@ func redistributeConnectedForLeaf(leaf infra.Leaf) {
 	config, err := infra.LeafConfigToFRR(leafConfiguration)
 	Expect(err).NotTo(HaveOccurred())
 	err = leaf.ReloadConfig(config)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func redistributeConnectedForLeafKind(nodes []corev1.Node) {
+	neighbors := []string{}
+	for _, node := range nodes {
+		neighborIP, err := infra.NeighborIP(infra.KindLeaf, node.Name)
+		Expect(err).NotTo(HaveOccurred())
+		neighbors = append(neighbors, neighborIP)
+	}
+
+	config := infra.LeafKindConfiguration{
+		RedistributeConnected: true,
+		Neighbors:             neighbors,
+	}
+
+	configString, err := infra.LeafKindConfigToFRR(config)
+	Expect(err).NotTo(HaveOccurred())
+	err = infra.LeafKindConfig.ReloadConfig(configString)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func resetLeafKindConfig(nodes []corev1.Node) {
+	err := infra.UpdateLeafKindConfig(nodes, false)
 	Expect(err).NotTo(HaveOccurred())
 }

--- a/internal/conversion/frr_conversion.go
+++ b/internal/conversion/frr_conversion.go
@@ -17,7 +17,9 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-const defaultRouterIDCidr = "10.0.0.0/24"
+const (
+	defaultRouterIDCidr = "10.0.0.0/24"
+)
 
 type FRREmptyConfigError string
 
@@ -86,12 +88,13 @@ func APItoFRR(config ApiConfigData, nodeIndex int, logLevel string) (frr.Config,
 		}, nil
 	}
 
-	vtepIP, err := ipam.VTEPIp(underlay.Spec.EVPN.VTEPCIDR, nodeIndex)
-	if err != nil {
-		return frr.Config{}, fmt.Errorf("failed to get vtep ip, cidr %s, nodeIntex %d", underlay.Spec.EVPN.VTEPCIDR, nodeIndex)
-	}
-	underlayConfig.EVPN = &frr.UnderlayEvpn{
-		VTEP: vtepIP.String(),
+	underlayConfig.EVPN = &frr.UnderlayEvpn{}
+	if underlay.Spec.EVPN.VTEPCIDR != "" {
+		vtepIP, err := ipam.VTEPIp(underlay.Spec.EVPN.VTEPCIDR, nodeIndex)
+		if err != nil {
+			return frr.Config{}, fmt.Errorf("failed to get vtep ip, cidr %s, nodeIndex %d: %w", underlay.Spec.EVPN.VTEPCIDR, nodeIndex, err)
+		}
+		underlayConfig.EVPN.VTEP = vtepIP.String()
 	}
 
 	vniConfigs := []frr.L3VNIConfig{}

--- a/internal/conversion/validate_underlay_test.go
+++ b/internal/conversion/validate_underlay_test.go
@@ -186,6 +186,57 @@ func TestValidateUnderlay(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "both vtepcidr and vtepInterface specified",
+			underlay: v1alpha1.Underlay{
+				Spec: v1alpha1.UnderlaySpec{
+					EVPN: &v1alpha1.EVPNConfig{
+						VTEPCIDR:      "192.168.1.0/24",
+						VTEPInterface: "eth0",
+					},
+					Nics: []string{"eth0"},
+					ASN:  65001,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "neither vtepcidr nor vtepInterface specified",
+			underlay: v1alpha1.Underlay{
+				Spec: v1alpha1.UnderlaySpec{
+					EVPN: &v1alpha1.EVPNConfig{},
+					Nics: []string{"eth0"},
+					ASN:  65001,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "only vtepInterface specified",
+			underlay: v1alpha1.Underlay{
+				Spec: v1alpha1.UnderlaySpec{
+					EVPN: &v1alpha1.EVPNConfig{
+						VTEPInterface: "eth0",
+					},
+					Nics: []string{"eth1"},
+					ASN:  65001,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid vtepInterface name",
+			underlay: v1alpha1.Underlay{
+				Spec: v1alpha1.UnderlaySpec{
+					EVPN: &v1alpha1.EVPNConfig{
+						VTEPInterface: "1invalid",
+					},
+					Nics: []string{"eth0"},
+					ASN:  65001,
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/frr/templates/underlay_evpn.tmpl
+++ b/internal/frr/templates/underlay_evpn.tmpl
@@ -1,8 +1,9 @@
 {{ define "underlayevpn"}}
+{{- if .Underlay.EVPN.VTEP }}
   address-family ipv4 unicast
     network {{ .Underlay.EVPN.VTEP }}
   exit-address-family
-
+{{ end }}
   address-family l2vpn evpn
 {{- range .Underlay.Neighbors }}
     neighbor {{ .Addr }} activate

--- a/internal/hostnetwork/underlay.go
+++ b/internal/hostnetwork/underlay.go
@@ -53,8 +53,11 @@ func SetupUnderlay(ctx context.Context, params UnderlayParams) error {
 	if params.EVPN == nil {
 		return nil
 	}
-	if err := createLoopback(ctx, ns, params.EVPN.VtepIP); err != nil {
-		return err
+
+	if params.EVPN.VtepIP != "" {
+		if err := ensureLoopback(ctx, ns, params.EVPN.VtepIP); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -66,7 +69,7 @@ func (e UnderlayExistsError) Error() string {
 	return string(e)
 }
 
-func createLoopback(ctx context.Context, ns netns.NsHandle, vtepIP string) error {
+func ensureLoopback(ctx context.Context, ns netns.NsHandle, vtepIP string) error {
 	slog.DebugContext(ctx, "setup underlay", "step", "creating loopback interface")
 	defer slog.DebugContext(ctx, "setup underlay", "step", "loopback interface created")
 
@@ -84,7 +87,6 @@ func createLoopback(ctx context.Context, ns netns.NsHandle, vtepIP string) error
 		if err != nil {
 			return err
 		}
-
 		return nil
 	}); err != nil {
 		return err

--- a/internal/hostnetwork/underlay_test.go
+++ b/internal/hostnetwork/underlay_test.go
@@ -187,7 +187,7 @@ func validateUnderlay(g Gomega, params UnderlayParams, interfaceIPs ...string) {
 	for _, l := range links {
 		if l.Attrs().Name == UnderlayLoopback {
 			loopbackFound = true
-			if params.EVPN != nil {
+			if params.EVPN != nil && params.EVPN.VtepIP != "" {
 				validateIP(g, l, params.EVPN.VtepIP)
 			}
 		}
@@ -200,7 +200,9 @@ func validateUnderlay(g Gomega, params UnderlayParams, interfaceIPs ...string) {
 		}
 
 	}
-	if params.EVPN != nil {
+	if params.EVPN != nil && params.EVPN.VtepIP == "" {
+		g.Expect(loopbackFound).To(BeFalse(), fmt.Sprintf("loopback should not exist when vtepInterface is set, links %v", links))
+	} else if params.EVPN != nil {
 		g.Expect(loopbackFound).To(BeTrue(), fmt.Sprintf("failed to find loopback in ns, links %v", links))
 	}
 	if params.UnderlayInterface != "" && !mainNicFound {

--- a/internal/hostnetwork/vni.go
+++ b/internal/hostnetwork/vni.go
@@ -19,11 +19,12 @@ import (
 )
 
 type VNIParams struct {
-	VRF       string `json:"vrf"`
-	TargetNS  string `json:"targetns"`
-	VTEPIP    string `json:"vtepip"`
-	VNI       int    `json:"vni"`
-	VXLanPort int    `json:"vxlanport"`
+	VRF           string `json:"vrf"`
+	TargetNS      string `json:"targetns"`
+	VTEPIP        string `json:"vtepip"`
+	VTEPInterface string `json:"vtepiface"`
+	VNI           int    `json:"vni"`
+	VXLanPort     int    `json:"vxlanport"`
 }
 
 type L3VNIParams struct {

--- a/internal/hostnetwork/vni_test.go
+++ b/internal/hostnetwork/vni_test.go
@@ -568,8 +568,12 @@ func validateL2VNI(g Gomega, params L2VNIParams) {
 }
 
 func validateVNI(g Gomega, params VNIParams) {
-	loopback, err := netlink.LinkByName(UnderlayLoopback)
-	g.Expect(err).NotTo(HaveOccurred(), "loopback not found", UnderlayLoopback)
+	vtepDevName := UnderlayLoopback
+	if params.VTEPInterface != "" {
+		vtepDevName = params.VTEPInterface
+	}
+	vtepDev, err := netlink.LinkByName(vtepDevName)
+	g.Expect(err).NotTo(HaveOccurred(), "vtep device not found %q", vtepDevName)
 
 	vxlanLink, err := netlink.LinkByName(vxLanNameFromVNI(params.VNI))
 	g.Expect(err).NotTo(HaveOccurred(), "vxlan link not found %q", vxLanNameFromVNI(params.VNI))
@@ -597,7 +601,7 @@ func validateVNI(g Gomega, params VNIParams) {
 	addrGenModeNone = checkAddrGenModeNone(bridge)
 	g.Expect(addrGenModeNone).To(BeTrue())
 
-	err = checkVXLanConfigured(vxlan, bridge.Index, loopback.Attrs().Index, params)
+	err = checkVXLanConfigured(vxlan, bridge.Index, vtepDev.Attrs().Index, params)
 	g.Expect(err).NotTo(HaveOccurred())
 }
 

--- a/operator/bundle/manifests/openpe.openperouter.github.io_underlays.yaml
+++ b/operator/bundle/manifests/openpe.openperouter.github.io_underlays.yaml
@@ -47,14 +47,31 @@ spec:
                 minimum: 1
                 type: integer
               evpn:
+                description: EVPNConfig contains EVPN-VXLAN configuration for the
+                  underlay.
                 properties:
-                  vtepcidr:
-                    description: VTEPCIDR is CIDR to be used to assign IPs to the
-                      local VTEP on each node.
+                  vtepInterface:
+                    description: |-
+                      VTEPInterface is the name of an existing interface to use as the VTEP source.
+                      The interface must already have an IP address configured that will be used
+                      as the VTEP IP. Mutually exclusive with VTEPCIDR.
+                      The ToR must advertise the interface IP into the fabric underlay
+                      (e.g. via redistribute connected) so that the VTEP address is reachable
+                      from other leaves.
+                    maxLength: 15
+                    pattern: ^[a-zA-Z][a-zA-Z0-9._-]*$
                     type: string
-                required:
-                - vtepcidr
+                  vtepcidr:
+                    description: |-
+                      VTEPCIDR is CIDR to be used to assign IPs to the local VTEP on each node.
+                      A loopback interface will be created with an IP derived from this CIDR.
+                      Mutually exclusive with VTEPInterface.
+                    type: string
                 type: object
+                x-kubernetes-validations:
+                - message: exactly one of vtepcidr or vtepInterface must be specified
+                  rule: (self.?vtepcidr.orValue("") != "") != (self.?vtepInterface.orValue("")
+                    != "")
               neighbors:
                 description: Neighbors is the list of external neighbors to peer with.
                 items:

--- a/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2026-02-05T12:40:23Z"
+    createdAt: "2026-02-12T09:50:48Z"
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: openperouter-operator.v0.0.0


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind feature

**What this PR does / why we need it**:

Add a new vtepInterface field to EVPNConfig as a mutually exclusive
alternative to vtepCIDR. When set, the specified interface is used
directly as the VXLAN source device without creating a loopback.

Since the interface IP is already routable by the ToR, the BGP network
advertisement in frr.conf is skipped and no network namespace access is
needed to resolve the address.

When vtepInterface is specified:
- No loopback interface is created
- The VXLAN uses the interface directly via VtepDevIndex
- The interface's IPv4 address is resolved at VXLAN creation time and set
  as the VXLAN local attribute so FRR can determine the local VTEP IP for
  Type-3 IMET routes
- The frr.conf ipv4 unicast network line is omitted
- The APItoFRR function no longer requires the targetNamespace parameter

When vtepCIDR is specified (existing behavior unchanged):
- A loopback interface is created with an IP derived from the CIDR
- The IP is advertised via BGP in frr.conf

The two fields are mutually exclusive, enforced via CEL validation on the
CRD and in the webhook validation logic.

**Special notes for your reviewer**:
Jira: https://issues.redhat.com/browse/CNV-79088
Closes #220

Depends-On:
- https://github.com/openperouter/openperouter/pull/239

**Release note**:

```release-note
Add vtepInterface field to EVPNConfig to allow using an existing interface as VTEP source instead of creating a loopback from vtepCIDR
```