### PR TITLE
cleanup: Fix `deploy-helm` rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,9 +252,9 @@ deploy-controller-cluster: kubectl kustomize ## Deploy controller to a specific 
 
 .PHONY: deploy-helm
 deploy-helm: helm kind deploy-cluster
-	$(KUBECTL) -n ${NAMESPACE} delete ds controller || true
-	$(KUBECTL) -n ${NAMESPACE} delete ds router || true
-	$(KUBECTL) -n ${NAMESPACE} delete deployment nodemarker || true
+	$(KUBECTL) -n ${NAMESPACE} delete ds openperouter-controller || true
+	$(KUBECTL) -n ${NAMESPACE} delete ds openperouter-router || true
+	$(KUBECTL) -n ${NAMESPACE} delete deployment openperouter-nodemarker || true
 	$(KUBECTL) create ns ${NAMESPACE} || true
 	$(KUBECTL) label ns ${NAMESPACE} pod-security.kubernetes.io/enforce=privileged
 	$(HELM) install openperouter charts/openperouter/ --set openperouter.image.tag=${IMG_TAG} \


### PR DESCRIPTION
`deploy-helm` Makefile rule deletes the previous installation by targeting the wrong daemonset and deployment names.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
