### PR TITLE
Integration tests: auto-discover runasroot suites and pass ginkgo.v

### DIFF
--- a/hack/integration_tests.sh
+++ b/hack/integration_tests.sh
@@ -47,4 +47,12 @@ echo "OVS is ready"
 ovs-vsctl show
 
 umask 0
-exec /src/bin/hostnetwork.test -test.v
+shift # skip container image name
+for test_bin in "$@"; do
+    echo "Running $test_bin..."
+    if "$test_bin" -help 2>&1 | grep -q ginkgo; then
+        "$test_bin" -test.v -ginkgo.v
+    else
+        "$test_bin" -test.v
+    fi
+done

--- a/internal/controller/routerconfiguration/router_host.go
+++ b/internal/controller/routerconfiguration/router_host.go
@@ -18,11 +18,11 @@ import (
 )
 
 type RouterHostProvider struct {
-	FRRConfigPath          string
-	RouterPidFilePath      string
-	CurrentNodeIndex       int
-	SystemdSocketPath      string
-	RouterHealthCheckPort  int
+	FRRConfigPath         string
+	RouterPidFilePath     string
+	CurrentNodeIndex      int
+	SystemdSocketPath     string
+	RouterHealthCheckPort int
 }
 
 var _ RouterProvider = (*RouterHostProvider)(nil)

--- a/internal/hostnetwork/bridgerefresh/arp.go
+++ b/internal/hostnetwork/bridgerefresh/arp.go
@@ -43,7 +43,7 @@ func (r *BridgeRefresher) sendARPProbe(targetIP net.IP, targetMAC net.HardwareAd
 	if ipfamily.ForAddress(targetIP) != ipfamily.IPv4 {
 		return fmt.Errorf("target IP %s is not IPv4", targetIP)
 	}
-	targetAddr, ok := netip.AddrFromSlice(targetIP)
+	targetAddr, ok := netip.AddrFromSlice(targetIP.To4())
 	if !ok {
 		return fmt.Errorf("failed to convert target IP %s to netip.Addr", targetIP)
 	}


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:
Dynamically find test packages with the runasroot build tag instead of
hardcoding them in the Makefile. This revealed that the bridgerefresh
test suite was not being run. Compiled test binary paths are passed as
arguments to integration_tests.sh, which detects ginkgo suites and
adds -ginkgo.v for verbose output.

**Release note**:

```release-note
NONE
```