### PR TITLE
CI gating improvements

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -19,6 +19,93 @@ Also see [Claude.md](../Claude.md) for detailed Go style guidelines including:
 - Dependency management
 - Control flow recommendations
 
+### Unnecessary Comments
+Remove obvious comments that restate what the code already says. Comments should explain *why*, never *what*. AI-generated boilerplate comments are especially problematic — they add noise without value.
+
+**Bad:** `// Create the client` above `client := NewClient()`
+**Good:** `// Retry with a new client because FRR drops idle connections after 90s`
+
+If removing the comment wouldn't confuse a future reader, remove it.
+
+### Code Organization — Newspaper Structure
+Follow [newspaper code structure](https://kentcdodds.com/blog/newspaper-code-structure): public/exported functions at the top, private/utility functions at the bottom. Callers before callees. This makes files scannable — readers find the "what" first, the "how" below.
+
+- Exported methods and types go at the top of the file
+- Exception: `init()` functions go at the top, near package-level vars they initialize
+- Unexported helpers go at the bottom
+- When a function calls another function in the same file, the caller should appear above the callee
+
+### Flat Control Flow — Early Returns Over Nested Ifs
+Avoid complex nested `if` conditions. Especially if they include ors and mix ands and ors or negations.
+
+**Bad:** complex condition guarding a nested block inline
+```go
+if (gvk.Group == "" && gvk.Kind == "Service") || gvk.Kind == "Foo" {
+    // logic
+}
+```
+
+**Good:** extract the block into a function with early returns for each condition
+```go
+
+func isKindToSkip(gvk *gvk) bool {
+    if gvk.Kind == "Foo" {
+        return true
+    }
+    if gvk.Group == "" && gvk.Kind == "Service" {
+        return true
+    }
+    return false
+}
+```
+
+```go
+if isKindToSkip(gvk) {
+    // logic
+}
+```
+
+### Return Early — Avoid Intermediate Variables
+When each branch of a switch or if/else produces a complete result, return it directly instead of assigning to intermediate variables and returning at the end. This makes each branch self-contained and avoids tracking state across the function.
+
+**Bad:** accumulate into variables, return once at the end
+```go
+func bridgeName(spec BridgeSpec) string {
+    var name string
+    switch spec.Type {
+    case Linux:
+        name = spec.LinuxBridge.Name
+    case OVS:
+        name = spec.OVSBridge.Name
+    }
+    return name
+}
+```
+
+**Good:** return directly from each branch
+```go
+func bridgeName(spec BridgeSpec) string {
+    switch spec.Type {
+    case Linux:
+        return spec.LinuxBridge.Name
+    case OVS:
+        return spec.OVSBridge.Name
+    }
+    return ""
+}
+```
+
+### Simplification — Remove Unnecessary Wrappers
+Push back on overengineered solutions. If a wrapper, abstraction, or indirection doesn't earn its complexity, remove it.
+
+Watch for:
+- Wrapper functions that just forward to another function — let the consumer call the inner function directly
+- Methods that should be plain functions (no receiver state used)
+- Generic solutions for problems that only have one or two concrete cases
+- Premature abstractions ("in case we need to support X later")
+
+The test: if removing the abstraction makes the code shorter and equally clear, remove it.
+
 ## Code Review Focus Areas
 
 When reviewing code, pay special attention to:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  feature-needs-docs:
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'kind/feature')
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for website changes
+        run: |
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
+          if git diff --name-only "$BASE"..."$HEAD" | grep '^website/' | grep -qv 'api-reference\.md$'; then
+            echo "Website changes found."
+          else
+            echo "ERROR: PRs labeled kind/feature must include documentation updates under website/."
+            echo "Please add or update the relevant documentation."
+            exit 1
+          fi
+
   static-security-analysis:
     runs-on: ubuntu-22.04
     env:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ linters:
   default: none
   enable:
     - copyloopvar
+    - depguard
     - dupl
     - errcheck
     - forbidigo
@@ -25,6 +26,22 @@ linters:
     - unparam
     - unused
   settings:
+    depguard:
+      rules:
+        no-generic-packages:
+          deny:
+            - pkg: '*/utils'
+              desc: "avoid generic 'utils' packages — use descriptive package names instead"
+            - pkg: '*/util'
+              desc: "avoid generic 'util' packages — use descriptive package names instead"
+            - pkg: '*/common'
+              desc: "avoid generic 'common' packages — use descriptive package names instead"
+            - pkg: '*/lib'
+              desc: "avoid generic 'lib' packages — use descriptive package names instead"
+            - pkg: '*/misc'
+              desc: "avoid generic 'misc' packages — use descriptive package names instead"
+            - pkg: '*/helpers'
+              desc: "avoid generic 'helpers' packages — use descriptive package names instead"
     forbidigo:
       forbid:
         - pattern: 'time\.Sleep'
@@ -37,6 +54,8 @@ linters:
       rules:
         - name: comment-spacings
         - name: early-return
+        - name: var-naming
+        - name: unexported-return
   exclusions:
     generated: lax
     rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,12 +9,14 @@ linters:
     - errcheck
     - ginkgolinter
     - goconst
+    - gocognit
     - gocyclo
     - govet
     - ineffassign
     - lll
     - misspell
     - nakedret
+    - nestif
     - prealloc
     - revive
     - staticcheck
@@ -22,9 +24,14 @@ linters:
     - unparam
     - unused
   settings:
+    gocognit:
+      min-complexity: 30
+    nestif:
+      min-complexity: 3
     revive:
       rules:
         - name: comment-spacings
+        - name: early-return
   exclusions:
     generated: lax
     rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - copyloopvar
     - dupl
     - errcheck
+    - forbidigo
     - ginkgolinter
     - goconst
     - gocognit
@@ -24,6 +25,10 @@ linters:
     - unparam
     - unused
   settings:
+    forbidigo:
+      forbid:
+        - pattern: 'time\.Sleep'
+          msg: "use polling or async assertions instead of time.Sleep"
     gocognit:
       min-complexity: 30
     nestif:

