### PR TITLE
Allow raw FRR configuration without an underlay

### DIFF
--- a/internal/conversion/frr_conversion.go
+++ b/internal/conversion/frr_conversion.go
@@ -32,11 +32,22 @@ func APItoFRR(config ApiConfigData, nodeIndex int, logLevel string) (frr.Config,
 	if len(config.Underlays) > 1 {
 		return frr.Config{}, errors.New("multiple underlays defined")
 	}
-	if len(config.Underlays) == 0 {
-		return frr.Config{}, FRREmptyConfigError("no underlays provided")
-	}
 	if len(config.L3Passthrough) > 1 {
 		return frr.Config{}, errors.New("multiple passthrough defined, can have only one")
+	}
+
+	rawSnippets := rawConfigSnippets(config.RawFRRConfigs)
+	// if we have raw config, we apply it regardless of the rest of the configuration
+	if len(rawSnippets) > 0 && len(config.Underlays) == 0 {
+		slog.Info("no underlay provided, applying raw configuration only")
+		return frr.Config{
+			Loglevel:  logLevel,
+			RawConfig: rawSnippets,
+		}, nil
+	}
+
+	if len(config.Underlays) == 0 {
+		return frr.Config{}, FRREmptyConfigError("no underlays provided")
 	}
 
 	underlay := config.Underlays[0]
@@ -79,7 +90,6 @@ func APItoFRR(config ApiConfigData, nodeIndex int, logLevel string) (frr.Config,
 	if len(config.L3VNIs) > 0 && underlay.Spec.EVPN == nil {
 		return frr.Config{}, fmt.Errorf("EVPN configuration is required when L3 VNIs are defined")
 	}
-	rawSnippets := rawConfigSnippets(config.RawFRRConfigs)
 
 	if underlay.Spec.EVPN == nil {
 		return frr.Config{

--- a/internal/conversion/frr_conversion_test.go
+++ b/internal/conversion/frr_conversion_test.go
@@ -774,3 +774,124 @@ func TestAPItoFRRRawConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestAPItoFRRRawConfigWithoutUnderlay(t *testing.T) {
+	rawConfigs := []v1alpha1.RawFRRConfig{
+		{
+			Spec: v1alpha1.RawFRRConfigSpec{
+				Priority:  10,
+				RawConfig: "ip prefix-list test seq 10 permit 10.0.0.0/8",
+			},
+		},
+		{
+			Spec: v1alpha1.RawFRRConfigSpec{
+				Priority:  5,
+				RawConfig: "route-map test permit 10",
+			},
+		},
+	}
+
+	wantConfig := frr.Config{
+		Loglevel: "debug",
+		RawConfig: []frr.RawFRRSnippet{
+			{Priority: 5, Config: "route-map test permit 10"},
+			{Priority: 10, Config: "ip prefix-list test seq 10 permit 10.0.0.0/8"},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		l3VNIs        []v1alpha1.L3VNI
+		l3Passthrough []v1alpha1.L3Passthrough
+	}{
+		{
+			name: "raw config only",
+		},
+		{
+			name: "raw config with L3VNIs ignores VNIs",
+			l3VNIs: []v1alpha1.L3VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni1"},
+					Spec: v1alpha1.L3VNISpec{
+						HostSession: &v1alpha1.HostSession{
+							ASN: 65000,
+							LocalCIDR: v1alpha1.LocalCIDRConfig{
+								IPv4: "192.168.2.0/24",
+							},
+							HostASN: 65001,
+						},
+						VRF: "vrf1",
+						VNI: 200,
+					},
+				},
+			},
+		},
+		{
+			name: "raw config with L3Passthrough ignores passthrough",
+			l3Passthrough: []v1alpha1.L3Passthrough{
+				{
+					Spec: v1alpha1.L3PassthroughSpec{
+						HostSession: v1alpha1.HostSession{
+							HostASN: 65001,
+							ASN:     65000,
+							LocalCIDR: v1alpha1.LocalCIDRConfig{
+								IPv4: "192.168.2.0/24",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "raw config with both L3VNIs and L3Passthrough ignores both",
+			l3VNIs: []v1alpha1.L3VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni1"},
+					Spec: v1alpha1.L3VNISpec{
+						HostSession: &v1alpha1.HostSession{
+							ASN: 65000,
+							LocalCIDR: v1alpha1.LocalCIDRConfig{
+								IPv4: "192.168.2.0/24",
+							},
+							HostASN: 65001,
+						},
+						VRF: "vrf1",
+						VNI: 200,
+					},
+				},
+			},
+			l3Passthrough: []v1alpha1.L3Passthrough{
+				{
+					Spec: v1alpha1.L3PassthroughSpec{
+						HostSession: v1alpha1.HostSession{
+							HostASN: 65001,
+							ASN:     65000,
+							LocalCIDR: v1alpha1.LocalCIDRConfig{
+								IPv4: "192.168.2.0/24",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			apiConfig := ApiConfigData{
+				Underlays:     []v1alpha1.Underlay{},
+				RawFRRConfigs: rawConfigs,
+				L3VNIs:        tt.l3VNIs,
+				L3Passthrough: tt.l3Passthrough,
+			}
+			got, err := APItoFRR(apiConfig, 0, "debug")
+			if err != nil {
+				t.Fatalf("APItoFRR() unexpected error: %v", err)
+			}
+
+			if !cmp.Equal(got, wantConfig) {
+				t.Errorf("APItoFRR() diff: %s", cmp.Diff(got, wantConfig))
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

When only raw FRR config snippets are provided and no underlay is defined, return a valid config with just the raw snippets instead of failing. This enables standalone raw configuration use cases.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Don't fail when only rawConfig is provided.
```
