### PR TITLE
Fix health probe port race between static and k8s reconcilers

### DIFF
--- a/cmd/hostcontroller/main.go
+++ b/cmd/hostcontroller/main.go
@@ -206,7 +206,9 @@ func runHostMode(
 	staticControllerCtx, stopStaticReconciler := context.WithCancel(ctx)
 	defer stopStaticReconciler()
 
+	staticDone := make(chan struct{})
 	go func() {
+		defer close(staticDone)
 		logger.Info("creating static configuration controller for host mode")
 		err := runStaticConfigReconciler(
 			staticControllerCtx, args, hostModeParams, nodeConfig, logger, args.probeAddr,
@@ -232,6 +234,10 @@ func runHostMode(
 	logger.Info("kubernetes API is now available, stopping static reconciler and starting k8s reconciler")
 
 	stopStaticReconciler()
+	// Wait for the static reconciler to fully stop and release the health probe port
+	// before starting the K8s reconciler, which binds the same port.
+	<-staticDone
+	logger.Info("static reconciler fully stopped, starting k8s reconciler")
 
 	// Start API reconciler in main thread (blocking) - keeps process alive
 	if err := runK8sConfigReconcilerHostMode(


### PR DESCRIPTION


<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

In host mode, when the K8s API is available immediately (e.g. on a control-plane node), stopStaticReconciler() cancels the context but the static manager's health probe listener on :9081 hasn't released the port yet. The K8s reconciler then fails to bind the same port with "address already in use", crashing the controller.

Wait for the static reconciler goroutine to fully exit before starting the K8s reconciler, ensuring the health probe port is released.


Spotted in https://github.com/openperouter/openperouter/actions/runs/24667715133/job/72130625439?pr=310

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix start race condition where k8s api is available already, the static controller dies but the health port is not free yet, causing the k8sapicontroller to die because the port is not ready. 
```
