### PR TITLE
vet: Make cel expressions vet compatible

### DIFF
--- a/api/v1alpha1/l2vni_types.go
+++ b/api/v1alpha1/l2vni_types.go
@@ -67,7 +67,7 @@ type L2VNISpec struct {
 }
 
 // LinuxBridgeConfig contains configuration for Linux bridge type.
-// +kubebuilder:validation:xvalidation:rule="(self.name != '' && self.autoCreate == false) || (self.name == '' && self.autoCreate == true)",message="either name must be set or autoCreate must be true, but not both."
+// +kubebuilder:validation:XValidation:rule="(self.?name.orValue(\"\") == \"\") == self.autoCreate",message="either name must be set or autoCreate must be true, but not both."
 type LinuxBridgeConfig struct {
 	// Name of the Linux bridge interface.
 	// +kubebuilder:validation:Pattern=`^[a-zA-Z][a-zA-Z0-9_-]*$`
@@ -83,7 +83,7 @@ type LinuxBridgeConfig struct {
 }
 
 // OVSBridgeConfig contains configuration for OVS bridge type.
-// +kubebuilder:validation:xvalidation:rule="(self.name != '' && self.autoCreate == false) || (self.name == '' && self.autoCreate == true)",message="either name must be set or autoCreate must be true, but not both."
+// +kubebuilder:validation:XValidation:rule="(self.?name.orValue(\"\") == \"\") == self.autoCreate",message="either name must be set or autoCreate must be true, but not both."
 type OVSBridgeConfig struct {
 	// Name of the OVS bridge interface.
 	// +kubebuilder:validation:Pattern=`^[a-zA-Z][a-zA-Z0-9_-]*$`

--- a/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_l2vnis.yaml
+++ b/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_l2vnis.yaml
@@ -64,6 +64,10 @@ spec:
                         pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: either name must be set or autoCreate must be true,
+                        but not both.
+                      rule: (self.?name.orValue("") == "") == self.autoCreate
                   ovsBridge:
                     description: OVSBridge configuration. Must be set when Type is
                       "ovs-bridge".
@@ -80,6 +84,10 @@ spec:
                         pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: either name must be set or autoCreate must be true,
+                        but not both.
+                      rule: (self.?name.orValue("") == "") == self.autoCreate
                   type:
                     description: 'Type of the host interface. Supported values: "linux-bridge",
                       "ovs-bridge".'

--- a/config/all-in-one/crio.yaml
+++ b/config/all-in-one/crio.yaml
@@ -73,6 +73,10 @@ spec:
                         pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: either name must be set or autoCreate must be true,
+                        but not both.
+                      rule: (self.?name.orValue("") == "") == self.autoCreate
                   ovsBridge:
                     description: OVSBridge configuration. Must be set when Type is
                       "ovs-bridge".
@@ -89,6 +93,10 @@ spec:
                         pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: either name must be set or autoCreate must be true,
+                        but not both.
+                      rule: (self.?name.orValue("") == "") == self.autoCreate
                   type:
                     description: 'Type of the host interface. Supported values: "linux-bridge",
                       "ovs-bridge".'

--- a/config/all-in-one/openpe.yaml
+++ b/config/all-in-one/openpe.yaml
@@ -73,6 +73,10 @@ spec:
                         pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: either name must be set or autoCreate must be true,
+                        but not both.
+                      rule: (self.?name.orValue("") == "") == self.autoCreate
                   ovsBridge:
                     description: OVSBridge configuration. Must be set when Type is
                       "ovs-bridge".
@@ -89,6 +93,10 @@ spec:
                         pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: either name must be set or autoCreate must be true,
+                        but not both.
+                      rule: (self.?name.orValue("") == "") == self.autoCreate
                   type:
                     description: 'Type of the host interface. Supported values: "linux-bridge",
                       "ovs-bridge".'

--- a/config/crd/bases/openpe.openperouter.github.io_l2vnis.yaml
+++ b/config/crd/bases/openpe.openperouter.github.io_l2vnis.yaml
@@ -64,6 +64,10 @@ spec:
                         pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: either name must be set or autoCreate must be true,
+                        but not both.
+                      rule: (self.?name.orValue("") == "") == self.autoCreate
                   ovsBridge:
                     description: OVSBridge configuration. Must be set when Type is
                       "ovs-bridge".
@@ -80,6 +84,10 @@ spec:
                         pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: either name must be set or autoCreate must be true,
+                        but not both.
+                      rule: (self.?name.orValue("") == "") == self.autoCreate
                   type:
                     description: 'Type of the host interface. Supported values: "linux-bridge",
                       "ovs-bridge".'

--- a/operator/bundle/manifests/openpe.openperouter.github.io_l2vnis.yaml
+++ b/operator/bundle/manifests/openpe.openperouter.github.io_l2vnis.yaml
@@ -64,6 +64,10 @@ spec:
                         pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: either name must be set or autoCreate must be true,
+                        but not both.
+                      rule: (self.?name.orValue("") == "") == self.autoCreate
                   ovsBridge:
                     description: OVSBridge configuration. Must be set when Type is
                       "ovs-bridge".
@@ -80,6 +84,10 @@ spec:
                         pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: either name must be set or autoCreate must be true,
+                        but not both.
+                      rule: (self.?name.orValue("") == "") == self.autoCreate
                   type:
                     description: 'Type of the host interface. Supported values: "linux-bridge",
                       "ovs-bridge".'

--- a/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2026-01-13T13:22:06Z"
+    createdAt: "2026-02-05T12:40:23Z"
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: openperouter-operator.v0.0.0


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:
The go fmt command is breaking the cel expression by changing "" into
single double quote unsupported char, this change replace the expressions to use
propertly double quote.

Also replacing xvalidation with XValidation since the former end up with
cel expressions not embedded at the generated manifests](api: Make cel expressions fmt compatible and use proper tag)


**Release note**:

```release-note
Generate linux bridge and ovs bridge manifests with CEL expressions
```
