### PR TITLE
E2E: Refactor redistributeConnectedForLeaf and RemovePrefixes()

### DIFF
--- a/e2etests/pkg/infra/leaf.go
+++ b/e2etests/pkg/infra/leaf.go
@@ -189,31 +189,26 @@ func (l Leaf) ChangePrefixes(defaultPrefixes, redPrefixes, bluePrefixes []string
 	redIPv4, redIPv6 := SeparateIPFamilies(redPrefixes)
 	blueIPv4, blueIPv6 := SeparateIPFamilies(bluePrefixes)
 
-	leafConfiguration := LeafConfiguration{
-		Leaf: l,
-		Default: Addresses{
-			IPV4: defaultIPv4,
-			IPV6: defaultIPv6,
-		},
-		Red: Addresses{
-			IPV4: redIPv4,
-			IPV6: redIPv6,
-		},
-		Blue: Addresses{
-			IPV4: blueIPv4,
-			IPV6: blueIPv6,
-		},
-	}
-	config, err := LeafConfigToFRR(leafConfiguration)
-	if err != nil {
-		return err
-	}
-	return l.ReloadConfig(config)
+	return l.Configure(LeafConfiguration{
+		Default: Addresses{IPV4: defaultIPv4, IPV6: defaultIPv6},
+		Red:     Addresses{IPV4: redIPv4, IPV6: redIPv6},
+		Blue:    Addresses{IPV4: blueIPv4, IPV6: blueIPv6},
+	})
 }
 
