### PR TITLE
feature: Configurable FRR paths

### DIFF
--- a/cmd/reloader/handler_test.go
+++ b/cmd/reloader/handler_test.go
@@ -8,21 +8,22 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/openperouter/openperouter/internal/frr/vtysh"
 	"github.com/openperouter/openperouter/internal/frrconfig"
 )
 
 func TestHandler(t *testing.T) {
-	reloadSucceeds := func(_ string) error {
+	reloadSucceeds := func(_, _, _ string) error {
 		return nil
 	}
 
-	reloadFails := func(_ string) error {
+	reloadFails := func(_, _, _ string) error {
 		return errors.New("failed")
 	}
 
 	tests := []struct {
 		name       string
-		reloadMock func(string) error
+		reloadMock func(string, string, string) error
 		method     string
 		httpStatus int
 	}{
@@ -54,7 +55,8 @@ func TestHandler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
 			req, _ := http.NewRequest(tc.method, "/", nil)
-			handler := http.HandlerFunc(reloadHandler("/etc/frr/frr.conf"))
+			handler := http.HandlerFunc(
+				reloadHandler("/etc/frr/frr.conf", frrconfig.DefaultReloaderPath, vtysh.DefaultVtyshPath))
 
 			handler.ServeHTTP(w, req)
 			res := w.Result()

--- a/cmd/reloader/main.go
+++ b/cmd/reloader/main.go
@@ -42,8 +42,10 @@ import (
 type Args struct {
 	bindAddress   string
 	frrConfigPath string
+	frrReloadPath string
 	logLevel      string
 	unixSocket    string
+	vtyshPath     string
 }
 
 func main() {
@@ -52,6 +54,9 @@ func main() {
 	flag.StringVar(&args.unixSocket, "unixsocket", "", "Unix socket path to listen on")
 	flag.StringVar(&args.logLevel, "loglevel", "info", "The log level of the process")
 	flag.StringVar(&args.frrConfigPath, "frrconfig", "/etc/frr/frr.conf", "The path the frr configuration is at")
+	flag.StringVar(&args.frrReloadPath, "frrreloadpath",
+		frrconfig.DefaultReloaderPath, "The path to the frr-reload.py script")
+	flag.StringVar(&args.vtyshPath, "vtyshpath", vtysh.DefaultVtyshPath, "The path to the vtysh binary")
 	flag.Parse()
 
 	_, err := logging.New(args.logLevel)
@@ -84,13 +89,14 @@ func serveReload(args Args) error {
 	}
 
 	unixServer := newServer(
-		[]handlerConfig{{pattern: "/", handler: reloadHandler(args.frrConfigPath)}},
+		[]handlerConfig{{pattern: "/", handler: reloadHandler(args.frrConfigPath, args.frrReloadPath, args.vtyshPath)}},
 	)
 
+	vtyshCli := vtysh.NewCli(args.vtyshPath)
 	healthServer := newServer(
 		[]handlerConfig{
-			{pattern: "/healthz", handler: health()},
-			{pattern: "/readyz", handler: health()},
+			{pattern: "/healthz", handler: health(vtyshCli)},
+			{pattern: "/readyz", handler: health(vtyshCli)},
 		},
 		withEndpoint(args.bindAddress),
 	)
@@ -140,14 +146,14 @@ func serveReload(args Args) error {
 
 var updateConfig = frrconfig.Update
 
-func reloadHandler(frrConfigPath string) func(w http.ResponseWriter, req *http.Request) {
+func reloadHandler(frrConfigPath, frrReloadPath, vtyshPath string) func(w http.ResponseWriter, req *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
 		if req.Method != http.MethodPost {
 			http.Error(w, "invalid method", http.StatusBadRequest)
 			return
 		}
 		slog.Info("reload handler", "event", "received request")
-		err := updateConfig(frrConfigPath)
+		err := updateConfig(frrConfigPath, frrReloadPath, vtyshPath)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -157,14 +163,14 @@ func reloadHandler(frrConfigPath string) func(w http.ResponseWriter, req *http.R
 	}
 }
 
-func health() func(w http.ResponseWriter, req *http.Request) {
+func health(vtyshCli vtysh.Cli) func(w http.ResponseWriter, req *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
 		if req.Method != http.MethodGet {
 			http.Error(w, "invalid method", http.StatusMethodNotAllowed)
 			return
 		}
 
-		if err := liveness.PingFrr(vtysh.Run); err != nil {
+		if err := liveness.PingFrr(vtyshCli); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/internal/frr/vtysh/vtysh.go
+++ b/internal/frr/vtysh/vtysh.go
@@ -6,11 +6,13 @@ import (
 	"os/exec"
 )
 
+const DefaultVtyshPath = "/usr/bin/vtysh"
+
 type Cli func(args string) (string, error)
 
-func Run(args string) (string, error) {
-	out, err := exec.Command("/usr/bin/vtysh", "-c", args).CombinedOutput()
-	return string(out), err
+func NewCli(path string) Cli {
+	return func(args string) (string, error) {
+		out, err := exec.Command(path, "-c", args).CombinedOutput()
+		return string(out), err
+	}
 }
-
-var _ Cli = Run

--- a/internal/frrconfig/frrconfig.go
+++ b/internal/frrconfig/frrconfig.go
@@ -6,24 +6,25 @@ import (
 	"fmt"
 	"log/slog"
 	"os/exec"
+	"path/filepath"
 )
 
 type Action string
 
 const (
-	Test         Action = "test"
-	Reload       Action = "reload"
-	reloaderPath        = "/usr/lib/frr/frr-reload.py"
+	Test                Action = "test"
+	Reload              Action = "reload"
+	DefaultReloaderPath        = "/usr/lib/frr/frr-reload.py"
 )
 
 // Update reloads the frr configuration at the given path.
-func Update(path string) error {
-	slog.Info("config update", "path", path)
-	err := reloadAction(path, Test)
+func Update(configPath, reloaderPath, vtyshPath string) error {
+	slog.Info("config update", "path", configPath)
+	err := reloadAction(configPath, reloaderPath, vtyshPath, Test)
 	if err != nil {
 		return err
 	}
-	err = reloadAction(path, Reload)
+	err = reloadAction(configPath, reloaderPath, vtyshPath, Reload)
 	if err != nil {
 		return err
 	}
@@ -32,9 +33,9 @@ func Update(path string) error {
 
 var execCommand = exec.Command
 
-func reloadAction(path string, action Action) error {
+func reloadAction(configPath, reloaderPath, vtyshPath string, action Action) error {
 	reloadParameter := "--" + string(action)
-	cmd := execCommand("python3", reloaderPath, reloadParameter, path)
+	cmd := execCommand("python3", reloaderPath, "--bindir", filepath.Dir(vtyshPath), reloadParameter, configPath)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		slog.Error("frr update failed", "action", action, "error", err, "output", string(output))

--- a/internal/frrconfig/frrconfig_test.go
+++ b/internal/frrconfig/frrconfig_test.go
@@ -35,7 +35,7 @@ func TestReload(t *testing.T) {
 
 	for tc, params := range tests {
 		t.Run(fmt.Sprintf("reload %s", tc), func(t *testing.T) {
-			err := Update(tc)
+			err := Update(tc, DefaultReloaderPath, "/usr/bin/vtysh")
 			if (params.failReload || params.failValidate) && err == nil {
 				t.Fatalf("expecting failure, got no error")
 			}
@@ -83,17 +83,21 @@ func TestFakeReloadHelper(t *testing.T) {
 		}
 		args = args[1:]
 	}
-	if len(args) != 3 {
-		fmt.Printf("expecting 3 args, got %v", args)
+	if len(args) != 5 {
+		fmt.Printf("expecting 5 args, got %v", args)
 		os.Exit(1)
 	}
 
-	if !reflect.DeepEqual(args[0], reloaderPath) {
-		fmt.Println("expected to be called with -c reloader args", args)
+	if !reflect.DeepEqual(args[0], DefaultReloaderPath) {
+		fmt.Println("expected to be called with reloader path as first arg", args)
 		os.Exit(1)
 	}
-	action, _ := strings.CutPrefix(args[1], "--")
-	path := args[2]
+	if args[1] != "--bindir" {
+		fmt.Println("expected --bindir as second arg", args)
+		os.Exit(1)
+	}
+	action, _ := strings.CutPrefix(args[3], "--")
+	path := args[4]
 
 	params, ok := tests[path]
 	if !ok {


### PR DESCRIPTION

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

Depending on the installation type of FRR, `vtysh` binary and `frr-reload.py` script can be in different locations.

Make the paths configurable via CLI arguments.
Also, pass the `--bindir` argument to frr-reload.py, in order to make it find the right vtysh binary.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Reloader path arguments for frr-reload.py and vtysh
```
