### PR TITLE
Bump kind to v0.31.0 and drop deprecated containerdConfigPatches

### DIFF
--- a/.github/workflows/build-kind-node-image.yaml
+++ b/.github/workflows/build-kind-node-image.yaml
@@ -14,9 +14,9 @@ on:
   workflow_dispatch:
     inputs:
       kind_version:
-        description: 'Kind node version to use as base (e.g., v1.32.2)'
+        description: 'Kind node version to use as base (e.g., v1.32.11)'
         required: false
-        default: 'v1.32.2'
+        default: 'v1.32.11'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -47,7 +47,7 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "version=${{ github.event.inputs.kind_version }}" >> $GITHUB_OUTPUT
           else
-            echo "version=v1.32.2" >> $GITHUB_OUTPUT
+            echo "version=v1.32.11" >> $GITHUB_OUTPUT
           fi
 
       - name: Build image for platform

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ KUSTOMIZE_VERSION ?= v5.0.0
 CONTROLLER_TOOLS_VERSION ?= v0.19.0
 KUBECTL_VERSION ?= v1.27.0
 GINKGO_VERSION ?= $(shell go list -m -f '{{.Version}}' github.com/onsi/ginkgo/v2)
-KIND_VERSION ?= v0.27.0
+KIND_VERSION ?= v0.31.0
 KIND_CLUSTER_NAME ?= pe-kind
 HELM_VERSION ?= v3.12.3
 HELM_DOCS_VERSION ?= v1.10.0
@@ -167,7 +167,7 @@ APIDOCSGEN_VERSION ?= v0.3.0
 HUGO_VERSION ?= v0.147.8
 
 # Kind node image configuration
-KIND_NODE_VERSION ?= v1.32.2
+KIND_NODE_VERSION ?= v1.32.11
 KIND_NODE_IMG_REPO ?= quay.io/openperouter
 KIND_NODE_IMG_NAME ?= kind-node-openperouter
 KIND_NODE_IMG_TAG ?= $(KIND_NODE_VERSION)

--- a/clab/tools/generate_kind_config/kind_template/kind-configuration-registry.yaml.template
+++ b/clab/tools/generate_kind_config/kind_template/kind-configuration-registry.yaml.template
@@ -15,7 +15,3 @@ networking:
   disableDefaultCNI: true
 {{- end }}
   ipFamily: dual
-containerdConfigPatches:
-- |-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
-    endpoint = ["http://kind-registry:5000"]

--- a/hack/kind-node-image/Dockerfile
+++ b/hack/kind-node-image/Dockerfile
@@ -1,7 +1,7 @@
 # Custom Kind Node Image with OpenVSwitch
 # Based on official kindest/node image with OVS pre-installed for OpenPERouter
 
-ARG KIND_NODE_VERSION=v1.32.2
+ARG KIND_NODE_VERSION=v1.32.11
 FROM kindest/node:${KIND_NODE_VERSION}
 
 # Re-declare ARG to make it available after FROM

--- a/hack/kind-node-image/build.sh
+++ b/hack/kind-node-image/build.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # Configuration - can be overridden via environment variables
-KIND_NODE_VERSION="${KIND_NODE_VERSION:-v1.32.2}"
+KIND_NODE_VERSION="${KIND_NODE_VERSION:-v1.32.11}"
 IMG_REPO="${IMG_REPO:-quay.io/openperouter}"
 IMG_NAME="${IMG_NAME:-kind-node-openperouter}"
 IMG_TAG="${IMG_TAG:-${KIND_NODE_VERSION}}"

--- a/hack/kind/config_with_registry.yaml
+++ b/hack/kind/config_with_registry.yaml
@@ -5,7 +5,3 @@ networking:
 nodes:
 - role: control-plane
 - role: worker
-containerdConfigPatches:
-- |-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
-    endpoint = ["http://kind-registry:5000"]


### PR DESCRIPTION


<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

kindest/node:v1.32.11 ships containerd v2.2.0 which no longer allows registry.mirrors when config_path is set. The old containerdConfigPatches broke the CRI plugin, preventing kubelet from starting.

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
