### PR TITLE
Fix default-container annotation to reference existing container name

### DIFF
--- a/charts/openperouter/templates/router.yaml
+++ b/charts/openperouter/templates/router.yaml
@@ -119,7 +119,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: router
+        kubectl.kubernetes.io/default-container: frr
         {{- if .Values.openperouter.multusNetworkAnnotation }}
         k8s.v1.cni.cncf.io/networks: {{ .Values.openperouter.multusNetworkAnnotation | quote }}
         {{- end }}

--- a/config/all-in-one/crio.yaml
+++ b/config/all-in-one/crio.yaml
@@ -1501,7 +1501,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: router
+        kubectl.kubernetes.io/default-container: frr
       labels:
         app: router
         control-plane: router

--- a/config/all-in-one/openpe.yaml
+++ b/config/all-in-one/openpe.yaml
@@ -1498,7 +1498,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: router
+        kubectl.kubernetes.io/default-container: frr
       labels:
         app: router
         control-plane: router

--- a/config/pods/perouter.yaml
+++ b/config/pods/perouter.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: router
+        kubectl.kubernetes.io/default-container: frr
       labels:
         control-plane: router
         app: router

--- a/operator/bindata/deployment/openperouter/templates/router.yaml
+++ b/operator/bindata/deployment/openperouter/templates/router.yaml
@@ -119,7 +119,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: router
+        kubectl.kubernetes.io/default-container: frr
         {{- if .Values.openperouter.multusNetworkAnnotation }}
         k8s.v1.cni.cncf.io/networks: {{ .Values.openperouter.multusNetworkAnnotation | quote }}
         {{- end }}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:


> Uncomment only one, leave it on its own line:
>

/kind bug

> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
The router pod has containers named "frr" and "reloader", but the default-container annotation incorrectly referenced "router" which does not exist.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Correct the router component default container name
```
