### PR TITLE
Set veth MTU based on underlay NIC for VXLan entry points

### DIFF
--- a/hack/integration_tests.sh
+++ b/hack/integration_tests.sh
@@ -47,7 +47,6 @@ echo "OVS is ready"
 ovs-vsctl show
 
 umask 0
-shift # skip container image name
 for test_bin in "$@"; do
     echo "Running $test_bin..."
     if "$test_bin" -help 2>&1 | grep -q ginkgo; then

--- a/internal/hostnetwork/link_properties.go
+++ b/internal/hostnetwork/link_properties.go
@@ -121,6 +121,21 @@ func linkSetUp(l netlink.Link) error {
 	return netlink.LinkSetUp(l)
 }
 
+// linkSetMTU sets the MTU on the link only if it differs from the desired value.
+// This avoids unnecessary RTM_NEWLINK events that can cause FRR to flush neighbor entries.
+func linkSetMTU(l netlink.Link, mtu int) error {
+	currentLink, err := netlink.LinkByIndex(l.Attrs().Index)
+	if err != nil {
+		return fmt.Errorf("linkSetMTU: failed to get link by index: %w", err)
+	}
+
+	if currentLink.Attrs().MTU == mtu {
+		return nil
+	}
+
+	return netlink.LinkSetMTU(l, mtu)
+}
+
 // linkSetMaster sets the master of a link only if it's not already set to the desired master.
 // This avoids unnecessary RTM_NEWLINK events that can cause FRR to flush neighbor entries.
 func linkSetMaster(link, master netlink.Link) error {

--- a/internal/hostnetwork/underlay.go
+++ b/internal/hostnetwork/underlay.go
@@ -133,6 +133,7 @@ func moveUnderlayInterface(ctx context.Context, underlayInterface string, ns net
 		if err := netlink.LinkSetUp(underlay); err != nil {
 			return fmt.Errorf("could not set link up for VRF %s: %v", underlay.Attrs().Name, err)
 		}
+
 		return nil
 	}); err != nil {
 		return err
@@ -163,33 +164,66 @@ func HasUnderlayInterface(namespace string) (bool, error) {
 // findInterfaceWithIP retrieves the interface assigned to the given ip
 // in the given network ns.
 func findInterfaceWithIP(ns netns.NsHandle, ip string) (string, error) {
-	res := ""
+	linkName := ""
 	err := netnamespace.In(ns, func() error {
-		links, err := netlink.LinkList()
+		l, err := findLinkWithIP(ip)
 		if err != nil {
-			return fmt.Errorf("failed to list links: %w", err)
+			return err
 		}
-		for _, l := range links {
-			addr, _ := netlink.AddrList(l, netlink.FAMILY_ALL)
-			slog.Debug("find underlay", "checking link", l.Attrs().Name, "addresses", addr)
-			hasIP, err := interfaceHasIP(l, ip)
-			if err != nil {
-				return err
-			}
-			if hasIP {
-				res = l.Attrs().Name
-				return nil
-			}
+		if l == nil {
+			return nil
 		}
+		linkName = l.Attrs().Name
 		return nil
 	})
 	if err != nil {
 		return "", err
 	}
-	if res != "" {
-		slog.Debug("returning found has ip", "res", res)
-		return res, nil
+	return linkName, nil
+}
+
+// findUnderlayMTU retrieve the underlay interface MTU, it finds the underlay
+// interface by looking with a link with the underlay special IP
+func findUnderlayMTU(ns netns.NsHandle) (int, error) {
+	underlayMTU := 0
+	err := netnamespace.In(ns, func() error {
+		underlayLink, err := findLinkWithIP(underlayInterfaceSpecialAddr)
+		if err != nil {
+			return err
+		}
+		if underlayLink == nil {
+			slog.Info("no underlay link found when finding MTU", "underlay address", underlayInterfaceSpecialAddr)
+
+			return nil
+		}
+		underlayMTU = underlayLink.Attrs().MTU
+		return nil
+
+	})
+	if err != nil {
+		return 0, err
+	}
+	return underlayMTU, nil
+}
+
+// findLinkWithIP retrieves the link assigned to the given ip.
+func findLinkWithIP(ip string) (netlink.Link, error) {
+	links, err := netlink.LinkList()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list links: %w", err)
+	}
+	for _, l := range links {
+		addr, _ := netlink.AddrList(l, netlink.FAMILY_ALL)
+		slog.Debug("find underlay", "checking link", l.Attrs().Name, "addresses", addr)
+		hasIP, err := interfaceHasIP(l, ip)
+		if err != nil {
+			return nil, err
+		}
+		if hasIP {
+			slog.Debug("returning found has ip", "res", l)
+			return l, nil
+		}
 	}
 	slog.Debug("returning not found")
-	return "", nil
+	return nil, nil
 }

--- a/internal/hostnetwork/vni.go
+++ b/internal/hostnetwork/vni.go
@@ -18,6 +18,16 @@ import (
 	"github.com/vishvananda/netns"
 )
 
+const (
+	// VXLanOverhead is the number of bytes added by VXLan encapsulation.
+	VXLanOverhead = 50
+
+	// MinVethMTU is the minimum MTU we will set on the veth.
+	// 1280 is the IPv6 minimum MTU (RFC 8200); the kernel will reject
+	// or disable IPv6 on the link below this.
+	MinVethMTU = 1280
+)
+
 type VNIParams struct {
 	VRF           string `json:"vrf"`
 	TargetNS      string `json:"targetns"`
@@ -105,16 +115,32 @@ func SetupL3VNI(ctx context.Context, params L3VNIParams) error {
 	if errors.As(err, &netlink.LinkNotFoundError{}) {
 		return fmt.Errorf("SetupL3VNI: host veth %s does not exist, cannot setup L3 VNI", vethNames.HostSide)
 	}
+	if err != nil {
+		return fmt.Errorf("SetupL3VNI: failed to get host veth %s: %w", vethNames.HostSide, err)
+	}
 
 	err = assignIPsToInterface(hostVeth, params.HostVeth.HostIPv4, params.HostVeth.HostIPv6)
 	if err != nil {
 		return fmt.Errorf("failed to assign IPs to host veth: %w", err)
 	}
 
+	underlayMTU, err := findUnderlayMTU(ns)
+	if err != nil {
+		return fmt.Errorf("could not find underlay MTU: %w", err)
+	}
+
+	if err := setVethMTUForVXLAN(hostVeth, underlayMTU); err != nil {
+		return fmt.Errorf("SetupL3VNI: failed to set MTU on host veth %s: %w", vethNames.HostSide, err)
+	}
+
 	if err := netnamespace.In(ns, func() error {
 		peVeth, err := netlink.LinkByName(vethNames.NamespaceSide)
 		if err != nil {
 			return fmt.Errorf("could not find peer veth %s in namespace %s: %w", vethNames.NamespaceSide, params.TargetNS, err)
+		}
+
+		if err := setVethMTUForVXLAN(peVeth, underlayMTU); err != nil {
+			return fmt.Errorf("failed to set MTU on pe veth %s: %w", vethNames.NamespaceSide, err)
 		}
 
 		vrf, err := netlink.LinkByName(params.VRF)
@@ -136,6 +162,7 @@ func SetupL3VNI(ctx context.Context, params L3VNIParams) error {
 	}); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -174,6 +201,15 @@ func SetupL2VNI(ctx context.Context, params L2VNIParams) error {
 	}
 	slog.Info("SetupL2VNI: found host veth", "name", vethNames.HostSide, "index", hostVeth.Attrs().Index)
 
+	underlayMTU, err := findUnderlayMTU(ns)
+	if err != nil {
+		return fmt.Errorf("could not find underlay MTU: %w", err)
+	}
+
+	if err := setVethMTUForVXLAN(hostVeth, underlayMTU); err != nil {
+		return fmt.Errorf("SetupL2VNI: failed to set MTU on host veth %s: %w", vethNames.HostSide, err)
+	}
+
 	if params.HostMaster != nil {
 		if err := setupHostMaster(ctx, params, hostVeth); err != nil {
 			return err
@@ -181,34 +217,43 @@ func SetupL2VNI(ctx context.Context, params L2VNIParams) error {
 	}
 
 	if err := netnamespace.In(ns, func() error {
-		peVeth, err := netlink.LinkByName(vethNames.NamespaceSide)
-		if err != nil {
-			return fmt.Errorf("could not find peer veth %s in namespace %s: %w", vethNames.NamespaceSide, params.TargetNS, err)
-		}
-		name := BridgeName(params.VNI)
-		bridge, err := netlink.LinkByName(name)
-		if err != nil {
-			return fmt.Errorf("could not find bridge %s in namespace %s: %w", name, params.TargetNS, err)
-		}
-		if err := linkSetMaster(peVeth, bridge); err != nil {
-			return fmt.Errorf("failed to set bridge %s as master of pe veth %s: %w", name, peVeth.Attrs().Name, err)
-		}
-		if len(params.L2GatewayIPs) > 0 {
-			for _, ip := range params.L2GatewayIPs {
-				if err := assignIPToInterface(bridge, ip); err != nil {
-					return fmt.Errorf("failed to assign L2 gateway IP %s to bridge %s: %w", ip, name, err)
-				}
-			}
-
-			// setting up the same mac address for all the nodes for distributed gateway
-			if err := ensureBridgeFixedMacAddress(bridge, params.VNI); err != nil {
-				return fmt.Errorf("failed to set bridge mac address %s: %v", name, err)
-			}
-		}
-
-		return nil
+		return setupL2VNIRouterSide(params, vethNames.NamespaceSide, underlayMTU)
 	}); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func setupL2VNIRouterSide(params L2VNIParams, vethName string, underlayMTU int) error {
+	peVeth, err := netlink.LinkByName(vethName)
+	if err != nil {
+		return fmt.Errorf("could not find peer veth %s in namespace %s: %w", vethName, params.TargetNS, err)
+	}
+
+	if err := setVethMTUForVXLAN(peVeth, underlayMTU); err != nil {
+		return fmt.Errorf("failed to set MTU on pe veth %s: %w", vethName, err)
+	}
+
+	name := BridgeName(params.VNI)
+	bridge, err := netlink.LinkByName(name)
+	if err != nil {
+		return fmt.Errorf("could not find bridge %s in namespace %s: %w", name, params.TargetNS, err)
+	}
+	if err := linkSetMaster(peVeth, bridge); err != nil {
+		return fmt.Errorf("failed to set bridge %s as master of pe veth %s: %w", name, peVeth.Attrs().Name, err)
+	}
+	if len(params.L2GatewayIPs) > 0 {
+		for _, ip := range params.L2GatewayIPs {
+			if err := assignIPToInterface(bridge, ip); err != nil {
+				return fmt.Errorf("failed to assign L2 gateway IP %s to bridge %s: %w", ip, name, err)
+			}
+		}
+
+		// setting up the same mac address for all the nodes for distributed gateway
+		if err := ensureBridgeFixedMacAddress(bridge, params.VNI); err != nil {
+			return fmt.Errorf("failed to set bridge mac address %s: %v", name, err)
+		}
 	}
 	return nil
 }
@@ -622,6 +667,25 @@ func hostMaster(vni int, m HostMaster) (netlink.Link, error) {
 		return nil, fmt.Errorf("getHostMaster: failed to create host bridge %d: %w", vni, err)
 	}
 	return bridge, nil
+}
+
+// setVethMTUForVXLAN sets the MTU on a veth interface to account for VXLan overhead.
+// If the underlay MTU is not found, or if the resulting MTU would be too small,
+// the MTU is left unchanged.
+func setVethMTUForVXLAN(link netlink.Link, underlayMTU int) error {
+	if underlayMTU == 0 {
+		slog.Debug("No underlay MTU found, leaving veth MTU at default", "veth", link.Attrs().Name)
+		return nil
+	}
+	targetMTU := underlayMTU - VXLanOverhead
+	if targetMTU <= MinVethMTU {
+		slog.Warn("Calculated veth MTU is too low, leaving at default",
+			"veth", link.Attrs().Name,
+			"underlayMTU", underlayMTU,
+			"calculatedMTU", targetMTU)
+		return nil
+	}
+	return linkSetMTU(link, targetMTU)
 }
 
 // assignIPsToInterface assigns both IPv4 and IPv6 addresses to an interface.

--- a/internal/hostnetwork/vni_test.go
+++ b/internal/hostnetwork/vni_test.go
@@ -249,6 +249,69 @@ var _ = Describe("L3 VNI configuration", func() {
 		_, err = netlink.LinkByName(vethNames.HostSide)
 		Expect(errors.As(err, &netlink.LinkNotFoundError{})).To(BeTrue(), "host veth should not exist when HostVeth is nil")
 	})
+
+	It("should set veth MTU to underlay MTU minus VXLan overhead when an underlay interface is configured", func() {
+		const underlayMTU = 9000
+		setupFakeUnderlay(testNS, "testunderlayl3", underlayMTU)
+
+		params := L3VNIParams{
+			VNIParams: VNIParams{
+				VRF:       "testred",
+				TargetNS:  testNSPath(),
+				VTEPIP:    "192.170.0.9/32",
+				VNI:       100,
+				VXLanPort: 4789,
+			},
+			HostVeth: &Veth{
+				HostIPv4: "192.168.9.1/32",
+				NSIPv4:   "192.168.9.0/32",
+			},
+		}
+
+		err := SetupL3VNI(context.Background(), params)
+		Expect(err).NotTo(HaveOccurred())
+
+		expectedMTU := underlayMTU - VXLanOverhead
+		Eventually(func(g Gomega) {
+			validateVethMTU(g, params.VNIParams, expectedMTU)
+			_ = netnamespace.In(testNS, func() error {
+				validateNSVethMTU(g, params.VNIParams, expectedMTU)
+				return nil
+			})
+		}, 30*time.Second, 1*time.Second).Should(Succeed())
+	})
+
+	It("should leave veth MTU at default when no underlay interface is configured", func() {
+		// No fake underlay is set up here, so findUnderlayMTU returns 0
+		// and setVethMTUForVXLAN must leave the veth MTU untouched. The
+		// host-side veth is not enslaved to any bridge in the L3 path
+		// (it is only attached to a VRF in the target ns), so the host
+		// leg's MTU reflects only what the code under test set.
+		params := L3VNIParams{
+			VNIParams: VNIParams{
+				VRF:       "testred",
+				TargetNS:  testNSPath(),
+				VTEPIP:    "192.170.0.9/32",
+				VNI:       100,
+				VXLanPort: 4789,
+			},
+			HostVeth: &Veth{
+				HostIPv4: "192.168.9.1/32",
+				NSIPv4:   "192.168.9.0/32",
+			},
+		}
+
+		err := SetupL3VNI(context.Background(), params)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func(g Gomega) {
+			validateVethMTU(g, params.VNIParams, defaultVethMTU)
+			_ = netnamespace.In(testNS, func() error {
+				validateNSVethMTU(g, params.VNIParams, defaultVethMTU)
+				return nil
+			})
+		}, 30*time.Second, 1*time.Second).Should(Succeed())
+	})
 })
 
 var _ = Describe("L2 VNI configuration", func() {
@@ -444,6 +507,68 @@ var _ = Describe("L2 VNI configuration", func() {
 			},
 		}),
 	)
+
+	It("should set veth MTU to underlay MTU minus VXLan overhead when an underlay interface is configured", func() {
+		const underlayMTU = 9000
+		setupFakeUnderlay(testNS, "testunderlayl2", underlayMTU)
+
+		params := L2VNIParams{
+			VNIParams: VNIParams{
+				VRF:       "testred",
+				TargetNS:  testNSPath(),
+				VTEPIP:    "192.170.0.9/32",
+				VNI:       100,
+				VXLanPort: 4789,
+			},
+			L2GatewayIPs: []string{"192.168.1.0/24"},
+			HostMaster: &HostMaster{
+				Name: bridgeName,
+				Type: BridgeLinkType,
+			},
+		}
+
+		err := SetupL2VNI(context.Background(), params)
+		Expect(err).NotTo(HaveOccurred())
+
+		expectedMTU := underlayMTU - VXLanOverhead
+		Eventually(func(g Gomega) {
+			validateVethMTU(g, params.VNIParams, expectedMTU)
+			_ = netnamespace.In(testNS, func() error {
+				validateNSVethMTU(g, params.VNIParams, expectedMTU)
+				return nil
+			})
+		}, 30*time.Second, 1*time.Second).Should(Succeed())
+	})
+
+	It("should leave veth MTU at default when no underlay interface is configured", func() {
+		// No fake underlay is set up here, so findUnderlayMTU returns 0
+		// and setVethMTUForVXLAN must leave the veth MTU untouched.
+		// HostMaster is intentionally omitted so the host veth is not
+		// enslaved to a bridge — Linux bridges auto-clamp their MTU to
+		// the smallest member, which would couple this assertion to
+		// bridge default MTU rather than to the code under test.
+		params := L2VNIParams{
+			VNIParams: VNIParams{
+				VRF:       "testred",
+				TargetNS:  testNSPath(),
+				VTEPIP:    "192.170.0.9/32",
+				VNI:       100,
+				VXLanPort: 4789,
+			},
+			L2GatewayIPs: []string{"192.168.1.0/24"},
+		}
+
+		err := SetupL2VNI(context.Background(), params)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func(g Gomega) {
+			validateVethMTU(g, params.VNIParams, defaultVethMTU)
+			_ = netnamespace.In(testNS, func() error {
+				validateNSVethMTU(g, params.VNIParams, defaultVethMTU)
+				return nil
+			})
+		}, 30*time.Second, 1*time.Second).Should(Succeed())
+	})
 })
 
 func validateL3HostLeg(g Gomega, params L3VNIParams) {
@@ -688,4 +813,50 @@ func validateBridgeMacAddress(g Gomega, bridge netlink.Link, vni int) {
 	actualMac := bridge.Attrs().HardwareAddr
 	g.Expect(actualMac).NotTo(BeNil(), "bridge should have a MAC address")
 	g.Expect(actualMac).To(Equal(expectedMac), "bridge MAC address should be %v for VNI %d", expectedMac, vni)
+}
+
+func validateVethMTU(g Gomega, params VNIParams, expectedMTU int) {
+	vethNames := vethNamesFromVNI(params.VNI)
+	hostLeg, err := netlink.LinkByName(vethNames.HostSide)
+	g.Expect(err).NotTo(HaveOccurred(), "host veth not found %q", vethNames.HostSide)
+	g.Expect(hostLeg.Attrs().MTU).To(Equal(expectedMTU),
+		"host veth MTU should be %d, got %d", expectedMTU, hostLeg.Attrs().MTU)
+}
+
+func validateNSVethMTU(g Gomega, params VNIParams, expectedMTU int) {
+	vethNames := vethNamesFromVNI(params.VNI)
+	peLeg, err := netlink.LinkByName(vethNames.NamespaceSide)
+	g.Expect(err).NotTo(HaveOccurred(), "pe veth not found %q", vethNames.NamespaceSide)
+	g.Expect(peLeg.Attrs().MTU).To(Equal(expectedMTU),
+		"pe veth MTU should be %d, got %d", expectedMTU, peLeg.Attrs().MTU)
+}
+
+// defaultVethMTU is the MTU veth pairs receive when no explicit MTU is set.
+const defaultVethMTU = 1500
+
+// setupFakeUnderlay creates a dummy interface inside the given namespace with
+// the underlay special address and a configurable MTU, so that findUnderlayMTU
+// can locate it. It is intended for unit tests exercising the MTU propagation
+// behavior of SetupL2VNI / SetupL3VNI.
+func setupFakeUnderlay(ns netns.NsHandle, name string, mtu int) {
+	err := netnamespace.In(ns, func() error {
+		dummy := &netlink.Dummy{
+			LinkAttrs: netlink.LinkAttrs{
+				Name: name,
+				MTU:  mtu,
+			},
+		}
+		if err := netlink.LinkAdd(dummy); err != nil {
+			return fmt.Errorf("failed to add fake underlay dummy %s: %w", name, err)
+		}
+		link, err := netlink.LinkByName(name)
+		if err != nil {
+			return fmt.Errorf("failed to get fake underlay dummy %s: %w", name, err)
+		}
+		if err := assignIPToInterface(link, underlayInterfaceSpecialAddr); err != nil {
+			return fmt.Errorf("failed to assign underlay special addr to %s: %w", name, err)
+		}
+		return nil
+	})
+	Expect(err).NotTo(HaveOccurred(), "failed to set up fake underlay")
 }

--- a/website/content/docs/configuration/evpn.md
+++ b/website/content/docs/configuration/evpn.md
@@ -153,10 +153,11 @@ When you create or update VNI configurations, OpenPERouter automatically:
 
 1. **Creates Network Interfaces**: Sets up VXLAN interface and Linux VRF named after the VNI
 2. **Establishes Connectivity**: Creates veth pair and moves one end to the router's namespace
-3. **Assigns IP Addresses**: Allocates IPs from the `localcidr` range:
+3. **Adjusts Veth MTU**: Sets the MTU on both veth legs to the underlay NIC's MTU minus 50 bytes to account for VXLan encapsulation overhead
+4. **Assigns IP Addresses**: Allocates IPs from the `localcidr` range:
    - Router side: First IP in the CIDR (e.g., `192.169.11.1`)
    - Host side: Each node gets a free IP in the CIDR, starting from the second (e.g., `192.169.11.15`)
-4. **Creates BGP Session**: Opens BGP session between router and host using the specified ASNs
+5. **Creates BGP Session**: Opens BGP session between router and host using the specified ASNs
 
 ## L2VNI Configuration
 
@@ -198,9 +199,10 @@ When you create or update VNI configurations, OpenPERouter automatically:
 
 1. **Creates Network Interfaces**: Sets up VXLAN interface and Linux VRF named after the VNI
 2. **Establishes Connectivity**: Creates veth pair and moves one end to the router's namespace
-3. **Enslaves the veth**: the veth is connected to the bridge corresponding to the l2 domain
-4. **Optionally creates a bridge on the host**: if hostmaster.autocreate is set to `true`
-5. **Optionally connects the host veth to the bridge on the host**: if hostmaster.autocreate is set to `true` or name
+3. **Adjusts Veth MTU**: Sets the MTU on both veth legs to the underlay NIC's MTU minus 50 bytes to account for VXLan encapsulation overhead
+4. **Enslaves the veth**: the veth is connected to the bridge corresponding to the l2 domain
+5. **Optionally creates a bridge on the host**: if hostmaster.autocreate is set to `true`
+6. **Optionally connects the host veth to the bridge on the host**: if hostmaster.autocreate is set to `true` or name
 is set
 
 ## Per-Node Configuration


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind feature

**What this PR does / why we need it**:

VXLan encapsulation adds 50 bytes of overhead to each frame. Without
adjusting the MTU of the veth pairs used as VXLan entry points, frames
at the underlay MTU limit will be fragmented or dropped.

This PR automatically sets the MTU of both veth legs (host and namespace
side) to the underlay NIC MTU minus 50 bytes for both L2 and L3 VNI
setups. The underlay MTU is resolved after the underlay is configured by
looking up the interface with the special marker address. When the
underlay MTU cannot be determined (e.g. Multus-managed underlay), the
configuration is skipped gracefully.

Fixes #291

**Special notes for your reviewer**:

The MTU setting is best-effort: when the underlay interface cannot be
identified (e.g. Multus-managed underlay without the marker address),
the veth MTU is left at the default. This avoids breaking existing
setups where the underlay is managed externally.

**Release note**:

```release-note
Automatically set veth MTU to underlay NIC MTU minus 50 bytes to
account for VXLan encapsulation overhead, preventing frame
fragmentation at MTU boundaries.
```