--- a/cmd/hostbridge/main.go
+++ b/cmd/hostbridge/main.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/openperouter/openperouter/internal/hostcredentials"
-	"github.com/openperouter/openperouter/internal/version"
+	"github.com/openperouter/openperouter/internal/buildversion"
 )
 
 type Config struct {
@@ -44,7 +44,7 @@ func main() {
 		NodeName:       nodeName,
 	}
 
-	slog.Info("version", "version", version.Version())
+	slog.Info("version", "version", buildversion.Version())
 	slog.Info("Starting hostbridge with configuration", "config", config)
 
 	ctx := context.Background()
@@ -93,7 +93,7 @@ func getAPIServer(config Config) (string, error) {
 		res := "https://" + net.JoinHostPort(config.APIServer, strconv.Itoa(config.K8sPort))
 		return res, nil
 	}
-	res, err := hostcredentials.ApiServerAddress(config.K8sPort)
+	res, err := hostcredentials.APIServerAddress(config.K8sPort)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/hostbridge/main.go
+++ b/cmd/hostbridge/main.go
@@ -13,8 +13,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/openperouter/openperouter/internal/hostcredentials"
 	"github.com/openperouter/openperouter/internal/buildversion"
+	"github.com/openperouter/openperouter/internal/hostcredentials"
 )
 
 type Config struct {

--- a/cmd/hostcontroller/main.go
+++ b/cmd/hostcontroller/main.go
@@ -46,6 +46,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/openperouter/openperouter/api/static"
 	periov1alpha1 "github.com/openperouter/openperouter/api/v1alpha1"
+	"github.com/openperouter/openperouter/internal/buildversion"
 	"github.com/openperouter/openperouter/internal/controller/routerconfiguration"
 	"github.com/openperouter/openperouter/internal/filewatcher"
 	"github.com/openperouter/openperouter/internal/hostnetwork"
@@ -53,7 +54,6 @@ import (
 	"github.com/openperouter/openperouter/internal/pods"
 	"github.com/openperouter/openperouter/internal/staticconfiguration"
 	"github.com/openperouter/openperouter/internal/systemdctl"
-	"github.com/openperouter/openperouter/internal/buildversion"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	// +kubebuilder:scaffold:imports
 )

--- a/cmd/hostcontroller/main.go
+++ b/cmd/hostcontroller/main.go
@@ -53,7 +53,7 @@ import (
 	"github.com/openperouter/openperouter/internal/pods"
 	"github.com/openperouter/openperouter/internal/staticconfiguration"
 	"github.com/openperouter/openperouter/internal/systemdctl"
-	"github.com/openperouter/openperouter/internal/version"
+	"github.com/openperouter/openperouter/internal/buildversion"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	// +kubebuilder:scaffold:imports
 )
@@ -146,7 +146,7 @@ func main() {
 		os.Exit(1)
 	}
 	ctrl.SetLogger(logr.FromSlogHandler(logger.Handler()))
-	setupLog.Info("version", "version", version.Version())
+	setupLog.Info("version", "version", buildversion.Version())
 	setupLog.Info("arguments", "args", fmt.Sprintf("%+v", args))
 
 	// Setup signal handler once for the entire process

--- a/cmd/nodemarker/main.go
+++ b/cmd/nodemarker/main.go
@@ -42,7 +42,7 @@ import (
 	"github.com/openperouter/openperouter/internal/controller/nodeindex"
 	"github.com/openperouter/openperouter/internal/logging"
 	"github.com/openperouter/openperouter/internal/tlsconfig"
-	"github.com/openperouter/openperouter/internal/version"
+	"github.com/openperouter/openperouter/internal/buildversion"
 	"github.com/openperouter/openperouter/internal/webhooks"
 	// +kubebuilder:scaffold:imports
 )
@@ -120,7 +120,7 @@ func main() {
 	}
 	ctrl.SetLogger(logr.FromSlogHandler(logger.Handler()))
 
-	setupLog.Info("version", "version", version.Version())
+	setupLog.Info("version", "version", buildversion.Version())
 	setupLog.Info("arguments", "args", fmt.Sprintf("%+v", args))
 
 	if !args.enableHTTP2 {

--- a/cmd/nodemarker/main.go
+++ b/cmd/nodemarker/main.go
@@ -39,10 +39,10 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/open-policy-agent/cert-controller/pkg/rotator"
 	"github.com/openperouter/openperouter/api/v1alpha1"
+	"github.com/openperouter/openperouter/internal/buildversion"
 	"github.com/openperouter/openperouter/internal/controller/nodeindex"
 	"github.com/openperouter/openperouter/internal/logging"
 	"github.com/openperouter/openperouter/internal/tlsconfig"
-	"github.com/openperouter/openperouter/internal/buildversion"
 	"github.com/openperouter/openperouter/internal/webhooks"
 	// +kubebuilder:scaffold:imports
 )

--- a/cmd/reloader/main.go
+++ b/cmd/reloader/main.go
@@ -32,11 +32,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/openperouter/openperouter/internal/buildversion"
 	"github.com/openperouter/openperouter/internal/frr/liveness"
 	"github.com/openperouter/openperouter/internal/frr/vtysh"
 	"github.com/openperouter/openperouter/internal/frrconfig"
 	"github.com/openperouter/openperouter/internal/logging"
-	"github.com/openperouter/openperouter/internal/buildversion"
 )
 
 type Args struct {

--- a/cmd/reloader/main.go
+++ b/cmd/reloader/main.go
@@ -36,7 +36,7 @@ import (
 	"github.com/openperouter/openperouter/internal/frr/vtysh"
 	"github.com/openperouter/openperouter/internal/frrconfig"
 	"github.com/openperouter/openperouter/internal/logging"
-	"github.com/openperouter/openperouter/internal/version"
+	"github.com/openperouter/openperouter/internal/buildversion"
 )
 
 type Args struct {
@@ -64,7 +64,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	slog.Info("version", "version", version.Version())
+	slog.Info("version", "version", buildversion.Version())
 	slog.Info("arguments", "args", fmt.Sprintf("%+v", args))
 	slog.Info("listening", "address", args.bindAddress)
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -7,5 +7,9 @@ module.exports = {
        'body-max-line-length': [1, 'always', 72],
        // Ensure the header line doesn't end with a period.
        'header-full-stop': [2, 'never'],
+       // Keep subject lines short enough for git log and GitHub UI.
+       'header-max-length': [2, 'always', 72],
+       // Reject trivially short subjects like "fix" or "update".
+       'header-min-length': [2, 'always', 10],
     },
 };

--- a/internal/buildversion/version.go
+++ b/internal/buildversion/version.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package version
+package buildversion
 
 import "runtime/debug"
 

--- a/internal/controller/routerconfiguration/frr.go
+++ b/internal/controller/routerconfiguration/frr.go
@@ -15,14 +15,14 @@ import (
 type frrConfigData struct {
 	configFile string
 	updater    frr.ConfigUpdater
-	conversion.ApiConfigData
+	conversion.APIConfigData
 	nodeIndex int
 	logLevel  string
 }
 
 func configureFRR(ctx context.Context, data frrConfigData) error {
 	slog.DebugContext(ctx, "reloading FRR config", "config", data)
-	frrConfig, err := conversion.APItoFRR(data.ApiConfigData, data.nodeIndex, data.logLevel)
+	frrConfig, err := conversion.APItoFRR(data.APIConfigData, data.nodeIndex, data.logLevel)
 	emptyConfig := conversion.FRREmptyConfigError("")
 	if errors.As(err, &emptyConfig) {
 		slog.InfoContext(ctx, "reloading FRR config", "empty config", data, "event", "cleaning the frr configuration")

--- a/internal/controller/routerconfiguration/host_config.go
+++ b/internal/controller/routerconfiguration/host_config.go
@@ -18,7 +18,7 @@ type interfacesConfiguration struct {
 	targetNamespace    string
 	underlayFromMultus bool
 	nodeIndex          int
-	conversion.ApiConfigData
+	conversion.APIConfigData
 }
 
 type UnderlayRemovedError struct{}
@@ -47,7 +47,7 @@ func configureInterfaces(ctx context.Context, config interfacesConfiguration) er
 
 	slog.InfoContext(ctx, "configure interface start", "namespace", config.targetNamespace)
 	defer slog.InfoContext(ctx, "configure interface end", "namespace", config.targetNamespace)
-	apiConfig := conversion.ApiConfigData{
+	apiConfig := conversion.APIConfigData{
 		Underlays:     config.Underlays,
 		L3VNIs:        config.L3VNIs,
 		L2VNIs:        config.L2VNIs,

--- a/internal/controller/routerconfiguration/reconcile.go
+++ b/internal/controller/routerconfiguration/reconcile.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openperouter/openperouter/internal/frr"
 )
 
-func Reconcile(ctx context.Context, apiConfig conversion.ApiConfigData, underlayFromMultus bool, nodeIndex int, logLevel, frrConfigPath, targetNamespace string, updater frr.ConfigUpdater) error {
+func Reconcile(ctx context.Context, apiConfig conversion.APIConfigData, underlayFromMultus bool, nodeIndex int, logLevel, frrConfigPath, targetNamespace string, updater frr.ConfigUpdater) error {
 	if err := conversion.ValidateUnderlays(apiConfig.Underlays); err != nil {
 		return fmt.Errorf("failed to validate underlays: %w", err)
 	}
@@ -38,7 +38,7 @@ func Reconcile(ctx context.Context, apiConfig conversion.ApiConfigData, underlay
 	if err := configureFRR(ctx, frrConfigData{
 		configFile:    frrConfigPath,
 		updater:       updater,
-		ApiConfigData: apiConfig,
+		APIConfigData: apiConfig,
 		nodeIndex:     nodeIndex,
 		logLevel:      logLevel,
 	}); err != nil {
@@ -47,7 +47,7 @@ func Reconcile(ctx context.Context, apiConfig conversion.ApiConfigData, underlay
 
 	if err := configureInterfaces(ctx, interfacesConfiguration{
 		targetNamespace:    targetNamespace,
-		ApiConfigData:      apiConfig,
+		APIConfigData:      apiConfig,
 		nodeIndex:          nodeIndex,
 		underlayFromMultus: underlayFromMultus,
 	}); err != nil {

--- a/internal/controller/routerconfiguration/static_configuration_reader.go
+++ b/internal/controller/routerconfiguration/static_configuration_reader.go
@@ -12,26 +12,26 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func readStaticConfigs(configDir string) (conversion.ApiConfigData, error) {
+func readStaticConfigs(configDir string) (conversion.APIConfigData, error) {
 	routerConfigs, err := staticconfiguration.ReadRouterConfigs(configDir)
 	if err != nil {
-		return conversion.ApiConfigData{}, fmt.Errorf("failed to read router configs: %w", err)
+		return conversion.APIConfigData{}, fmt.Errorf("failed to read router configs: %w", err)
 	}
 
-	apiConfigs := make([]conversion.ApiConfigData, len(routerConfigs))
+	apiConfigs := make([]conversion.APIConfigData, len(routerConfigs))
 	for i, rc := range routerConfigs {
 		apiConfigs[i] = staticConfigToAPIConfig(rc)
 	}
 
 	merged, err := conversion.MergeAPIConfigs(apiConfigs...)
 	if err != nil {
-		return conversion.ApiConfigData{}, fmt.Errorf("failed to merge static configs: %w", err)
+		return conversion.APIConfigData{}, fmt.Errorf("failed to merge static configs: %w", err)
 	}
 
 	return merged, nil
 }
 
-func staticConfigToAPIConfig(staticConfig *static.PERouterConfig) conversion.ApiConfigData {
+func staticConfigToAPIConfig(staticConfig *static.PERouterConfig) conversion.APIConfigData {
 	underlays := make([]v1alpha1.Underlay, len(staticConfig.Underlays))
 	for i, spec := range staticConfig.Underlays {
 		underlays[i] = v1alpha1.Underlay{
@@ -104,7 +104,7 @@ func staticConfigToAPIConfig(staticConfig *static.PERouterConfig) conversion.Api
 		}
 	}
 
-	return conversion.ApiConfigData{
+	return conversion.APIConfigData{
 		Underlays:     underlays,
 		L3VNIs:        l3vnis,
 		L2VNIs:        l2vnis,

--- a/internal/controller/routerconfiguration/underlay_vni_controller.go
+++ b/internal/controller/routerconfiguration/underlay_vni_controller.go
@@ -138,7 +138,7 @@ func (r *PERouterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	return ctrl.Result{}, nil
 }
 
-func mergeStaticConfig(staticConfigDir string, config conversion.ApiConfigData, logger *slog.Logger) (conversion.ApiConfigData, error) {
+func mergeStaticConfig(staticConfigDir string, config conversion.APIConfigData, logger *slog.Logger) (conversion.APIConfigData, error) {
 	var noConfigErr *staticconfiguration.NoConfigAvailable
 	staticConfig, err := readStaticConfigs(staticConfigDir)
 	// if we don't have a static configuration is fair to continue and use only the dynamic one
@@ -148,7 +148,7 @@ func mergeStaticConfig(staticConfigDir string, config conversion.ApiConfigData, 
 	}
 	if err != nil {
 		logger.Error("failed to read static configuration", "error", err, "dir", staticConfigDir)
-		return conversion.ApiConfigData{}, fmt.Errorf("failed to read static configuration: %w", err)
+		return conversion.APIConfigData{}, fmt.Errorf("failed to read static configuration: %w", err)
 	}
 
 	merged, err := conversion.MergeAPIConfigs(config, staticConfig)
@@ -161,72 +161,72 @@ func mergeStaticConfig(staticConfigDir string, config conversion.ApiConfigData, 
 	return merged, nil
 }
 
-func (r *PERouterReconciler) getConfigFromAPI(ctx context.Context, logger *slog.Logger) (conversion.ApiConfigData, error) {
+func (r *PERouterReconciler) getConfigFromAPI(ctx context.Context, logger *slog.Logger) (conversion.APIConfigData, error) {
 	var underlays v1alpha1.UnderlayList
 	if err := r.List(ctx, &underlays); err != nil {
 		slog.Error("failed to list underlays", "error", err)
-		return conversion.ApiConfigData{}, err
+		return conversion.APIConfigData{}, err
 	}
 
 	var l3vnis v1alpha1.L3VNIList
 	if err := r.List(ctx, &l3vnis); err != nil {
 		slog.Error("failed to list l3vnis", "error", err)
-		return conversion.ApiConfigData{}, err
+		return conversion.APIConfigData{}, err
 	}
 
 	var l2vnis v1alpha1.L2VNIList
 	if err := r.List(ctx, &l2vnis); err != nil {
 		slog.Error("failed to list l2vnis", "error", err)
-		return conversion.ApiConfigData{}, err
+		return conversion.APIConfigData{}, err
 	}
 
 	var l3passthrough v1alpha1.L3PassthroughList
 	if err := r.List(ctx, &l3passthrough); err != nil {
 		slog.Error("failed to list l3passthrough", "error", err)
-		return conversion.ApiConfigData{}, err
+		return conversion.APIConfigData{}, err
 	}
 
 	var rawFRRConfigs v1alpha1.RawFRRConfigList
 	if err := r.List(ctx, &rawFRRConfigs); err != nil {
 		slog.Error("failed to list rawfrrconfigs", "error", err)
-		return conversion.ApiConfigData{}, err
+		return conversion.APIConfigData{}, err
 	}
 
 	node := &v1.Node{}
 	if err := r.Get(ctx, client.ObjectKey{Name: r.MyNode}, node); err != nil {
 		slog.Error("failed to get node", "node", r.MyNode, "error", err)
-		return conversion.ApiConfigData{}, err
+		return conversion.APIConfigData{}, err
 	}
 
 	// Filter resources by node selector
 	filteredUnderlays, err := filter.UnderlaysForNode(node, underlays.Items)
 	if err != nil {
 		slog.Error("failed to filter underlays for node", "node", r.MyNode, "error", err)
-		return conversion.ApiConfigData{}, err
+		return conversion.APIConfigData{}, err
 	}
 
 	filteredL3VNIs, err := filter.L3VNIsForNode(node, l3vnis.Items)
 	if err != nil {
 		slog.Error("failed to filter l3vnis for node", "node", r.MyNode, "error", err)
-		return conversion.ApiConfigData{}, err
+		return conversion.APIConfigData{}, err
 	}
 
 	filteredL2VNIs, err := filter.L2VNIsForNode(node, l2vnis.Items)
 	if err != nil {
 		slog.Error("failed to filter l2vnis for node", "node", r.MyNode, "error", err)
-		return conversion.ApiConfigData{}, err
+		return conversion.APIConfigData{}, err
 	}
 
 	filteredL3Passthrough, err := filter.L3PassthroughsForNode(node, l3passthrough.Items)
 	if err != nil {
 		slog.Error("failed to filter l3passthrough for node", "node", r.MyNode, "error", err)
-		return conversion.ApiConfigData{}, err
+		return conversion.APIConfigData{}, err
 	}
 
 	filteredRawFRRConfigs, err := filter.RawFRRConfigsForNode(node, rawFRRConfigs.Items)
 	if err != nil {
 		slog.Error("failed to filter rawfrrconfigs for node", "node", r.MyNode, "error", err)
-		return conversion.ApiConfigData{}, err
+		return conversion.APIConfigData{}, err
 	}
 
 	if len(filteredRawFRRConfigs) > 0 {
@@ -235,7 +235,7 @@ func (r *PERouterReconciler) getConfigFromAPI(ctx context.Context, logger *slog.
 
 	logger.Debug("using config", "l3vnis", l3vnis.Items, "l2vnis", l2vnis.Items, "underlays", underlays.Items, "l3passthrough", l3passthrough.Items, "rawfrrconfigs", rawFRRConfigs.Items)
 
-	apiConfig := conversion.ApiConfigData{
+	apiConfig := conversion.APIConfigData{
 		Underlays:     filteredUnderlays,
 		L3VNIs:        filteredL3VNIs,
 		L2VNIs:        filteredL2VNIs,

--- a/internal/conversion/api.go
+++ b/internal/conversion/api.go
@@ -7,7 +7,7 @@ import (
 	"github.com/openperouter/openperouter/internal/hostnetwork"
 )
 
-type ApiConfigData struct {
+type APIConfigData struct {
 	Underlays     []v1alpha1.Underlay
 	L3VNIs        []v1alpha1.L3VNI
 	L2VNIs        []v1alpha1.L2VNI
@@ -22,12 +22,12 @@ type HostConfigData struct {
 	L3Passthrough *hostnetwork.PassthroughParams
 }
 
-func MergeAPIConfigs(configs ...ApiConfigData) (ApiConfigData, error) {
+func MergeAPIConfigs(configs ...APIConfigData) (APIConfigData, error) {
 	if len(configs) == 0 {
-		return ApiConfigData{}, nil
+		return APIConfigData{}, nil
 	}
 
-	merged := ApiConfigData{
+	merged := APIConfigData{
 		L3VNIs:        []v1alpha1.L3VNI{},
 		L2VNIs:        []v1alpha1.L2VNI{},
 		L3Passthrough: []v1alpha1.L3Passthrough{},

--- a/internal/conversion/api_test.go
+++ b/internal/conversion/api_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestMergeAPIConfigs_SingleConfig(t *testing.T) {
-	config := ApiConfigData{
+	config := APIConfigData{
 		Underlays: []v1alpha1.Underlay{
 			{
 				ObjectMeta: metav1.ObjectMeta{Name: "underlay1"},
@@ -36,7 +36,7 @@ func TestMergeAPIConfigs_SingleConfig(t *testing.T) {
 }
 
 func TestMergeAPIConfigs_MultipleConfigs(t *testing.T) {
-	config1 := ApiConfigData{
+	config1 := APIConfigData{
 		Underlays: []v1alpha1.Underlay{
 			{
 				ObjectMeta: metav1.ObjectMeta{Name: "underlay1"},
@@ -45,7 +45,7 @@ func TestMergeAPIConfigs_MultipleConfigs(t *testing.T) {
 		},
 	}
 
-	config2 := ApiConfigData{
+	config2 := APIConfigData{
 		L3VNIs: []v1alpha1.L3VNI{
 			{
 				ObjectMeta: metav1.ObjectMeta{Name: "l3vni1"},
@@ -54,7 +54,7 @@ func TestMergeAPIConfigs_MultipleConfigs(t *testing.T) {
 		},
 	}
 
-	config3 := ApiConfigData{
+	config3 := APIConfigData{
 		L2VNIs: []v1alpha1.L2VNI{
 			{
 				ObjectMeta: metav1.ObjectMeta{Name: "l2vni1"},
@@ -68,7 +68,7 @@ func TestMergeAPIConfigs_MultipleConfigs(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	want := ApiConfigData{
+	want := APIConfigData{
 		Underlays: []v1alpha1.Underlay{
 			{
 				ObjectMeta: metav1.ObjectMeta{Name: "underlay1"},
@@ -95,7 +95,7 @@ func TestMergeAPIConfigs_MultipleConfigs(t *testing.T) {
 	}
 }
 func TestMergeAPIConfigs_AllResourceTypes(t *testing.T) {
-	config := ApiConfigData{
+	config := APIConfigData{
 		Underlays: []v1alpha1.Underlay{
 			{ObjectMeta: metav1.ObjectMeta{Name: "underlay1"}},
 		},
@@ -121,14 +121,14 @@ func TestMergeAPIConfigs_AllResourceTypes(t *testing.T) {
 }
 
 func TestMergeAPIConfigs_ResourcesConcatenated(t *testing.T) {
-	config1 := ApiConfigData{
+	config1 := APIConfigData{
 		Underlays: []v1alpha1.Underlay{
 			{ObjectMeta: metav1.ObjectMeta{Name: "underlay1"}},
 			{ObjectMeta: metav1.ObjectMeta{Name: "underlay2"}},
 		},
 	}
 
-	config2 := ApiConfigData{
+	config2 := APIConfigData{
 		Underlays: []v1alpha1.Underlay{
 			{ObjectMeta: metav1.ObjectMeta{Name: "underlay3"}},
 		},
@@ -139,7 +139,7 @@ func TestMergeAPIConfigs_ResourcesConcatenated(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	want := ApiConfigData{
+	want := APIConfigData{
 		Underlays: []v1alpha1.Underlay{
 			{ObjectMeta: metav1.ObjectMeta{Name: "underlay1"}},
 			{ObjectMeta: metav1.ObjectMeta{Name: "underlay2"}},

--- a/internal/conversion/frr_conversion.go
+++ b/internal/conversion/frr_conversion.go
@@ -28,7 +28,7 @@ func (e FRREmptyConfigError) Error() string {
 	return string(e)
 }
 
-func APItoFRR(config ApiConfigData, nodeIndex int, logLevel string) (frr.Config, error) {
+func APItoFRR(config APIConfigData, nodeIndex int, logLevel string) (frr.Config, error) {
 	if len(config.Underlays) > 1 {
 		return frr.Config{}, errors.New("multiple underlays defined")
 	}

--- a/internal/conversion/frr_conversion_test.go
+++ b/internal/conversion/frr_conversion_test.go
@@ -807,7 +807,7 @@ func TestAPItoFRR(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			apiConfig := ApiConfigData{
+			apiConfig := APIConfigData{
 				Underlays:     tt.underlays,
 				L3VNIs:        tt.vnis,
 				L3Passthrough: tt.l3Passthrough,
@@ -893,7 +893,7 @@ func TestAPItoFRRRawConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			apiConfig := ApiConfigData{
+			apiConfig := APIConfigData{
 				Underlays:     baseUnderlay,
 				RawFRRConfigs: tt.rawFRRConfigs,
 			}
@@ -1011,7 +1011,7 @@ func TestAPItoFRRRawConfigWithoutUnderlay(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			apiConfig := ApiConfigData{
+			apiConfig := APIConfigData{
 				Underlays:     []v1alpha1.Underlay{},
 				RawFRRConfigs: rawConfigs,
 				L3VNIs:        tt.l3VNIs,

--- a/internal/conversion/host_conversion.go
+++ b/internal/conversion/host_conversion.go
@@ -124,39 +124,50 @@ func APItoHostConfig(nodeIndex int, targetNS string, underlayFromMultus bool, ap
 			copy(vni.L2GatewayIPs, l2vni.Spec.L2GatewayIPs)
 		}
 		if l2vni.Spec.HostMaster != nil {
-			var name string
-			var autoCreate bool
-
-			switch l2vni.Spec.HostMaster.Type {
-			case v1alpha1.LinuxBridge:
-				if l2vni.Spec.HostMaster.LinuxBridge != nil {
-					name = l2vni.Spec.HostMaster.LinuxBridge.Name
-					autoCreate = l2vni.Spec.HostMaster.LinuxBridge.AutoCreate
-				}
-			case v1alpha1.OVSBridge:
-				if l2vni.Spec.HostMaster.OVSBridge != nil {
-					name = l2vni.Spec.HostMaster.OVSBridge.Name
-					autoCreate = l2vni.Spec.HostMaster.OVSBridge.AutoCreate
-				}
-			default:
-				return HostConfigData{}, fmt.Errorf(
-					"unknown host master type %q for L2VNI %s",
-					l2vni.Spec.HostMaster.Type,
-					client.ObjectKeyFromObject(&l2vni),
-				)
+			hm, err := convertHostMaster(&l2vni)
+			if err != nil {
+				return HostConfigData{}, err
 			}
-
-			vni.HostMaster = &hostnetwork.HostMaster{
-				Name:       name,
-				Type:       l2vni.Spec.HostMaster.Type,
-				AutoCreate: autoCreate,
-			}
+			vni.HostMaster = hm
 		}
 
 		res.L2VNIs = append(res.L2VNIs, vni)
 	}
 
 	return res, nil
+}
+
+func convertHostMaster(l2vni *v1alpha1.L2VNI) (*hostnetwork.HostMaster, error) {
+	switch l2vni.Spec.HostMaster.Type {
+	case v1alpha1.LinuxBridge:
+		if l2vni.Spec.HostMaster.LinuxBridge != nil {
+			return &hostnetwork.HostMaster{
+				Name:       l2vni.Spec.HostMaster.LinuxBridge.Name,
+				Type:       l2vni.Spec.HostMaster.Type,
+				AutoCreate: l2vni.Spec.HostMaster.LinuxBridge.AutoCreate,
+			}, nil
+		}
+	case v1alpha1.OVSBridge:
+		if l2vni.Spec.HostMaster.OVSBridge != nil {
+			return &hostnetwork.HostMaster{
+				Name:       l2vni.Spec.HostMaster.OVSBridge.Name,
+				Type:       l2vni.Spec.HostMaster.Type,
+				AutoCreate: l2vni.Spec.HostMaster.OVSBridge.AutoCreate,
+			}, nil
+		}
+	default:
+		return nil, fmt.Errorf(
+			"unknown host master type %q for L2VNI %s",
+			l2vni.Spec.HostMaster.Type,
+			client.ObjectKeyFromObject(l2vni),
+		)
+	}
+
+	return nil, fmt.Errorf(
+		"host master config is nil for type %q in L2VNI %s",
+		l2vni.Spec.HostMaster.Type,
+		client.ObjectKeyFromObject(l2vni),
+	)
 }
 
 // ipNetToString returns the string representation of the IPNet, or empty string if IP is nil

--- a/internal/conversion/host_conversion.go
+++ b/internal/conversion/host_conversion.go
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func APItoHostConfig(nodeIndex int, targetNS string, underlayFromMultus bool, apiConfig ApiConfigData) (HostConfigData, error) {
+func APItoHostConfig(nodeIndex int, targetNS string, underlayFromMultus bool, apiConfig APIConfigData) (HostConfigData, error) {
 	res := HostConfigData{
 		L3VNIs: []hostnetwork.L3VNIParams{},
 		L2VNIs: []hostnetwork.L2VNIParams{},

--- a/internal/conversion/host_conversion_test.go
+++ b/internal/conversion/host_conversion_test.go
@@ -363,7 +363,7 @@ func TestAPItoHostConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			apiConfig := ApiConfigData{
+			apiConfig := APIConfigData{
 				Underlays:     tt.underlays,
 				L3VNIs:        tt.vnis,
 				L2VNIs:        tt.l2vnis,

--- a/internal/conversion/validate_underlay.go
+++ b/internal/conversion/validate_underlay.go
@@ -47,23 +47,8 @@ func validateUnderlay(underlay *v1alpha1.Underlay) error {
 	}
 
 	if underlay.Spec.EVPN != nil {
-		hasVTEPCIDR := underlay.Spec.EVPN.VTEPCIDR != ""
-		hasVTEPInterface := underlay.Spec.EVPN.VTEPInterface != ""
-
-		if hasVTEPCIDR == hasVTEPInterface {
-			return fmt.Errorf("underlay %s: either vtepcidr (%t) or vtepInterface (%t) (not both) must be specified", underlay.Name, hasVTEPCIDR, hasVTEPInterface)
-		}
-
-		if hasVTEPCIDR {
-			if _, _, err := net.ParseCIDR(underlay.Spec.EVPN.VTEPCIDR); err != nil {
-				return fmt.Errorf("invalid vtep CIDR format for underlay %s: %s - %w", underlay.Name, underlay.Spec.EVPN.VTEPCIDR, err)
-			}
-		}
-
-		if hasVTEPInterface {
-			if err := isValidInterfaceName(underlay.Spec.EVPN.VTEPInterface); err != nil {
-				return fmt.Errorf("invalid vtep interface name %q for underlay %q: %w", underlay.Name, underlay.Spec.EVPN.VTEPInterface, err)
-			}
+		if err := validateUnderlayEVPN(underlay); err != nil {
+			return err
 		}
 	}
 
@@ -76,5 +61,28 @@ func validateUnderlay(underlay *v1alpha1.Underlay) error {
 			return fmt.Errorf("invalid nic name for underlay %s: %s - %w", underlay.Name, n, err)
 		}
 	}
+	return nil
+}
+
+func validateUnderlayEVPN(underlay *v1alpha1.Underlay) error {
+	hasVTEPCIDR := underlay.Spec.EVPN.VTEPCIDR != ""
+	hasVTEPInterface := underlay.Spec.EVPN.VTEPInterface != ""
+
+	if hasVTEPCIDR == hasVTEPInterface {
+		return fmt.Errorf("underlay %s: either vtepcidr (%t) or vtepInterface (%t) (not both) must be specified", underlay.Name, hasVTEPCIDR, hasVTEPInterface)
+	}
+
+	if hasVTEPCIDR {
+		if _, _, err := net.ParseCIDR(underlay.Spec.EVPN.VTEPCIDR); err != nil {
+			return fmt.Errorf("invalid vtep CIDR format for underlay %s: %s - %w", underlay.Name, underlay.Spec.EVPN.VTEPCIDR, err)
+		}
+	}
+
+	if hasVTEPInterface {
+		if err := isValidInterfaceName(underlay.Spec.EVPN.VTEPInterface); err != nil {
+			return fmt.Errorf("invalid vtep interface name %q for underlay %q: %w", underlay.Name, underlay.Spec.EVPN.VTEPInterface, err)
+		}
+	}
+
 	return nil
 }

--- a/internal/conversion/validate_vni_test.go
+++ b/internal/conversion/validate_vni_test.go
@@ -681,11 +681,14 @@ func TestHasSubnetOverlap(t *testing.T) {
 			err := hasSubnetOverlap(vniSubnets)
 			if tt.wantErrContains != "" {
 				if err == nil {
-					t.Errorf("hasIPOverlap() error = nil, want error containing %q", tt.wantErrContains)
-				} else if !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Fatalf("hasIPOverlap() error = nil, want error containing %q", tt.wantErrContains)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrContains) {
 					t.Errorf("hasIPOverlap() error = %v, want error containing %q", err, tt.wantErrContains)
 				}
-			} else if err != nil {
+				return
+			}
+			if err != nil {
 				t.Errorf("hasIPOverlap() error = %v, want nil", err)
 			}
 		})

--- a/internal/filewatcher/filewatcher_test.go
+++ b/internal/filewatcher/filewatcher_test.go
@@ -104,7 +104,7 @@ func TestFileWatcherDebouncing(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to write test file iteration %d: %v", i, err)
 		}
-		time.Sleep(40 * time.Millisecond) // 40ms between changes = 200ms total
+		time.Sleep(40 * time.Millisecond) //nolint:forbidigo // testing debounce timing
 	}
 
 	// Should receive only ONE event after debounce window
@@ -173,7 +173,7 @@ func TestFileWatcherLifecycle(t *testing.T) {
 
 	// Cancel context - watcher should stop automatically
 	cancel()
-	time.Sleep(100 * time.Millisecond) // Give time for goroutine to exit and cleanup
+	time.Sleep(100 * time.Millisecond) //nolint:forbidigo // waiting for goroutine cleanup
 
 	// Test context cancellation with new watcher
 	fw2, err := New(tmpDir, triggerChan, logger)
@@ -189,7 +189,7 @@ func TestFileWatcherLifecycle(t *testing.T) {
 
 	// Cancel context and verify cleanup happens
 	cancel2()
-	time.Sleep(100 * time.Millisecond) // Give time for goroutine to exit and cleanup
+	time.Sleep(100 * time.Millisecond) //nolint:forbidigo // waiting for goroutine cleanup
 }
 
 func TestFileWatcherNonExistentDirectory(t *testing.T) {

--- a/internal/frr/frr_test.go
+++ b/internal/frr/frr_test.go
@@ -650,10 +650,8 @@ func testCompareFiles(t *testing.T, configFile, goldenFile string) {
 func testUpdateGoldenFile(t *testing.T, configFile, goldenFile string) {
 	t.Log("update golden file")
 
-	// Sleep to be sure the sessionManager has produced all configuration the test
-	// has triggered and no config is still waiting in the debouncer() local variables.
 	// No other conditions can be checked, so sleeping is our best option.
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond) //nolint:forbidigo // debouncer has no observable condition to poll
 
 	cmd := exec.Command("cp", "-a", configFile, goldenFile)
 	output, err := cmd.Output()

--- a/internal/frr/parse_test.go
+++ b/internal/frr/parse_test.go
@@ -25,6 +25,20 @@ var expectedStats = MessageStats{
 	TotalReceived:      10,
 }
 
+type neighbourTestCase struct {
+	name               string
+	neighborIP         string
+	remoteAS           string
+	localAS            string
+	status             string
+	ipv4PrefixSent     int
+	ipv6PrefixSent     int
+	ipv4PrefixReceived int
+	ipv6PrefixReceived int
+	port               int
+	expectedError      string
+}
+
 func TestNeighbour(t *testing.T) {
 	sample := `{
     "%s":{
@@ -99,19 +113,7 @@ func TestNeighbour(t *testing.T) {
     }
   }`
 
-	tests := []struct {
-		name               string
-		neighborIP         string
-		remoteAS           string
-		localAS            string
-		status             string
-		ipv4PrefixSent     int
-		ipv6PrefixSent     int
-		ipv4PrefixReceived int
-		ipv6PrefixReceived int
-		port               int
-		expectedError      string
-	}{
+	tests := []neighbourTestCase{
 		{
 			"ipv4, connected",
 			"172.18.0.5",
@@ -159,37 +161,42 @@ func TestNeighbour(t *testing.T) {
 			if err != nil {
 				t.Fatal("Failed to parse ", err)
 			}
-			if !n.IP.Equal(net.ParseIP(tt.neighborIP)) {
-				t.Fatal("Expected neighbour ip", tt.neighborIP, "got", n.IP.String())
-			}
-			if n.RemoteAS != tt.remoteAS {
-				t.Fatal("Expected remote as", tt.remoteAS, "got", n.RemoteAS)
-			}
-			if n.LocalAS != tt.localAS {
-				t.Fatal("Expected local as", tt.localAS, "got", n.LocalAS)
-			}
-			if tt.status == "Established" && n.Connected != true {
-				t.Fatal("Expected connected", true, "got", n.Connected)
-			}
-			if tt.status != "Established" && n.Connected == true {
-				t.Fatal("Expected connected", false, "got", n.Connected)
-			}
-			if tt.ipv4PrefixSent+tt.ipv6PrefixSent != n.PrefixSent {
-				t.Fatal("Expected prefix sent", tt.ipv4PrefixSent+tt.ipv6PrefixSent, "got", n.PrefixSent)
-			}
-			if tt.ipv4PrefixReceived+tt.ipv6PrefixReceived != n.PrefixReceived {
-				t.Fatal("Expected prefix received", tt.ipv4PrefixReceived+tt.ipv6PrefixReceived, "got", n.PrefixReceived)
-			}
-			if tt.port != n.Port {
-				t.Fatal("Expected port", tt.port, "got", n.Port)
-			}
-			if n.RemoteRouterID != "0.0.0.0" {
-				t.Fatal("Expected remote routerid 0.0.0.0")
-			}
-			if !cmp.Equal(expectedStats, n.MsgStats) {
-				t.Fatal("unexpected BGP messages stats (-want +got)\n", cmp.Diff(expectedStats, n.MsgStats))
-			}
+			assertNeighbourFields(t, n, tt)
 		})
+	}
+}
+
+func assertNeighbourFields(t *testing.T, n *Neighbor, tc neighbourTestCase) {
+	t.Helper()
+	if !n.IP.Equal(net.ParseIP(tc.neighborIP)) {
+		t.Fatal("Expected neighbour ip", tc.neighborIP, "got", n.IP.String())
+	}
+	if n.RemoteAS != tc.remoteAS {
+		t.Fatal("Expected remote as", tc.remoteAS, "got", n.RemoteAS)
+	}
+	if n.LocalAS != tc.localAS {
+		t.Fatal("Expected local as", tc.localAS, "got", n.LocalAS)
+	}
+	expectedConnected := tc.status == "Established"
+	if n.Connected != expectedConnected {
+		t.Fatal("Expected connected", expectedConnected, "got", n.Connected)
+	}
+	wantPrefixSent := tc.ipv4PrefixSent + tc.ipv6PrefixSent
+	if wantPrefixSent != n.PrefixSent {
+		t.Fatal("Expected prefix sent", wantPrefixSent, "got", n.PrefixSent)
+	}
+	wantPrefixReceived := tc.ipv4PrefixReceived + tc.ipv6PrefixReceived
+	if wantPrefixReceived != n.PrefixReceived {
+		t.Fatal("Expected prefix received", wantPrefixReceived, "got", n.PrefixReceived)
+	}
+	if tc.port != n.Port {
+		t.Fatal("Expected port", tc.port, "got", n.Port)
+	}
+	if n.RemoteRouterID != "0.0.0.0" {
+		t.Fatal("Expected remote routerid 0.0.0.0")
+	}
+	if !cmp.Equal(expectedStats, n.MsgStats) {
+		t.Fatal("unexpected BGP messages stats (-want +got)\n", cmp.Diff(expectedStats, n.MsgStats))
 	}
 }
 

--- a/internal/hostcredentials/hostcredentials.go
+++ b/internal/hostcredentials/hostcredentials.go
@@ -18,7 +18,7 @@ const (
 	kubeConfigFile = "kubeconfig"
 )
 
-func ApiServerAddress(port int) (string, error) {
+func APIServerAddress(port int) (string, error) {
 	clusterIP, err := resolveKubernetesServiceIP()
 	if err != nil {
 		return "", fmt.Errorf("failed to get kubernetes service IP: %w", err)

--- a/internal/hostcredentials/hostcredentials_test.go
+++ b/internal/hostcredentials/hostcredentials_test.go
@@ -97,48 +97,8 @@ func TestExportCredentials(t *testing.T) {
 			apiServer: "https://test-api-server:6443",
 			wantErr:   false,
 			validate: func(t *testing.T, outputPath string) {
-				files := []string{"kubeconfig", "token", "ca.crt", "namespace"}
-				for _, file := range files {
-					if _, err := os.Stat(filepath.Join(outputPath, file)); os.IsNotExist(err) {
-						t.Errorf("Expected file %s was not created", file)
-					}
-				}
-
-				tokenContent, err := os.ReadFile(filepath.Join(outputPath, "token"))
-				if err != nil {
-					t.Errorf("Failed to read token file: %v", err)
-				}
-				if string(tokenContent) != "test-token" {
-					t.Errorf("Token content = %v, want %v", string(tokenContent), "test-token")
-				}
-
-				caContent, err := os.ReadFile(filepath.Join(outputPath, "ca.crt"))
-				if err != nil {
-					t.Errorf("Failed to read ca.crt file: %v", err)
-				}
-				if string(caContent) != "test-ca-cert" {
-					t.Errorf("CA content = %v, want %v", string(caContent), "test-ca-cert")
-				}
-
-				namespaceContent, err := os.ReadFile(filepath.Join(outputPath, "namespace"))
-				if err != nil {
-					t.Errorf("Failed to read namespace file: %v", err)
-				}
-				if string(namespaceContent) != "test-namespace" {
-					t.Errorf("Namespace content = %v, want %v", string(namespaceContent), "test-namespace")
-				}
-
-				kubeconfigContent, err := os.ReadFile(filepath.Join(outputPath, "kubeconfig"))
-				if err != nil {
-					t.Errorf("Failed to read kubeconfig file: %v", err)
-				}
-				kubeconfigStr := string(kubeconfigContent)
-				if !strings.Contains(kubeconfigStr, "https://test-api-server:6443") {
-					t.Errorf("Kubeconfig does not contain expected API server URL")
-				}
-				if !strings.Contains(kubeconfigStr, "test-namespace") {
-					t.Errorf("Kubeconfig does not contain expected namespace")
-				}
+				t.Helper()
+				validateExportedCredentials(t, outputPath)
 			},
 		},
 		{
@@ -190,5 +150,42 @@ func TestExportCredentials(t *testing.T) {
 				tt.validate(t, outputPath)
 			}
 		})
+	}
+}
+
+func validateExportedCredentials(t *testing.T, outputPath string) {
+	t.Helper()
+
+	for _, file := range []string{"kubeconfig", "token", "ca.crt", "namespace"} {
+		if _, err := os.Stat(filepath.Join(outputPath, file)); os.IsNotExist(err) {
+			t.Errorf("Expected file %s was not created", file)
+		}
+	}
+
+	assertFileContent(t, outputPath, "token", "test-token")
+	assertFileContent(t, outputPath, "ca.crt", "test-ca-cert")
+	assertFileContent(t, outputPath, "namespace", "test-namespace")
+
+	kubeconfigContent, err := os.ReadFile(filepath.Join(outputPath, "kubeconfig"))
+	if err != nil {
+		t.Fatalf("Failed to read kubeconfig file: %v", err)
+	}
+	kubeconfigStr := string(kubeconfigContent)
+	if !strings.Contains(kubeconfigStr, "https://test-api-server:6443") {
+		t.Errorf("Kubeconfig does not contain expected API server URL")
+	}
+	if !strings.Contains(kubeconfigStr, "test-namespace") {
+		t.Errorf("Kubeconfig does not contain expected namespace")
+	}
+}
+
+func assertFileContent(t *testing.T, dir, filename, expected string) {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Join(dir, filename))
+	if err != nil {
+		t.Fatalf("Failed to read %s file: %v", filename, err)
+	}
+	if string(content) != expected {
+		t.Errorf("%s content = %v, want %v", filename, string(content), expected)
 	}
 }

--- a/internal/hostnetwork/link_properties.go
+++ b/internal/hostnetwork/link_properties.go
@@ -207,7 +207,7 @@ func moveInterfaceToNamespace(ctx context.Context, intf string, ns netns.NsHandl
 		slog.DebugContext(ctx, "restoring addresses in namespace", "addresses", addresses)
 		for _, a := range addresses {
 			slog.DebugContext(ctx, "restoring address in namespace", "address", a, "flags", a.Flags)
-			IFA_F_NOPREFIXROUTE := 0x200 // remove no prefix route
+			IFA_F_NOPREFIXROUTE := 0x200 //nolint:revive // matches kernel define
 			a.Flags &= ^IFA_F_NOPREFIXROUTE
 			slog.DebugContext(ctx, "restoring address in namespace after no prefix", "address", a, "flags", a.Flags)
 			err := netlink.AddrAdd(nsLink, &a)

--- a/internal/hostnetwork/vni.go
+++ b/internal/hostnetwork/vni.go
@@ -302,15 +302,40 @@ func RemoveNonConfiguredVNIs(targetNS string, params []VNIParams) error {
 		vrfs[p.VRF] = true
 		vnis[p.VNI] = true
 	}
+
+	failedDeletes := removeHostSideVNIs(vnis)
+
+	ns, err := netns.GetFromPath(targetNS)
+	if err != nil {
+		return fmt.Errorf("RemoveNonConfiguredVNIs: Failed to get network namespace %s: %w", targetNS, err)
+	}
+	defer func() {
+		if err := ns.Close(); err != nil {
+			slog.Error("failed to close namespace", "namespace", targetNS, "error", err)
+		}
+	}()
+
+	if err := netnamespace.In(ns, func() error {
+		nsErrors := removeNamespaceSideVNIs(vnis, vrfs)
+		failedDeletes = append(failedDeletes, nsErrors...)
+		return errors.Join(failedDeletes...)
+	}); err != nil {
+		return err
+	}
+
+	return errors.Join(failedDeletes...)
+}
+
+func removeHostSideVNIs(vnis map[int]bool) []error {
+	var failedDeletes []error
+
 	hostLinks, err := netlink.LinkList()
 	if err != nil {
-		return fmt.Errorf("remove non configured vnis: failed to list links: %w", err)
+		return []error{fmt.Errorf("remove non configured vnis: failed to list links: %w", err)}
 	}
-	failedDeletes := []error{}
 	if err := deleteLinksForType(BridgeLinkType, vnis, hostLinks, vniFromHostBridgeName); err != nil {
 		failedDeletes = append(failedDeletes, fmt.Errorf("remove bridge links: %w", err))
 	}
-
 	if err := removeOVSBridgesForVNIs(context.Background(), vnis); err != nil {
 		failedDeletes = append(failedDeletes, fmt.Errorf("remove OVS bridges: %w", err))
 	}
@@ -334,49 +359,35 @@ func RemoveNonConfiguredVNIs(targetNS string, params []VNIParams) error {
 			failedDeletes = append(failedDeletes, fmt.Errorf("remove host leg: %s %w", hl.Attrs().Name, err))
 		}
 	}
+	return failedDeletes
+}
 
-	ns, err := netns.GetFromPath(targetNS)
+func removeNamespaceSideVNIs(vnis map[int]bool, vrfs map[string]bool) []error {
+	var failedDeletes []error
+
+	links, err := netlink.LinkList()
 	if err != nil {
-		return fmt.Errorf("RemoveNonConfiguredVNIs: Failed to get network namespace %s: %w", targetNS, err)
+		return []error{fmt.Errorf("remove non configured vnis: failed to list links: %w", err)}
 	}
-	defer func() {
-		if err := ns.Close(); err != nil {
-			slog.Error("failed to close namespace", "namespace", targetNS, "error", err)
-		}
-	}()
-
-	if err := netnamespace.In(ns, func() error {
-		links, err := netlink.LinkList()
-		if err != nil {
-			return fmt.Errorf("remove non configured vnis: failed to list links: %w", err)
-		}
-
-		if err := deleteLinksForType(VXLanLinkType, vnis, links, vniFromVXLanName); err != nil {
-			failedDeletes = append(failedDeletes, fmt.Errorf("remove vlan links: %w", err))
-			return err
-		}
-		if err := deleteLinksForType(BridgeLinkType, vnis, links, vniFromBridgeName); err != nil {
-			failedDeletes = append(failedDeletes, fmt.Errorf("remove bridge links: %w", err))
-			return err
-		}
-
-		for _, l := range links {
-			if l.Type() != VRFLinkType {
-				continue
-			}
-			if vrfs[l.Attrs().Name] {
-				continue
-			}
-			if err := netlink.LinkDel(l); err != nil {
-				failedDeletes = append(failedDeletes, fmt.Errorf("remove non configured vnis: failed to delete vrf %s %w", l.Attrs().Name, err))
-			}
-		}
-		return errors.Join(failedDeletes...)
-	}); err != nil {
-		return err
+	if err := deleteLinksForType(VXLanLinkType, vnis, links, vniFromVXLanName); err != nil {
+		failedDeletes = append(failedDeletes, fmt.Errorf("remove vlan links: %w", err))
+	}
+	if err := deleteLinksForType(BridgeLinkType, vnis, links, vniFromBridgeName); err != nil {
+		failedDeletes = append(failedDeletes, fmt.Errorf("remove bridge links: %w", err))
 	}
 
-	return errors.Join(failedDeletes...)
+	for _, l := range links {
+		if l.Type() != VRFLinkType {
+			continue
+		}
+		if vrfs[l.Attrs().Name] {
+			continue
+		}
+		if err := netlink.LinkDel(l); err != nil {
+			failedDeletes = append(failedDeletes, fmt.Errorf("remove non configured vnis: failed to delete vrf %s %w", l.Attrs().Name, err))
+		}
+	}
+	return failedDeletes
 }
 
 // deleteLinks deletes all the links of the given type that do not correspond to

--- a/internal/hostnetwork/vni.go
+++ b/internal/hostnetwork/vni.go
@@ -175,26 +175,8 @@ func SetupL2VNI(ctx context.Context, params L2VNIParams) error {
 	slog.Info("SetupL2VNI: found host veth", "name", vethNames.HostSide, "index", hostVeth.Attrs().Index)
 
 	if params.HostMaster != nil {
-		bridgeConfig := *params.HostMaster
-		switch bridgeConfig.Type {
-		case OVSBridgeLinkType:
-			lowerDeviceName := bridgeConfig.Name
-			if bridgeConfig.AutoCreate {
-				lowerDeviceName = hostBridgeName(params.VNI)
-			}
-			if err := ensureOVSBridgeAndAttach(ctx, lowerDeviceName, hostVeth.Attrs().Name); err != nil {
-				return fmt.Errorf("failed to ensure OVS bridge %s and attach %s: %w", lowerDeviceName, hostVeth.Attrs().Name, err)
-			}
-		case BridgeLinkType:
-			master, err := hostMaster(params.VNI, bridgeConfig)
-			if err != nil {
-				return fmt.Errorf("SetupL2VNI: failed to get host master for VRF %s: %w", params.VRF, err)
-			}
-			if err := linkSetMaster(hostVeth, master); err != nil {
-				return fmt.Errorf("failed to set host master %s as master of host veth %s: %w", master.Attrs().Name, hostVeth.Attrs().Name, err)
-			}
-		default:
-			return fmt.Errorf("provided hostmaster.Type %q is not supported", bridgeConfig.Type)
+		if err := setupHostMaster(ctx, params, hostVeth); err != nil {
+			return err
 		}
 	}
 
@@ -227,6 +209,31 @@ func SetupL2VNI(ctx context.Context, params L2VNIParams) error {
 		return nil
 	}); err != nil {
 		return err
+	}
+	return nil
+}
+
+func setupHostMaster(ctx context.Context, params L2VNIParams, hostVeth netlink.Link) error {
+	bridgeConfig := *params.HostMaster
+	switch bridgeConfig.Type {
+	case OVSBridgeLinkType:
+		lowerDeviceName := bridgeConfig.Name
+		if bridgeConfig.AutoCreate {
+			lowerDeviceName = hostBridgeName(params.VNI)
+		}
+		if err := ensureOVSBridgeAndAttach(ctx, lowerDeviceName, hostVeth.Attrs().Name); err != nil {
+			return fmt.Errorf("failed to ensure OVS bridge %s and attach %s: %w", lowerDeviceName, hostVeth.Attrs().Name, err)
+		}
+	case BridgeLinkType:
+		master, err := hostMaster(params.VNI, bridgeConfig)
+		if err != nil {
+			return fmt.Errorf("SetupL2VNI: failed to get host master for VRF %s: %w", params.VRF, err)
+		}
+		if err := linkSetMaster(hostVeth, master); err != nil {
+			return fmt.Errorf("failed to set host master %s as master of host veth %s: %w", master.Attrs().Name, hostVeth.Attrs().Name, err)
+		}
+	default:
+		return fmt.Errorf("provided hostmaster.Type %q is not supported", bridgeConfig.Type)
 	}
 	return nil
 }
@@ -492,18 +499,22 @@ func removeOVSBridgesForVNIs(ctx context.Context, vnis map[int]bool) error {
 		ops = append(ops, deleteOps...)
 	}
 
-	if len(ops) > 0 {
-		txResult, err := ovs.Transact(ctx, ops...)
-		if err != nil {
-			deleteErrors = append(deleteErrors, fmt.Errorf("failed to delete OVS bridges: %w", err))
-			slog.Error("failed to batch-delete OVS bridges", "error", err)
-		} else if _, err := ovsdb.CheckOperationResults(txResult, ops); err != nil {
-			deleteErrors = append(deleteErrors, fmt.Errorf("OVS bridge deletion operations failed: %w", err))
-			slog.Error("OVS bridge deletion operations failed", "error", err)
-		} else {
-			slog.Info("successfully deleted auto-created OVS bridges")
-		}
+	if len(ops) == 0 {
+		return errors.Join(deleteErrors...)
 	}
+
+	txResult, err := ovs.Transact(ctx, ops...)
+	if err != nil {
+		deleteErrors = append(deleteErrors, fmt.Errorf("failed to delete OVS bridges: %w", err))
+		slog.Error("failed to batch-delete OVS bridges", "error", err)
+		return errors.Join(deleteErrors...)
+	}
+	if _, err := ovsdb.CheckOperationResults(txResult, ops); err != nil {
+		deleteErrors = append(deleteErrors, fmt.Errorf("OVS bridge deletion operations failed: %w", err))
+		slog.Error("OVS bridge deletion operations failed", "error", err)
+		return errors.Join(deleteErrors...)
+	}
+	slog.Info("successfully deleted auto-created OVS bridges")
 
 	return errors.Join(deleteErrors...)
 }
@@ -515,19 +526,20 @@ func removeOVSBridgesForVNIs(ctx context.Context, vnis map[int]bool) error {
 func removePortsFromBridge(ctx context.Context, ovs libovsclient.Client, bridge ovsmodel.Bridge, filter func(*ovsmodel.Port) bool) ([]ovsdb.Operation, error) {
 	var matchingUUIDs []string
 	for _, portUUID := range bridge.Ports {
-		if filter != nil {
-			port := &ovsmodel.Port{UUID: portUUID}
-			if err := ovs.Get(ctx, port); err != nil {
-				if errors.Is(err, libovsclient.ErrNotFound) {
-					continue
-				}
-				return nil, fmt.Errorf("failed to get port %s from bridge %s: %w", portUUID, bridge.Name, err)
-			}
-			if !filter(port) {
+		if filter == nil {
+			matchingUUIDs = append(matchingUUIDs, portUUID)
+			continue
+		}
+		port := &ovsmodel.Port{UUID: portUUID}
+		if err := ovs.Get(ctx, port); err != nil {
+			if errors.Is(err, libovsclient.ErrNotFound) {
 				continue
 			}
+			return nil, fmt.Errorf("failed to get port %s from bridge %s: %w", portUUID, bridge.Name, err)
 		}
-		matchingUUIDs = append(matchingUUIDs, portUUID)
+		if filter(port) {
+			matchingUUIDs = append(matchingUUIDs, portUUID)
+		}
 	}
 
 	if len(matchingUUIDs) == 0 {

--- a/internal/hostnetwork/vni_test.go
+++ b/internal/hostnetwork/vni_test.go
@@ -477,29 +477,27 @@ func validateL2HostLeg(g Gomega, params L2VNIParams) {
 	hasNoIP, err := interfaceHasNoIP(hostLegLink, netlink.FAMILY_V4)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(hasNoIP).To(BeTrue(), "host leg does have ip")
-	if params.HostMaster != nil {
-		switch params.HostMaster.Type {
-		case OVSBridgeLinkType:
-			hostMasterName := params.HostMaster.Name
-			if params.HostMaster.AutoCreate {
-				hostMasterName = hostBridgeName(params.VNI)
-			}
-			checkOVSBridgeExists(g, hostMasterName)
-			checkVethAttachedToOVSBridge(g, hostMasterName, vethNames.HostSide)
-		case BridgeLinkType:
-			hostMasterName := params.HostMaster.Name
-			if params.HostMaster.AutoCreate {
-				hostMasterName = hostBridgeName(params.VNI)
-			}
-			hostmaster, err := netlink.LinkByName(hostMasterName)
-			g.Expect(err).NotTo(HaveOccurred(), "host master not found", *params.HostMaster)
-			g.Expect(hostLegLink.Attrs().MasterIndex).To(Equal(hostmaster.Attrs().Index),
-				"host leg is not attached to the bridge", params.HostMaster)
-		default:
-			g.Expect(params.HostMaster.Type).To(BeEmpty(), "unknown bridge type: %s", params.HostMaster.Type)
-		}
-	} else {
+	if params.HostMaster == nil {
 		g.Expect(hostLegLink.Attrs().MasterIndex).To(BeZero(), "host leg is attached to a bridge but should not be")
+		return
+	}
+
+	hostMasterName := params.HostMaster.Name
+	if params.HostMaster.AutoCreate {
+		hostMasterName = hostBridgeName(params.VNI)
+	}
+
+	switch params.HostMaster.Type {
+	case OVSBridgeLinkType:
+		checkOVSBridgeExists(g, hostMasterName)
+		checkVethAttachedToOVSBridge(g, hostMasterName, vethNames.HostSide)
+	case BridgeLinkType:
+		hostmaster, err := netlink.LinkByName(hostMasterName)
+		g.Expect(err).NotTo(HaveOccurred(), "host master not found", *params.HostMaster)
+		g.Expect(hostLegLink.Attrs().MasterIndex).To(Equal(hostmaster.Attrs().Index),
+			"host leg is not attached to the bridge", params.HostMaster)
+	default:
+		g.Expect(params.HostMaster.Type).To(BeEmpty(), "unknown bridge type: %s", params.HostMaster.Type)
 	}
 }
 

--- a/internal/hostnetwork/vxlan.go
+++ b/internal/hostnetwork/vxlan.go
@@ -176,22 +176,22 @@ func validateVxlan(vxLan *netlink.Vxlan, params VNIParams) error {
 		return nil
 	}
 
-	if params.VTEPInterface != "" {
-		iface, err := net.InterfaceByName(params.VTEPInterface)
-		if err != nil {
-			return fmt.Errorf("failed to get vtep interface %s: %w", params.VTEPInterface, err)
-		}
-		expectedIP, err := findFirstInterfaceIPv4Address(iface)
-		if err != nil {
-			return fmt.Errorf("failed to get vtep source address from interface %s: %w", params.VTEPInterface, err)
-		}
-		if !vxLan.SrcAddr.Equal(expectedIP) {
-			return fmt.Errorf("src addr does not match vtep interface ip: %v, expected %v", vxLan.SrcAddr, expectedIP)
-		}
-		return nil
+	if params.VTEPInterface == "" {
+		return fmt.Errorf("missing vtepip or vtepinterface")
 	}
 
-	return fmt.Errorf("missing vtepip or vtepinterface")
+	iface, err := net.InterfaceByName(params.VTEPInterface)
+	if err != nil {
+		return fmt.Errorf("failed to get vtep interface %s: %w", params.VTEPInterface, err)
+	}
+	expectedIP, err := findFirstInterfaceIPv4Address(iface)
+	if err != nil {
+		return fmt.Errorf("failed to get vtep source address from interface %s: %w", params.VTEPInterface, err)
+	}
+	if !vxLan.SrcAddr.Equal(expectedIP) {
+		return fmt.Errorf("src addr does not match vtep interface ip: %v, expected %v", vxLan.SrcAddr, expectedIP)
+	}
+	return nil
 }
 
 // findVxlanSrcAddr resolve the source IP for the VXLAN interface.

--- a/internal/ipam/ipam_test.go
+++ b/internal/ipam/ipam_test.go
@@ -172,25 +172,31 @@ func TestVethIPsFromPool(t *testing.T) {
 			if err == nil && tc.shouldFail {
 				t.Fatalf("was expecting error, didn't fail")
 			}
-
-			if tc.poolIPv4 != "" && !tc.shouldFail {
-				if res.Ipv4.HostSide.String() != tc.expectedHostIPv4 {
-					t.Fatalf("was expecting %s, got %s on the host IPv4", tc.expectedHostIPv4, res.Ipv4.HostSide.String())
-				}
-				if res.Ipv4.PeSide.String() != tc.expectedPEIPv4 {
-					t.Fatalf("was expecting %s, got %s on the container IPv4", tc.expectedPEIPv4, res.Ipv4.PeSide.String())
-				}
+			if tc.shouldFail {
+				return
 			}
-
-			if tc.poolIPv6 != "" && !tc.shouldFail {
-				if res.Ipv6.HostSide.String() != tc.expectedHostIPv6 {
-					t.Fatalf("was expecting %s, got %s on the host IPv6", tc.expectedHostIPv6, res.Ipv6.HostSide.String())
-				}
-				if res.Ipv6.PeSide.String() != tc.expectedPEIPv6 {
-					t.Fatalf("was expecting %s, got %s on the container IPv6", tc.expectedPEIPv6, res.Ipv6.PeSide.String())
-				}
-			}
+			assertVethIPs(t, res, tc.poolIPv4, tc.poolIPv6, tc.expectedPEIPv4, tc.expectedHostIPv4, tc.expectedPEIPv6, tc.expectedHostIPv6)
 		})
+	}
+}
+
+func assertVethIPs(t *testing.T, res VethIPs, poolIPv4, poolIPv6, expectedPE4, expectedHost4, expectedPE6, expectedHost6 string) {
+	t.Helper()
+	if poolIPv4 != "" {
+		if res.Ipv4.HostSide.String() != expectedHost4 {
+			t.Fatalf("was expecting %s, got %s on the host IPv4", expectedHost4, res.Ipv4.HostSide.String())
+		}
+		if res.Ipv4.PeSide.String() != expectedPE4 {
+			t.Fatalf("was expecting %s, got %s on the container IPv4", expectedPE4, res.Ipv4.PeSide.String())
+		}
+	}
+	if poolIPv6 != "" {
+		if res.Ipv6.HostSide.String() != expectedHost6 {
+			t.Fatalf("was expecting %s, got %s on the host IPv6", expectedHost6, res.Ipv6.HostSide.String())
+		}
+		if res.Ipv6.PeSide.String() != expectedPE6 {
+			t.Fatalf("was expecting %s, got %s on the container IPv6", expectedPE6, res.Ipv6.PeSide.String())
+		}
 	}
 }
 

--- a/internal/pods/pods_test.go
+++ b/internal/pods/pods_test.go
@@ -36,7 +36,7 @@ func (m mockCRI) ListPodSandbox(ctx context.Context, in *cri.ListPodSandboxReque
 }
 
 func TestNamespaceForPod(t *testing.T) {
-	validNamespaceJson, err := json.Marshal(PodSandboxStatusInfo{
+	validNamespaceJSON, err := json.Marshal(PodSandboxStatusInfo{
 		RuntimeSpec: &runtimespec.Spec{
 			Linux: &runtimespec.Linux{
 				Namespaces: []runtimespec.LinuxNamespace{
@@ -71,7 +71,7 @@ func TestNamespaceForPod(t *testing.T) {
 				},
 				podSandboxStatusRes: &cri.PodSandboxStatusResponse{
 					Info: map[string]string{
-						InfoKey: string(validNamespaceJson),
+						InfoKey: string(validNamespaceJSON),
 					},
 				},
 			},

--- a/internal/staticconfiguration/reader_test.go
+++ b/internal/staticconfiguration/reader_test.go
@@ -88,36 +88,17 @@ func TestReadRouterConfigs(t *testing.T) {
 	t.Run("empty directory", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		_, err := ReadRouterConfigs(tmpDir)
-		if err == nil {
-			t.Fatal("expected NoConfigAvailable error, got nil")
-		}
-		var noConfigErr *NoConfigAvailable
-		if !errors.As(err, &noConfigErr) {
-			t.Errorf("expected NoConfigAvailable error, got: %v", err)
-		}
+		assertNoConfigAvailable(t, err)
 	})
 
 	t.Run("non-existent directory", func(t *testing.T) {
 		_, err := ReadRouterConfigs("/nonexistent/path")
-		if err == nil {
-			t.Fatal("expected NoConfigAvailable error, got nil")
-		}
-		var noConfigErr *NoConfigAvailable
-		if !errors.As(err, &noConfigErr) {
-			t.Errorf("expected NoConfigAvailable error, got: %v", err)
-		}
+		assertNoConfigAvailable(t, err)
 	})
 
 	t.Run("single file", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		configPath := filepath.Join(tmpDir, "openpe_underlay.yaml")
-		content := `underlays:
-  - asn: 64515
-    routeridcidr: "10.0.0.0/24"
-`
-		if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
-			t.Fatalf("failed to write test config file: %v", err)
-		}
+		writeTestFile(t, tmpDir, "openpe_underlay.yaml", "underlays:\n  - asn: 64515\n    routeridcidr: \"10.0.0.0/24\"\n")
 
 		configs, err := ReadRouterConfigs(tmpDir)
 		if err != nil {
@@ -133,32 +114,9 @@ func TestReadRouterConfigs(t *testing.T) {
 
 	t.Run("multiple files", func(t *testing.T) {
 		tmpDir := t.TempDir()
-
-		// Create first config file
-		configPath1 := filepath.Join(tmpDir, "openpe_underlay.yaml")
-		content1 := `underlays:
-  - asn: 64515
-    routeridcidr: "10.0.0.0/24"
-`
-		if err := os.WriteFile(configPath1, []byte(content1), 0644); err != nil {
-			t.Fatalf("failed to write test config file: %v", err)
-		}
-
-		// Create second config file
-		configPath2 := filepath.Join(tmpDir, "openpe_l3vni.yaml")
-		content2 := `l3vnis:
-  - vrf: "vrf-test"
-    vni: 1000
-`
-		if err := os.WriteFile(configPath2, []byte(content2), 0644); err != nil {
-			t.Fatalf("failed to write test config file: %v", err)
-		}
-
-		// Create a non-matching file (should be ignored)
-		nonMatchingPath := filepath.Join(tmpDir, "other.yaml")
-		if err := os.WriteFile(nonMatchingPath, []byte("test: value\n"), 0644); err != nil {
-			t.Fatalf("failed to write non-matching file: %v", err)
-		}
+		writeTestFile(t, tmpDir, "openpe_underlay.yaml", "underlays:\n  - asn: 64515\n    routeridcidr: \"10.0.0.0/24\"\n")
+		writeTestFile(t, tmpDir, "openpe_l3vni.yaml", "l3vnis:\n  - vrf: \"vrf-test\"\n    vni: 1000\n")
+		writeTestFile(t, tmpDir, "other.yaml", "test: value\n")
 
 		configs, err := ReadRouterConfigs(tmpDir)
 		if err != nil {
@@ -167,38 +125,55 @@ func TestReadRouterConfigs(t *testing.T) {
 		if len(configs) != 2 {
 			t.Fatalf("expected 2 configs, got %d", len(configs))
 		}
-
-		// Verify contents
-		var hasUnderlay, hasL3VNI bool
-		for _, cfg := range configs {
-			if len(cfg.Underlays) > 0 {
-				hasUnderlay = true
-			}
-			if len(cfg.L3VNIs) > 0 {
-				hasL3VNI = true
-			}
-		}
-		if !hasUnderlay {
-			t.Error("expected at least one config with underlays")
-		}
-		if !hasL3VNI {
-			t.Error("expected at least one config with l3vnis")
-		}
+		assertConfigTypes(t, configs)
 	})
 
 	t.Run("invalid file in directory", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		configPath := filepath.Join(tmpDir, "openpe_invalid.yaml")
-		content := "invalid: [unclosed\n"
-		if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
-			t.Fatalf("failed to write test config file: %v", err)
-		}
+		writeTestFile(t, tmpDir, "openpe_invalid.yaml", "invalid: [unclosed\n")
 
 		_, err := ReadRouterConfigs(tmpDir)
 		if err == nil {
 			t.Error("expected error for invalid YAML file")
 		}
 	})
+}
+
+func assertNoConfigAvailable(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected NoConfigAvailable error, got nil")
+	}
+	var noConfigErr *NoConfigAvailable
+	if !errors.As(err, &noConfigErr) {
+		t.Errorf("expected NoConfigAvailable error, got: %v", err)
+	}
+}
+
+func writeTestFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test config file %s: %v", name, err)
+	}
+}
+
+func assertConfigTypes(t *testing.T, configs []*static.PERouterConfig) {
+	t.Helper()
+	var hasUnderlay, hasL3VNI bool
+	for _, cfg := range configs {
+		if len(cfg.Underlays) > 0 {
+			hasUnderlay = true
+		}
+		if len(cfg.L3VNIs) > 0 {
+			hasL3VNI = true
+		}
+	}
+	if !hasUnderlay {
+		t.Error("expected at least one config with underlays")
+	}
+	if !hasL3VNI {
+		t.Error("expected at least one config with l3vnis")
+	}
 }
 
 func TestReadRouterConfigsFromFiles(t *testing.T) {

--- a/internal/webhooks/l2vni_webhook.go
+++ b/internal/webhooks/l2vni_webhook.go
@@ -51,14 +51,15 @@ func (v *L2VNIValidator) Handle(ctx context.Context, req admission.Request) (res
 		if err := v.decoder.DecodeRaw(req.OldObject, &l2vni); err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
-	} else {
+	}
+	if req.Operation != v1.Delete {
 		if err := v.decoder.Decode(req, &l2vni); err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
-		if req.OldObject.Size() > 0 {
-			if err := v.decoder.DecodeRaw(req.OldObject, &oldL2VNI); err != nil {
-				return admission.Errored(http.StatusBadRequest, err)
-			}
+	}
+	if req.Operation != v1.Delete && req.OldObject.Size() > 0 {
+		if err := v.decoder.DecodeRaw(req.OldObject, &oldL2VNI); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
 		}
 	}
 

--- a/internal/webhooks/l3passthrough_webhook.go
+++ b/internal/webhooks/l3passthrough_webhook.go
@@ -49,14 +49,15 @@ func (v *L3PassthroughValidator) Handle(ctx context.Context, req admission.Reque
 		if err := v.decoder.DecodeRaw(req.OldObject, &l3passthrough); err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
-	} else {
+	}
+	if req.Operation != v1.Delete {
 		if err := v.decoder.Decode(req, &l3passthrough); err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
-		if req.OldObject.Size() > 0 {
-			if err := v.decoder.DecodeRaw(req.OldObject, &oldL3Passthrough); err != nil {
-				return admission.Errored(http.StatusBadRequest, err)
-			}
+	}
+	if req.Operation != v1.Delete && req.OldObject.Size() > 0 {
+		if err := v.decoder.DecodeRaw(req.OldObject, &oldL3Passthrough); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
 		}
 	}
 

--- a/internal/webhooks/l3vni_webhook.go
+++ b/internal/webhooks/l3vni_webhook.go
@@ -50,14 +50,15 @@ func (v *L3VNIValidator) Handle(ctx context.Context, req admission.Request) (res
 		if err := v.decoder.DecodeRaw(req.OldObject, &l3vni); err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
-	} else {
+	}
+	if req.Operation != v1.Delete {
 		if err := v.decoder.Decode(req, &l3vni); err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
-		if req.OldObject.Size() > 0 {
-			if err := v.decoder.DecodeRaw(req.OldObject, &oldL3VNI); err != nil {
-				return admission.Errored(http.StatusBadRequest, err)
-			}
+	}
+	if req.Operation != v1.Delete && req.OldObject.Size() > 0 {
+		if err := v.decoder.DecodeRaw(req.OldObject, &oldL3VNI); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
 		}
 	}
 

--- a/internal/webhooks/underlay_webhook.go
+++ b/internal/webhooks/underlay_webhook.go
@@ -51,14 +51,15 @@ func (v *UnderlayValidator) Handle(ctx context.Context, req admission.Request) (
 		if err := v.decoder.DecodeRaw(req.OldObject, &underlay); err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
-	} else {
+	}
+	if req.Operation != v1.Delete {
 		if err := v.decoder.Decode(req, &underlay); err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
-		if req.OldObject.Size() > 0 {
-			if err := v.decoder.DecodeRaw(req.OldObject, &oldUnderlay); err != nil {
-				return admission.Errored(http.StatusBadRequest, err)
-			}
+	}
+	if req.Operation != v1.Delete && req.OldObject.Size() > 0 {
+		if err := v.decoder.DecodeRaw(req.OldObject, &oldUnderlay); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
 		}
 	}
 

--- a/operator/internal/helm/helm_test.go
+++ b/operator/internal/helm/helm_test.go
@@ -280,16 +280,7 @@ func TestParseChartWithMasterTolerations(t *testing.T) {
 					ds := appsv1.DaemonSet{}
 					err = runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), &ds)
 					g.Expect(err).ToNot(HaveOccurred())
-
-					hasMasterToleration := false
-					for _, tol := range ds.Spec.Template.Spec.Tolerations {
-						if (tol.Key == "node-role.kubernetes.io/master" || tol.Key == "node-role.kubernetes.io/control-plane") &&
-							tol.Effect == v1.TaintEffectNoSchedule {
-							hasMasterToleration = true
-							break
-						}
-					}
-					g.Expect(hasMasterToleration).To(Equal(tt.expectTolerations),
+					g.Expect(hasMasterToleration(ds.Spec.Template.Spec.Tolerations)).To(Equal(tt.expectTolerations),
 						fmt.Sprintf("DaemonSet %s should have master toleration=%v", obj.GetName(), tt.expectTolerations))
 				}
 
@@ -297,21 +288,22 @@ func TestParseChartWithMasterTolerations(t *testing.T) {
 					deployment := appsv1.Deployment{}
 					err = runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), &deployment)
 					g.Expect(err).ToNot(HaveOccurred())
-
-					hasMasterToleration := false
-					for _, tol := range deployment.Spec.Template.Spec.Tolerations {
-						if (tol.Key == "node-role.kubernetes.io/master" || tol.Key == "node-role.kubernetes.io/control-plane") &&
-							tol.Effect == v1.TaintEffectNoSchedule {
-							hasMasterToleration = true
-							break
-						}
-					}
-					g.Expect(hasMasterToleration).To(Equal(tt.expectTolerations),
+					g.Expect(hasMasterToleration(deployment.Spec.Template.Spec.Tolerations)).To(Equal(tt.expectTolerations),
 						fmt.Sprintf("Deployment %s should have master toleration=%v", obj.GetName(), tt.expectTolerations))
 				}
 			}
 		})
 	}
+}
+
+func hasMasterToleration(tolerations []v1.Toleration) bool {
+	for _, tol := range tolerations {
+		if (tol.Key == "node-role.kubernetes.io/master" || tol.Key == "node-role.kubernetes.io/control-plane") &&
+			tol.Effect == v1.TaintEffectNoSchedule {
+			return true
+		}
+	}
+	return false
 }
 
 func validateLogLevel(level string, pod v1.PodTemplateSpec) error {

--- a/operator/internal/helm/merge.go
+++ b/operator/internal/helm/merge.go
@@ -82,57 +82,57 @@ func mergeDeploymentForUpdate(current, updated *uns.Unstructured) error {
 // mergeServiceForUpdate ensures the ClusterIP/IPFamily is never modified
 func mergeServiceForUpdate(current, updated *uns.Unstructured) error {
 	gvk := updated.GroupVersionKind()
-	if gvk.Group == "" && gvk.Kind == "Service" {
-		clusterIP, found, err := uns.NestedString(current.Object, "spec", "clusterIP")
-		if err != nil {
-			return err
-		}
-		if found {
-			err = uns.SetNestedField(updated.Object, clusterIP, "spec", "clusterIP")
-			if err != nil {
-				return err
-			}
-		}
-
-		clusterIPs, found, err := uns.NestedStringSlice(current.Object, "spec", "clusterIPs")
-		if err != nil {
-			return err
-		}
-		if found {
-			err = uns.SetNestedStringSlice(updated.Object, clusterIPs, "spec", "clusterIPs")
-			if err != nil {
-				return err
-			}
-		}
-
-		ipFamilies, found, err := uns.NestedStringSlice(current.Object, "spec", "ipFamilies")
-		if err != nil {
-			return err
-		}
-		if found {
-			err = uns.SetNestedStringSlice(updated.Object, ipFamilies, "spec", "ipFamilies")
-			if err != nil {
-				return err
-			}
-		}
-
-		ipFamilyPolicy, foundOld, err := uns.NestedString(current.Object, "spec", "ipFamilyPolicy")
-		if err != nil {
-			return err
-		}
-		_, foundNew, err := uns.NestedString(updated.Object, "spec", "ipFamilyPolicy")
-		if err != nil {
-			return err
-		}
-		if foundOld && !foundNew {
-			err = uns.SetNestedField(updated.Object, ipFamilyPolicy, "spec", "ipFamilyPolicy")
-			if err != nil {
-				return err
-			}
-		}
-
+	if gvk.Group != "" {
+		return nil
+	}
+	if gvk.Kind != "Service" {
+		return nil
 	}
 
+	if err := copyNestedString(current.Object, updated.Object, "spec", "clusterIP"); err != nil {
+		return err
+	}
+	if err := copyNestedStringSlice(current.Object, updated.Object, "spec", "clusterIPs"); err != nil {
+		return err
+	}
+	if err := copyNestedStringSlice(current.Object, updated.Object, "spec", "ipFamilies"); err != nil {
+		return err
+	}
+
+	ipFamilyPolicy, foundOld, err := uns.NestedString(current.Object, "spec", "ipFamilyPolicy")
+	if err != nil {
+		return err
+	}
+	_, foundNew, err := uns.NestedString(updated.Object, "spec", "ipFamilyPolicy")
+	if err != nil {
+		return err
+	}
+	if foundOld && !foundNew {
+		return uns.SetNestedField(updated.Object, ipFamilyPolicy, "spec", "ipFamilyPolicy")
+	}
+
+	return nil
+}
+
+func copyNestedString(src, dst map[string]interface{}, fields ...string) error {
+	val, found, err := uns.NestedString(src, fields...)
+	if err != nil {
+		return err
+	}
+	if found {
+		return uns.SetNestedField(dst, val, fields...)
+	}
+	return nil
+}
+
+func copyNestedStringSlice(src, dst map[string]interface{}, fields ...string) error {
+	val, found, err := uns.NestedStringSlice(src, fields...)
+	if err != nil {
+		return err
+	}
+	if found {
+		return uns.SetNestedStringSlice(dst, val, fields...)
+	}
 	return nil
 }
 
@@ -142,23 +142,27 @@ func mergeServiceForUpdate(current, updated *uns.Unstructured) error {
 // any secrets ourselves.
 func mergeServiceAccountForUpdate(current, updated *uns.Unstructured) error {
 	gvk := updated.GroupVersionKind()
-	if gvk.Group == "" && gvk.Kind == "ServiceAccount" {
-		curSecrets, ok, err := uns.NestedSlice(current.Object, "secrets")
-		if err != nil {
-			return err
-		}
+	if gvk.Group != "" {
+		return nil
+	}
+	if gvk.Kind != "ServiceAccount" {
+		return nil
+	}
 
-		if ok {
-			_ = uns.SetNestedField(updated.Object, curSecrets, "secrets")
-		}
+	curSecrets, ok, err := uns.NestedSlice(current.Object, "secrets")
+	if err != nil {
+		return err
+	}
+	if ok {
+		_ = uns.SetNestedField(updated.Object, curSecrets, "secrets")
+	}
 
-		curImagePullSecrets, ok, err := uns.NestedSlice(current.Object, "imagePullSecrets")
-		if err != nil {
-			return err
-		}
-		if ok {
-			_ = uns.SetNestedField(updated.Object, curImagePullSecrets, "imagePullSecrets")
-		}
+	curImagePullSecrets, ok, err := uns.NestedSlice(current.Object, "imagePullSecrets")
+	if err != nil {
+		return err
+	}
+	if ok {
+		_ = uns.SetNestedField(updated.Object, curImagePullSecrets, "imagePullSecrets")
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

Trying to cover and automate a few recurring themes in CI

> Uncomment only one, leave it on its own line:
>
> /kind bug
kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

There are a lot of recurring patterns that can be (at least partially) automated by CI.
Here we try to cover them either with CI or by instructing gemini.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