-// RemovePrefixes removes all prefixes from the leaf configuration.
-func (l Leaf) RemovePrefixes() error {
-	return l.ChangePrefixes([]string{}, []string{}, []string{})
+// RedistributeConnected updates the leaf configuration to redistribute connected
+// prefixes.
+func (l Leaf) RedistributeConnected() error {
+	return l.Configure(LeafConfiguration{
+		Red:     Addresses{RedistributeConnected: true},
+		Blue:    Addresses{RedistributeConnected: true},
+		Default: Addresses{RedistributeConnected: true},
+	})
+}
+
+// Reset resets Leaf configuration to default values.
+func (l Leaf) Reset() error {
+	return l.Configure(LeafConfiguration{})
 }
 
 // SeparateIPFamilies separates a slice of CIDR prefixes into IPv4 and IPv6 slices

--- a/e2etests/pkg/infra/leaf.go
+++ b/e2etests/pkg/infra/leaf.go
@@ -192,31 +192,26 @@ func (l Leaf) ChangePrefixes(defaultPrefixes, redPrefixes, bluePrefixes []string
 	redIPv4, redIPv6 := SeparateIPFamilies(redPrefixes)
 	blueIPv4, blueIPv6 := SeparateIPFamilies(bluePrefixes)
 
-	leafConfiguration := LeafConfiguration{
-		Leaf: l,
-		Default: Addresses{
-			IPV4: defaultIPv4,
-			IPV6: defaultIPv6,
-		},
-		Red: Addresses{
-			IPV4: redIPv4,
-			IPV6: redIPv6,
-		},
-		Blue: Addresses{
-			IPV4: blueIPv4,
-			IPV6: blueIPv6,
-		},
-	}
-	config, err := LeafConfigToFRR(leafConfiguration)
-	if err != nil {
-		return err
-	}
-	return l.ReloadConfig(config)
+	return l.Configure(LeafConfiguration{
+		Default: Addresses{IPV4: defaultIPv4, IPV6: defaultIPv6},
+		Red:     Addresses{IPV4: redIPv4, IPV6: redIPv6},
+		Blue:    Addresses{IPV4: blueIPv4, IPV6: blueIPv6},
+	})
 }
 
-// RemovePrefixes removes all prefixes from the leaf configuration.
-func (l Leaf) RemovePrefixes() error {
-	return l.ChangePrefixes([]string{}, []string{}, []string{})
+// RedistributeConnected updates the leaf configuration to redistribute connected
+// prefixes.
+func (l Leaf) RedistributeConnected() error {
+	return l.Configure(LeafConfiguration{
+		Red:     Addresses{RedistributeConnected: true},
+		Blue:    Addresses{RedistributeConnected: true},
+		Default: Addresses{RedistributeConnected: true},
+	})
+}
+
+// Reset resets Leaf configuration to default values.
+func (l Leaf) Reset() error {
+	return l.Configure(LeafConfiguration{})
 }
 
 // SeparateIPFamilies separates a slice of CIDR prefixes into IPv4 and IPv6 slices

--- a/e2etests/systemd_static_suite/systemd_static_files_test.go
+++ b/e2etests/systemd_static_suite/systemd_static_files_test.go
@@ -56,8 +56,8 @@ var _ = Describe("Static configuration", Ordered, func() {
 
 	Context("with vnis", func() {
 		AfterEach(func() {
-			Expect(infra.LeafAConfig.RemovePrefixes()).To(Succeed())
-			Expect(infra.LeafBConfig.RemovePrefixes()).To(Succeed())
+			Expect(infra.LeafAConfig.Reset()).To(Succeed())
+			Expect(infra.LeafBConfig.Reset()).To(Succeed())
 		})
 
 		It("receives type 5 routes from the fabric", func() {

--- a/e2etests/tests/bridgerefresh.go
+++ b/e2etests/tests/bridgerefresh.go
@@ -88,8 +88,8 @@ var _ = Describe("BridgeRefresher E2E - Type 2 Route Persistence", Ordered, func
 		routers.Dump(ginkgo.GinkgoWriter)
 
 		By("setting redistribute connected on leaves")
-		redistributeConnectedForLeaf(infra.LeafAConfig)
-		redistributeConnectedForLeaf(infra.LeafBConfig)
+		Expect(infra.LeafAConfig.RedistributeConnected()).To(Succeed())
+		Expect(infra.LeafBConfig.RedistributeConnected()).To(Succeed())
 	})
 
 	AfterAll(func() {
@@ -104,8 +104,8 @@ var _ = Describe("BridgeRefresher E2E - Type 2 Route Persistence", Ordered, func
 			return openperouter.DaemonsetRolled(routers, newRouters)
 		}, 2*time.Minute, time.Second).ShouldNot(HaveOccurred())
 
-		Expect(infra.LeafAConfig.RemovePrefixes()).To(Succeed())
-		Expect(infra.LeafBConfig.RemovePrefixes()).To(Succeed())
+		Expect(infra.LeafAConfig.Reset()).To(Succeed())
+		Expect(infra.LeafBConfig.Reset()).To(Succeed())
 	})
 
 	Context("Type 2 Route Persistence with Silent Workload", func() {
@@ -393,4 +393,3 @@ func checkNeighborStale(cs clientset.Interface, podIP string, vni int, nodeName 
 	}
 	return fmt.Errorf("neighbor %s on %s in router %s is not STALE yet: %s", podIP, bridgeDev, exec.Name(), out)
 }
-

--- a/e2etests/tests/bridgerefresh.go
+++ b/e2etests/tests/bridgerefresh.go
@@ -88,8 +88,10 @@ var _ = Describe("BridgeRefresher E2E - Type 2 Route Persistence", Ordered, func
 		routers.Dump(ginkgo.GinkgoWriter)
 
 		By("setting redistribute connected on leaves")
-		redistributeConnectedForLeaf(infra.LeafAConfig)
-		redistributeConnectedForLeaf(infra.LeafBConfig)
+		err = infra.LeafAConfig.RedistributeConnected()
+		Expect(err).NotTo(HaveOccurred())
+		err = infra.LeafBConfig.RedistributeConnected()
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterAll(func() {
@@ -104,8 +106,8 @@ var _ = Describe("BridgeRefresher E2E - Type 2 Route Persistence", Ordered, func
 			return openperouter.DaemonsetRolled(routers, newRouters)
 		}, 2*time.Minute, time.Second).ShouldNot(HaveOccurred())
 
-		Expect(infra.LeafAConfig.RemovePrefixes()).To(Succeed())
-		Expect(infra.LeafBConfig.RemovePrefixes()).To(Succeed())
+		Expect(infra.LeafAConfig.Reset()).To(Succeed())
+		Expect(infra.LeafBConfig.Reset()).To(Succeed())
 	})
 
 	Context("Type 2 Route Persistence with Silent Workload", func() {
@@ -393,4 +395,3 @@ func checkNeighborStale(cs clientset.Interface, podIP string, vni int, nodeName 
 	}
 	return fmt.Errorf("neighbor %s on %s in router %s is not STALE yet: %s", podIP, bridgeDev, exec.Name(), out)
 }
-

--- a/e2etests/tests/evpn_l2.go
+++ b/e2etests/tests/evpn_l2.go
@@ -125,8 +125,8 @@ var _ = Describe("Routes between bgp and the fabric", Ordered, func() {
 		nadMaster                                                         string              // Bridge name for NAD (defaults to "br-hs-110")
 	}
 	AfterEach(func() {
-		Expect(infra.LeafAConfig.RemovePrefixes()).To(Succeed())
-		Expect(infra.LeafBConfig.RemovePrefixes()).To(Succeed())
+		Expect(infra.LeafAConfig.Reset()).To(Succeed())
+		Expect(infra.LeafBConfig.Reset()).To(Succeed())
 		dumpIfFails(cs)
 		err := Updater.CleanButUnderlay()
 		Expect(err).NotTo(HaveOccurred())
@@ -136,8 +136,10 @@ var _ = Describe("Routes between bgp and the fabric", Ordered, func() {
 
 	DescribeTable("should create two pods connected to the l2 overlay", func(tc testCase) {
 		By("setting redistribute connected on leaves")
-		redistributeConnectedForLeaf(infra.LeafAConfig)
-		redistributeConnectedForLeaf(infra.LeafBConfig)
+		err := infra.LeafAConfig.RedistributeConnected()
+		Expect(err).NotTo(HaveOccurred())
+		err = infra.LeafBConfig.RedistributeConnected()
+		Expect(err).NotTo(HaveOccurred())
 
 		nodes, err := k8s.GetNodes(cs)
 		Expect(err).NotTo(HaveOccurred())

--- a/e2etests/tests/evpn_l2.go
+++ b/e2etests/tests/evpn_l2.go
@@ -125,8 +125,8 @@ var _ = Describe("Routes between bgp and the fabric", Ordered, func() {
 		nadMaster                                                         string              // Bridge name for NAD (defaults to "br-hs-110")
 	}
 	AfterEach(func() {
-		Expect(infra.LeafAConfig.RemovePrefixes()).To(Succeed())
-		Expect(infra.LeafBConfig.RemovePrefixes()).To(Succeed())
+		Expect(infra.LeafAConfig.Reset()).To(Succeed())
+		Expect(infra.LeafBConfig.Reset()).To(Succeed())
 		dumpIfFails(cs)
 		err := Updater.CleanButUnderlay()
 		Expect(err).NotTo(HaveOccurred())
@@ -136,8 +136,8 @@ var _ = Describe("Routes between bgp and the fabric", Ordered, func() {
 
 	DescribeTable("should create two pods connected to the l2 overlay", func(tc testCase) {
 		By("setting redistribute connected on leaves")
-		redistributeConnectedForLeaf(infra.LeafAConfig)
-		redistributeConnectedForLeaf(infra.LeafBConfig)
+		Expect(infra.LeafAConfig.RedistributeConnected()).To(Succeed())
+		Expect(infra.LeafBConfig.RedistributeConnected()).To(Succeed())
 
 		nodes, err := k8s.GetNodes(cs)
 		Expect(err).NotTo(HaveOccurred())

--- a/e2etests/tests/evpn_routes.go
+++ b/e2etests/tests/evpn_routes.go
@@ -117,8 +117,8 @@ var _ = Describe("Routes between bgp and the fabric", Ordered, func() {
 			dumpIfFails(cs)
 			err := Updater.CleanButUnderlay()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(infra.LeafAConfig.RemovePrefixes()).To(Succeed())
-			Expect(infra.LeafBConfig.RemovePrefixes()).To(Succeed())
+			Expect(infra.LeafAConfig.Reset()).To(Succeed())
+			Expect(infra.LeafBConfig.Reset()).To(Succeed())
 		})
 
 		BeforeEach(func() {
@@ -225,8 +225,8 @@ var _ = Describe("Routes between bgp and the fabric", Ordered, func() {
 			dumpIfFails(cs)
 			err := Updater.CleanButUnderlay()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(infra.LeafAConfig.RemovePrefixes()).To(Succeed())
-			Expect(infra.LeafBConfig.RemovePrefixes()).To(Succeed())
+			Expect(infra.LeafAConfig.Reset()).To(Succeed())
+			Expect(infra.LeafBConfig.Reset()).To(Succeed())
 		})
 
 		It("translates EVPN incoming routes as BGP routes", func() {
@@ -276,8 +276,8 @@ var _ = Describe("Routes between bgp and the fabric", Ordered, func() {
 
 		BeforeAll(func() {
 			By("setting redistribute connected on leaves")
-			redistributeConnectedForLeaf(infra.LeafAConfig)
-			redistributeConnectedForLeaf(infra.LeafBConfig)
+			Expect(infra.LeafAConfig.RedistributeConnected()).To(Succeed())
+			Expect(infra.LeafBConfig.RedistributeConnected()).To(Succeed())
 
 			By("Creating the test namespace")
 			_, err := k8s.CreateNamespace(cs, testNamespace)
@@ -318,8 +318,8 @@ var _ = Describe("Routes between bgp and the fabric", Ordered, func() {
 
 			err = Updater.CleanButUnderlay()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(infra.LeafAConfig.RemovePrefixes()).To(Succeed())
-			Expect(infra.LeafBConfig.RemovePrefixes()).To(Succeed())
+			Expect(infra.LeafAConfig.Reset()).To(Succeed())
+			Expect(infra.LeafBConfig.Reset()).To(Succeed())
 		})
 
 		AfterEach(func() {
@@ -489,8 +489,8 @@ var _ = Describe("Routes between bgp and the fabric with iBGP testing e2e integr
 		Expect(err).NotTo(HaveOccurred())
 
 		By("setting redistribute connected on leaves")
-		redistributeConnectedForLeaf(infra.LeafAConfig)
-		redistributeConnectedForLeaf(infra.LeafBConfig)
+		Expect(infra.LeafAConfig.RedistributeConnected()).To(Succeed())
+		Expect(infra.LeafBConfig.RedistributeConnected()).To(Succeed())
 
 		By("Creating the test namespace")
 		_, err = k8s.CreateNamespace(cs, testNamespace)
@@ -532,8 +532,8 @@ var _ = Describe("Routes between bgp and the fabric with iBGP testing e2e integr
 		Expect(err).NotTo(HaveOccurred())
 
 		// RemovePrefixes() is used to reset the LeafA and LeafB configurations to default.
-		Expect(infra.LeafAConfig.RemovePrefixes()).To(Succeed())
-		Expect(infra.LeafBConfig.RemovePrefixes()).To(Succeed())
+		Expect(infra.LeafAConfig.Reset()).To(Succeed())
+		Expect(infra.LeafBConfig.Reset()).To(Succeed())
 
 		resetLeafKindConfig(nodes)
 

--- a/e2etests/tests/evpn_routes.go
+++ b/e2etests/tests/evpn_routes.go
@@ -117,8 +117,8 @@ var _ = Describe("Routes between bgp and the fabric", Ordered, func() {
 			dumpIfFails(cs)
 			err := Updater.CleanButUnderlay()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(infra.LeafAConfig.RemovePrefixes()).To(Succeed())
-			Expect(infra.LeafBConfig.RemovePrefixes()).To(Succeed())
+			Expect(infra.LeafAConfig.Reset()).To(Succeed())
+			Expect(infra.LeafBConfig.Reset()).To(Succeed())
 		})
 
 		BeforeEach(func() {
@@ -228,8 +228,8 @@ var _ = Describe("Routes between bgp and the fabric", Ordered, func() {
 			dumpIfFails(cs)
 			err := Updater.CleanButUnderlay()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(infra.LeafAConfig.RemovePrefixes()).To(Succeed())
-			Expect(infra.LeafBConfig.RemovePrefixes()).To(Succeed())
+			Expect(infra.LeafAConfig.Reset()).To(Succeed())
+			Expect(infra.LeafBConfig.Reset()).To(Succeed())
 		})
 
 		It("translates EVPN incoming routes as BGP routes", func() {
@@ -279,11 +279,13 @@ var _ = Describe("Routes between bgp and the fabric", Ordered, func() {
 
 		BeforeAll(func() {
 			By("setting redistribute connected on leaves")
-			redistributeConnectedForLeaf(infra.LeafAConfig)
-			redistributeConnectedForLeaf(infra.LeafBConfig)
+			err := infra.LeafAConfig.RedistributeConnected()
+			Expect(err).NotTo(HaveOccurred())
+			err = infra.LeafBConfig.RedistributeConnected()
+			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating the test namespace")
-			_, err := k8s.CreateNamespace(cs, testNamespace)
+			_, err = k8s.CreateNamespace(cs, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating the test pod")
@@ -339,8 +341,8 @@ var _ = Describe("Routes between bgp and the fabric", Ordered, func() {
 
 			err = Updater.CleanButUnderlay()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(infra.LeafAConfig.RemovePrefixes()).To(Succeed())
-			Expect(infra.LeafBConfig.RemovePrefixes()).To(Succeed())
+			Expect(infra.LeafAConfig.Reset()).To(Succeed())
+			Expect(infra.LeafBConfig.Reset()).To(Succeed())
 		})
 
 		AfterEach(func() {

--- a/e2etests/tests/frr_restart.go
+++ b/e2etests/tests/frr_restart.go
@@ -75,8 +75,8 @@ var _ = Describe("North/south traffic after FRR container restart", Ordered, fun
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		redistributeConnectedForLeaf(infra.LeafAConfig)
-		redistributeConnectedForLeaf(infra.LeafBConfig)
+		Expect(infra.LeafAConfig.RedistributeConnected()).To(Succeed())
+		Expect(infra.LeafBConfig.RedistributeConnected()).To(Succeed())
 	})
 
 	AfterAll(func() {
@@ -115,8 +115,8 @@ var _ = Describe("North/south traffic after FRR container restart", Ordered, fun
 		Expect(err).NotTo(HaveOccurred())
 
 		DeferCleanup(func() {
-			Expect(infra.LeafAConfig.RemovePrefixes()).To(Succeed())
-			Expect(infra.LeafBConfig.RemovePrefixes()).To(Succeed())
+			Expect(infra.LeafAConfig.Reset()).To(Succeed())
+			Expect(infra.LeafBConfig.Reset()).To(Succeed())
 			dumpIfFails(cs)
 			err := Updater.CleanButUnderlay()
 			Expect(err).NotTo(HaveOccurred())

--- a/e2etests/tests/frr_restart.go
+++ b/e2etests/tests/frr_restart.go
@@ -75,8 +75,10 @@ var _ = Describe("North/south traffic after FRR container restart", Ordered, fun
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		redistributeConnectedForLeaf(infra.LeafAConfig)
-		redistributeConnectedForLeaf(infra.LeafBConfig)
+		err = infra.LeafAConfig.RedistributeConnected()
+		Expect(err).NotTo(HaveOccurred())
+		err = infra.LeafBConfig.RedistributeConnected()
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterAll(func() {
@@ -115,8 +117,8 @@ var _ = Describe("North/south traffic after FRR container restart", Ordered, fun
 		Expect(err).NotTo(HaveOccurred())
 
 		DeferCleanup(func() {
-			Expect(infra.LeafAConfig.RemovePrefixes()).To(Succeed())
-			Expect(infra.LeafBConfig.RemovePrefixes()).To(Succeed())
+			Expect(infra.LeafAConfig.Reset()).To(Succeed())
+			Expect(infra.LeafBConfig.Reset()).To(Succeed())
 			dumpIfFails(cs)
 			err := Updater.CleanButUnderlay()
 			Expect(err).NotTo(HaveOccurred())

--- a/e2etests/tests/leaf.go
+++ b/e2etests/tests/leaf.go
@@ -8,25 +8,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func redistributeConnectedForLeaf(leaf infra.Leaf) {
-	leafConfiguration := infra.LeafConfiguration{
-		Leaf: leaf,
-		Red: infra.Addresses{
-			RedistributeConnected: true,
-		},
-		Blue: infra.Addresses{
-			RedistributeConnected: true,
-		},
-		Default: infra.Addresses{
-			RedistributeConnected: true,
-		},
-	}
-	config, err := infra.LeafConfigToFRR(leafConfiguration)
-	Expect(err).NotTo(HaveOccurred())
-	err = leaf.ReloadConfig(config)
-	Expect(err).NotTo(HaveOccurred())
-}
-
 func redistributeConnectedForLeafKind(nodes []corev1.Node) {
 	neighbors := []string{}
 	for _, node := range nodes {

--- a/e2etests/tests/passthrough_routes.go
+++ b/e2etests/tests/passthrough_routes.go
@@ -126,8 +126,8 @@ var _ = Describe("Routes between bgp and the fabric", Label("passthrough"), Orde
 			dumpIfFails(cs)
 			err := Updater.CleanButUnderlay()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(infra.LeafAConfig.RemovePrefixes()).To(Succeed())
-			Expect(infra.LeafBConfig.RemovePrefixes()).To(Succeed())
+			Expect(infra.LeafAConfig.Reset()).To(Succeed())
+			Expect(infra.LeafBConfig.Reset()).To(Succeed())
 		})
 
 		It("translates BGP incoming routes as BGP routes", func() {
@@ -163,11 +163,13 @@ var _ = Describe("Routes between bgp and the fabric", Label("passthrough"), Orde
 
 		BeforeAll(func() {
 			By("setting redistribute connected on leaves")
-			redistributeConnectedForLeaf(infra.LeafAConfig)
-			redistributeConnectedForLeaf(infra.LeafBConfig)
+			err := infra.LeafAConfig.RedistributeConnected()
+			Expect(err).NotTo(HaveOccurred())
+			err = infra.LeafBConfig.RedistributeConnected()
+			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating the test namespace")
-			_, err := k8s.CreateNamespace(cs, testNamespace)
+			_, err = k8s.CreateNamespace(cs, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating the test pod")
@@ -220,8 +222,8 @@ var _ = Describe("Routes between bgp and the fabric", Label("passthrough"), Orde
 
 			err = Updater.CleanButUnderlay()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(infra.LeafAConfig.RemovePrefixes()).To(Succeed())
-			Expect(infra.LeafBConfig.RemovePrefixes()).To(Succeed())
+			Expect(infra.LeafAConfig.Reset()).To(Succeed())
+			Expect(infra.LeafBConfig.Reset()).To(Succeed())
 		})
 
 		AfterEach(func() {

--- a/e2etests/tests/passthrough_routes.go
+++ b/e2etests/tests/passthrough_routes.go
@@ -121,8 +121,8 @@ var _ = Describe("Routes between bgp and the fabric", Label("passthrough"), Orde
 			dumpIfFails(cs)
 			err := Updater.CleanButUnderlay()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(infra.LeafAConfig.RemovePrefixes()).To(Succeed())
-			Expect(infra.LeafBConfig.RemovePrefixes()).To(Succeed())
+			Expect(infra.LeafAConfig.Reset()).To(Succeed())
+			Expect(infra.LeafBConfig.Reset()).To(Succeed())
 		})
 
 		It("translates BGP incoming routes as BGP routes", func() {
@@ -158,8 +158,8 @@ var _ = Describe("Routes between bgp and the fabric", Label("passthrough"), Orde
 
 		BeforeAll(func() {
 			By("setting redistribute connected on leaves")
-			redistributeConnectedForLeaf(infra.LeafAConfig)
-			redistributeConnectedForLeaf(infra.LeafBConfig)
+			Expect(infra.LeafAConfig.RedistributeConnected()).To(Succeed())
+			Expect(infra.LeafBConfig.RedistributeConnected()).To(Succeed())
 
 			By("Creating the test namespace")
 			_, err := k8s.CreateNamespace(cs, testNamespace)
@@ -215,8 +215,8 @@ var _ = Describe("Routes between bgp and the fabric", Label("passthrough"), Orde
 
 			err = Updater.CleanButUnderlay()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(infra.LeafAConfig.RemovePrefixes()).To(Succeed())
-			Expect(infra.LeafBConfig.RemovePrefixes()).To(Succeed())
+			Expect(infra.LeafAConfig.Reset()).To(Succeed())
+			Expect(infra.LeafBConfig.Reset()).To(Succeed())
 		})
 
 		AfterEach(func() {

--- a/e2etests/tests/static_and_api.go
+++ b/e2etests/tests/static_and_api.go
@@ -164,8 +164,8 @@ var _ = Describe("Hybrid mode: static files and API configuration", Label("syste
 			GinkgoWriter.Printf("Warning: failed to delete DaemonSet: %v\n", err)
 		}
 
-		Expect(infra.LeafAConfig.RemovePrefixes()).To(Succeed())
-		Expect(infra.LeafBConfig.RemovePrefixes()).To(Succeed())
+		Expect(infra.LeafAConfig.Reset()).To(Succeed())
+		Expect(infra.LeafBConfig.Reset()).To(Succeed())
 
 		err = Updater.CleanAll()
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Make redistributeConnectedForLeaf a method of Leaf.
Having RedistributeConnected() as a method mirrors ChangePrefixes()
and is thus more consistent with that code.
Combined with the changes for leafkind in PR286 for leafkind, this
will allow us to remove file e2etests/tests/leaf.go.
Rename RemovePrefixes() to Reset() to clarify the intent and avoid
confusion.

Fixes: https://github.com/openperouter/openperouter/issues/324

**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:

A lot of the E2E tests run:
redistributeConnectedForLeaf(infra.LeafAConfig) which is then reset by infra.LeafAConfig.RemovePrefixes())
infra.LeafAConfig.RemovePrefixes()) will generate and apply a clean, default leaf configuration and thus resets the change made by redistributeConnectedForLeaf. However, readers of the E2Etests can only understand this logic if they drill into RemovePrefixes().

We should fix this misleading naming.

**Special notes for your reviewer**:

N/A

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Cleanup of E2E Leaf modification logic
```
