### PR TITLE
fix(vrf): add unreachable routes to prevent VRF escape

### DIFF
--- a/internal/hostnetwork/vni_test.go
+++ b/internal/hostnetwork/vni_test.go
@@ -750,6 +750,15 @@ func validateVNI(g Gomega, params VNIParams) {
 
 	err = checkVXLanConfigured(vxlan, bridge.Index, vtepDev.Attrs().Index, params)
 	g.Expect(err).NotTo(HaveOccurred())
+
+	ok, err := hasUnreachableDefaultRoute(int(vrf.Table), netlink.FAMILY_V4)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ok).To(BeTrue())
+
+	ok, err = hasUnreachableDefaultRoute(int(vrf.Table), netlink.FAMILY_V6)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ok).To(BeTrue())
+
 }
 
 func validateVethForVNI(g Gomega, params VNIParams) {

--- a/internal/hostnetwork/vrf.go
+++ b/internal/hostnetwork/vrf.go
@@ -6,9 +6,24 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net"
 
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
+
+// Route priority (aka metric) value that must be set on default unreachable routes.
+// This value is the one recommended by the Linux kernel documentation, must be higher than any other route priority used in the system, to ensure that it is only used when no other route matches.
+// See https://docs.kernel.org/networking/vrf.html for more details.
+const UnreachableRoutePriority = 4278198272
+
+var defaultUnreachableRoutes = []struct {
+	family int
+	dst    *net.IPNet
+}{
+	{family: netlink.FAMILY_V4, dst: &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)}},
+	{family: netlink.FAMILY_V6, dst: &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)}},
+}
 
 // setupVRF creates a new VRF and sets it up.
 func setupVRF(name string) (*netlink.Vrf, error) {
@@ -22,7 +37,55 @@ func setupVRF(name string) (*netlink.Vrf, error) {
 		return nil, fmt.Errorf("could not set link up for VRF %s: %v", name, err)
 	}
 
+	if err := ensureUnreachableDefaultRoutes(vrf); err != nil {
+		return nil, err
+	}
+
 	return vrf, nil
+}
+
+func hasUnreachableDefaultRoute(vrfTable int, family int) (bool, error) {
+	// Note: When listing routes, netlink represents the default route with Dst == nil.
+	// So we need to filter with Dst: nil to match the default route, and it makes the function agnostic to the IP version.
+	routeFilter := &netlink.Route{
+		Dst:      nil,
+		Table:    vrfTable,
+		Type:     unix.RTN_UNREACHABLE,
+		Priority: UnreachableRoutePriority,
+	}
+	filterMask := netlink.RT_FILTER_DST | netlink.RT_FILTER_TABLE | netlink.RT_FILTER_TYPE | netlink.RT_FILTER_PRIORITY
+	routes, err := netlink.RouteListFiltered(family, routeFilter, filterMask)
+	if err != nil {
+		return false, fmt.Errorf("failed to get routes: %w", err)
+	}
+	return len(routes) > 0, nil
+}
+
+// ensureUnreachableDefaultRoutes adds default unreachable routes for both IPv4 and IPv6 to the given VRF, if they do not already exist.
+// This is needed to ensure that packets that do not match any entry in the VRF table are dropped, instead of being routed to the next table referenced in `ip rule`.
+func ensureUnreachableDefaultRoutes(vrf *netlink.Vrf) error {
+	for _, r := range defaultUnreachableRoutes {
+		found, err := hasUnreachableDefaultRoute(int(vrf.Table), r.family)
+		if err != nil {
+			return fmt.Errorf("failed to get unreachable default route from VRF %s (table %d): %w", vrf.Name, vrf.Table, err)
+		}
+		if found {
+			continue
+		}
+
+		route := &netlink.Route{
+			Dst:      r.dst,
+			Family:   r.family,
+			Table:    int(vrf.Table),
+			Type:     unix.RTN_UNREACHABLE,
+			Priority: UnreachableRoutePriority,
+		}
+		if err := netlink.RouteReplace(route); err != nil {
+			return fmt.Errorf("failed to add unreachable default route to VRF %s (table %d): %w", vrf.Name, vrf.Table, err)
+		}
+	}
+
+	return nil
 }
 
 func createVRF(name string) (*netlink.Vrf, error) {


### PR DESCRIPTION
This commit ensures that unreachable default routes are added to each VRF, preventing packets from escaping to the main routing table when no match is found.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**: Fixes #227 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix: add unreachable routes to prevent VRF escape
```
