### PR TITLE
E2E passthrough: remove duplicate passthrough FRR config

### DIFF
--- a/e2etests/tests/evpn_routes.go
+++ b/e2etests/tests/evpn_routes.go
@@ -196,16 +196,13 @@ var _ = Describe("Routes between bgp and the fabric", Ordered, func() {
 	Context("with vnis and frr-k8s", func() {
 		ShouldExist := true
 		frrk8sPods := []*corev1.Pod{}
-		frrK8sConfigRed, err := frrk8s.ConfigFromHostSession(*vniRed.Spec.HostSession, vniRed.Name)
-		if err != nil {
-			panic(err)
-		}
-		frrK8sConfigBlue, err := frrk8s.ConfigFromHostSession(*vniBlue.Spec.HostSession, vniBlue.Name)
-		if err != nil {
-			panic(err)
-		}
 
 		BeforeEach(func() {
+			frrK8sConfigRed, err := frrk8s.ConfigFromHostSession(*vniRed.Spec.HostSession, vniRed.Name)
+			Expect(err).NotTo(HaveOccurred())
+			frrK8sConfigBlue, err := frrk8s.ConfigFromHostSession(*vniBlue.Spec.HostSession, vniBlue.Name)
+			Expect(err).NotTo(HaveOccurred())
+
 			frrk8sPods, err = frrk8s.Pods(cs)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/e2etests/tests/passthrough_routes.go
+++ b/e2etests/tests/passthrough_routes.go
@@ -96,16 +96,11 @@ var _ = Describe("Routes between bgp and the fabric", Label("passthrough"), Orde
 	Context("with passthrough and frr-k8s", func() {
 		ShouldExist := true
 		frrk8sPods := []*corev1.Pod{}
-		frrK8sConfigRed, err := frrk8s.ConfigFromHostSession(passthrough.Spec.HostSession, passthrough.Name)
-		if err != nil {
-			panic(err)
-		}
-		frrK8sConfigBlue, err := frrk8s.ConfigFromHostSession(passthrough.Spec.HostSession, passthrough.Name)
-		if err != nil {
-			panic(err)
-		}
 
 		BeforeEach(func() {
+			frrK8sPassthroughConfigs, err := frrk8s.ConfigFromHostSession(passthrough.Spec.HostSession, passthrough.Name)
+			Expect(err).NotTo(HaveOccurred())
+
 			frrk8sPods, err = frrk8s.Pods(cs)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -115,7 +110,7 @@ var _ = Describe("Routes between bgp and the fabric", Label("passthrough"), Orde
 				L3Passthrough: []v1alpha1.L3Passthrough{
 					passthrough,
 				},
-				FRRConfigurations: append(frrK8sConfigRed, frrK8sConfigBlue...),
+				FRRConfigurations: frrK8sPassthroughConfigs,
 			})
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
ConfigFromHostSession was called twice with the same arguments,
resulting in duplicated FRR configurations being appended together.

**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:

ConfigFromHostSession was called twice with the same arguments,
resulting in duplicated FRR configurations being appended together.

**Special notes for your reviewer**:

N/A

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Minor cleanup of L3Passthrough E2E test
```
