### PR TITLE
enhancement: controller-provisioned underlay interfaces

### DIFF
--- a/enhancements/controller-provisioned-underlay-interfaces.md
+++ b/enhancements/controller-provisioned-underlay-interfaces.md
@@ -1,0 +1,615 @@
+# Controller-Provisioned Underlay Interfaces
+
+## Summary
+
+Replace the current underlay connectivity model — where the controller either
+moves a physical NIC into the router network namespace or delegates to Multus —
+with a single, explicit API field that lets the operator choose **how** the
+router connects to the physical underlay. The new `underlayInterface` field in
+the Underlay CRD uses a discriminated union (type enum + per-type sub-struct)
+to support three modes: `physical` (move the entire NIC), `macvlan` (derive a
+macvlan child), and `ipvlan` (derive an ipvlan child). The controller provisions
+the interface directly — Multus is no longer involved in underlay connectivity
+for the router.
+
+## Motivation
+
+### Goals
+
+- **Deprecate Multus for router underlay connectivity.** With the persistent
+  named netns model (see [router-resiliency.md](router-resiliency.md)), the
+  router runs as a `hostNetwork` pod or a Podman quadlet. Neither deployment
+  model integrates with Multus CNI, which operates on pod network namespaces
+  managed by the container runtime. The controller must provision underlay
+  interfaces itself.
+
+- **Explicit interface type selection.** Today, the operator must coordinate
+  two separate knobs — the `nics` field in the Underlay CRD and the
+  `--underlay-from-multus` controller flag — to express a single intent.
+  The new API collapses this into one declarative field with explicit type
+  semantics.
+
+- **Enable NIC sharing.** Moving a physical NIC into the router netns
+  (`physical` mode) makes the NIC exclusively available to the router. The
+  `macvlan` and `ipvlan` modes let the parent device remain on the host,
+  enabling scenarios such as:
+  - The host using the same NIC for management traffic.
+  - Multiple router instances (future redundant-instances enhancement) deriving
+    separate child interfaces from the same parent.
+
+- **Consistent API pattern.** Follow the existing discriminated-union pattern
+  established by `HostMaster` in the L2VNI CRD (`type` enum + per-type
+  sub-struct), so operators encounter a familiar structure across the API
+  surface.
+
+### Non-Goals
+
+- **SR-IOV support.** While the discriminated-union pattern makes it trivial to
+  add an `sriov` variant in the future, designing or implementing SR-IOV
+  support is out of scope for this enhancement.
+- **Changes to workload pod networking.** Multus-attached secondary interfaces
+  on application pods and KubeVirt VMs are completely unaffected.
+- **Redundant router instances.** macvlan/ipvlan enables NIC sharing, which is
+  a prerequisite for running multiple router instances per node, but the
+  multi-instance design itself is a separate enhancement.
+- **Per-node interface overrides.** All nodes matching the Underlay's
+  `nodeSelector` use the same interface configuration. Per-node customization
+  (e.g. different parent device names on different hardware) is handled by
+  creating multiple Underlay objects with non-overlapping node selectors.
+
+## Proposal
+
+### Overview
+
+Replace `UnderlaySpec.Nics []string` and the `--underlay-from-multus`
+controller flag with a single `underlayInterface` field. This field is a
+discriminated union: a `type` enum selects one of three modes, and a
+corresponding per-type sub-struct carries the parameters relevant to that mode.
+
+The three modes are:
+
+| Mode | Behavior | Host NIC availability |
+|------|----------|----------------------|
+| `physical` | Moves the entire NIC into the router netns | NIC is exclusively owned by the router |
+| `macvlan` | Creates a macvlan child from the parent device and moves the child into the router netns | Parent stays on the host |
+| `ipvlan` | Creates an ipvlan child from the parent device and moves the child into the router netns | Parent stays on the host |
+
+### API
+
+```yaml
+apiVersion: network.openperouter.io/v1alpha1
+kind: Underlay
+metadata:
+  name: underlay
+spec:
+  asn: 64514
+  routeridcidr: "10.0.0.0/24"
+  underlayInterface:
+    type: macvlan
+    macvlan:
+      parentDevice: eth1
+      mode: bridge
+  evpn:
+    vtepcidr: "100.65.0.0/24"
+  neighbors:
+    - address: 192.168.1.1
+      asn: 65000
+```
+
+#### Go Types
+
+```go
+// UnderlayInterface defines how the router connects to the physical underlay.
+// The type field selects the provisioning mode; exactly one of the corresponding
+// sub-structs (physical, macvlan, ipvlan) must be set to match the type.
+//
+// This follows the same discriminated-union pattern as HostMaster in L2VNISpec.
+//
+// +kubebuilder:validation:Required
+// +kubebuilder:validation:XValidation:rule="(self.type == 'physical' && has(self.physical) && !has(self.macvlan) && !has(self.ipvlan)) || (self.type == 'macvlan' && has(self.macvlan) && !has(self.physical) && !has(self.ipvlan)) || (self.type == 'ipvlan' && has(self.ipvlan) && !has(self.physical) && !has(self.macvlan))",message="type/config mismatch: the sub-struct must match the type field"
+type UnderlayInterface struct {
+	// Type selects how the router obtains underlay connectivity.
+	// +kubebuilder:validation:Enum=physical;macvlan;ipvlan
+	// +kubebuilder:validation:Required
+	Type string `json:"type"`
+
+	// Physical moves a host NIC exclusively into the router netns.
+	// Must be set when type is "physical".
+	// +optional
+	Physical *PhysicalInterface `json:"physical,omitempty"`
+
+	// Macvlan creates a macvlan child interface from a host NIC.
+	// The parent device stays on the host; the child is moved into the
+	// router netns. Must be set when type is "macvlan".
+	// +optional
+	Macvlan *MacvlanInterface `json:"macvlan,omitempty"`
+
+	// Ipvlan creates an ipvlan child interface from a host NIC.
+	// The parent device stays on the host; the child is moved into the
+	// router netns. Must be set when type is "ipvlan".
+	// +optional
+	Ipvlan *IpvlanInterface `json:"ipvlan,omitempty"`
+}
+
+// PhysicalInterface specifies a host NIC to move into the router netns.
+// The host loses access to this device while the router owns it.
+type PhysicalInterface struct {
+	// InterfaceName is the name of the host NIC to move.
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z][a-zA-Z0-9._-]*$`
+	// +kubebuilder:validation:MaxLength=15
+	// +kubebuilder:validation:Required
+	InterfaceName string `json:"interfaceName"`
+}
+
+// MacvlanInterface specifies a macvlan child interface to create from a
+// host NIC. The parent device remains on the host.
+type MacvlanInterface struct {
+	// ParentDevice is the host NIC from which the macvlan is derived.
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z][a-zA-Z0-9._-]*$`
+	// +kubebuilder:validation:MaxLength=15
+	// +kubebuilder:validation:Required
+	ParentDevice string `json:"parentDevice"`
+
+	// Mode is the macvlan operating mode.
+	// - bridge: all child interfaces can communicate directly (most common).
+	// - vepa: all traffic goes through the parent's external bridge/switch,
+	//   even between children on the same host.
+	// - private: children are completely isolated from each other.
+	// - passthru: a single child takes over the parent; only one child allowed.
+	// +kubebuilder:validation:Enum=bridge;vepa;private;passthru
+	// +kubebuilder:default=bridge
+	// +optional
+	Mode string `json:"mode,omitempty"`
+}
+
+// IpvlanInterface specifies an ipvlan child interface to create from a
+// host NIC. The parent device remains on the host. Unlike macvlan, ipvlan
+// shares the parent's MAC address — only one MAC appears on the wire.
+type IpvlanInterface struct {
+	// ParentDevice is the host NIC from which the ipvlan is derived.
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z][a-zA-Z0-9._-]*$`
+	// +kubebuilder:validation:MaxLength=15
+	// +kubebuilder:validation:Required
+	ParentDevice string `json:"parentDevice"`
+
+	// Mode is the ipvlan operating mode.
+	// - l2: operates at L2, child participates in ARP (most common).
+	// - l3: operates at L3, no ARP/NDP — the parent acts as a router.
+	// - l3s: like l3, but with netfilter/conntrack integration.
+	// +kubebuilder:validation:Enum=l2;l3;l3s
+	// +kubebuilder:default=l2
+	// +optional
+	Mode string `json:"mode,omitempty"`
+}
+```
+
+#### Examples
+
+**Physical (current behavior, replaces `nics: [eth1]`):**
+```yaml
+underlayInterface:
+  type: physical
+  physical:
+    interfaceName: eth1
+```
+
+**Macvlan (replaces Multus-based underlay):**
+```yaml
+underlayInterface:
+  type: macvlan
+  macvlan:
+    parentDevice: eth1
+    mode: bridge
+```
+
+**Ipvlan (shared MAC, useful when MAC learning is constrained):**
+```yaml
+underlayInterface:
+  type: ipvlan
+  ipvlan:
+    parentDevice: eth1
+    mode: l2
+```
+
+### User Stories
+
+#### Story 1: Operator Migrating from Multus-Based Underlay
+
+As a cluster operator currently using Multus to plumb the underlay NIC into the
+router pod, I want to switch to the named netns deployment model without losing
+underlay connectivity, so that I benefit from persistent data plane resiliency.
+
+**Before (Multus):**
+```yaml
+# Underlay CRD — nics omitted, Multus handles it
+spec:
+  asn: 64514
+  evpn:
+    vtepcidr: "100.65.0.0/24"
+  neighbors:
+    - address: 192.168.1.1
+      asn: 65000
+---
+# Separate NetworkAttachmentDefinition + controller flag
+# --underlay-from-multus=true
+```
+
+**After (controller-provisioned macvlan):**
+```yaml
+spec:
+  asn: 64514
+  underlayInterface:
+    type: macvlan
+    macvlan:
+      parentDevice: eth1
+      mode: bridge
+  evpn:
+    vtepcidr: "100.65.0.0/24"
+  neighbors:
+    - address: 192.168.1.1
+      asn: 65000
+```
+
+The intent is fully captured in one CRD. No separate NAD, no controller flag.
+
+#### Story 2: Operator Using Dedicated Physical NIC
+
+As a cluster operator with a dedicated physical NIC for underlay traffic, I want
+to move it exclusively into the router netns for maximum performance and
+isolation.
+
+```yaml
+underlayInterface:
+  type: physical
+  physical:
+    interfaceName: eth1
+```
+
+This is equivalent to the current `nics: [eth1]` behavior.
+
+#### Story 3: Operator Needing Shared NIC
+
+As a cluster operator on hardware with limited NICs, I want the host and the
+router to share the same physical NIC, so that I don't need a dedicated NIC for
+underlay traffic.
+
+```yaml
+underlayInterface:
+  type: macvlan
+  macvlan:
+    parentDevice: eth1
+    mode: bridge
+```
+
+The host retains `eth1` for management; the router gets a macvlan child with
+its own MAC and IP addressing.
+
+#### Story 4: Operator on a Network with MAC Restrictions
+
+As a cluster operator on a network that limits the number of MAC addresses per
+port (e.g. certain cloud or campus environments), I want the router's underlay
+interface to share the physical NIC's MAC address.
+
+```yaml
+underlayInterface:
+  type: ipvlan
+  ipvlan:
+    parentDevice: eth1
+    mode: l2
+```
+
+Only one MAC appears on the wire regardless of how many ipvlan children exist.
+
+### Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Breaking change to `nics` field | This is a `v1alpha1` API with no stability guarantees. Provide clear migration documentation. The `physical` mode is a direct equivalent. |
+| macvlan/ipvlan performance overhead vs physical NIC | Minimal for macvlan in bridge mode (~1-2% throughput impact in benchmarks). Document that `physical` mode is preferred when a dedicated NIC is available. |
+| macvlan child cannot communicate with parent on the same host | This is a well-known Linux kernel constraint. Document it: if the host needs to reach the router via the underlay NIC, use `ipvlan` or a separate veth pair. |
+| ipvlan requires parent and children to share the same L3 subnet | Document the L3 implications of ipvlan mode selection. |
+| Operator forgets to set the sub-struct matching the type | CEL validation rejects the resource at admission time with a clear error message. |
+
+## Design Details
+
+### API Pattern: Discriminated Union
+
+The `UnderlayInterface` struct uses the same discriminated-union pattern as
+`HostMaster` in the L2VNI CRD:
+
+```go
+// L2VNI's HostMaster (existing pattern)
+type HostMaster struct {
+    Type        string             `json:"type"`         // "linux-bridge" | "ovs-bridge"
+    LinuxBridge *LinuxBridgeConfig `json:"linuxBridge,omitempty"`
+    OVSBridge   *OVSBridgeConfig   `json:"ovsBridge,omitempty"`
+}
+
+// UnderlayInterface (proposed — same pattern)
+type UnderlayInterface struct {
+    Type     string             `json:"type"`     // "physical" | "macvlan" | "ipvlan"
+    Physical *PhysicalInterface `json:"physical,omitempty"`
+    Macvlan  *MacvlanInterface  `json:"macvlan,omitempty"`
+    Ipvlan   *IpvlanInterface   `json:"ipvlan,omitempty"`
+}
+```
+
+A CEL validation on the struct enforces that exactly the sub-struct matching the
+`type` enum is set. This gives operators:
+- An explicit discriminator (`type`) that makes the intent unambiguous in YAML
+  and in code (switch on `Type`, not on which pointer is non-nil).
+- Per-type fields that are only present when relevant — no unused `macvlanMode`
+  field when the type is `physical`.
+- Clear `kubectl explain` output — each sub-struct is its own section with
+  contextual documentation.
+
+### Controller Provisioning Flow
+
+The controller's `SetupUnderlay` function is extended to handle the three
+interface types. The provisioning logic runs inside the controller's
+reconciliation loop, in the same phase where it currently moves the physical
+NIC.
+
+#### Physical Mode
+
+No change from current behavior:
+
+1. `moveUnderlayInterface(interfaceName, targetNS)` — moves the NIC from the
+   host netns into the router netns.
+2. Assigns the marker address (`172.16.1.1/32`) for detection.
+3. Sets the interface UP.
+
+#### Macvlan Mode
+
+1. Look up the parent device on the host by name.
+2. Create a macvlan link: `netlink.LinkAdd(&netlink.Macvlan{...})` with the
+   specified mode and parent.
+3. Move the macvlan child into the router netns.
+4. Assign the marker address for detection.
+5. Set the interface UP.
+6. The parent device stays on the host, untouched.
+
+#### Ipvlan Mode
+
+1. Look up the parent device on the host by name.
+2. Create an ipvlan link: `netlink.LinkAdd(&netlink.IPVlan{...})` with the
+   specified mode and parent.
+3. Move the ipvlan child into the router netns.
+4. Assign the marker address for detection.
+5. Set the interface UP.
+6. The parent device stays on the host, untouched.
+
+### Naming Convention
+
+The macvlan/ipvlan child interface is created with a deterministic name derived
+from the parent device. The interface is renamed inside the router netns to
+match the `interfaceName` / `parentDevice` so that FRR configuration and
+existing references work consistently:
+
+- **Physical**: interface keeps its original name (e.g. `eth1`).
+- **Macvlan/Ipvlan**: child is renamed to `ul-<parentDevice>` in the router
+  netns (e.g. `ul-eth1`). The `ul-` prefix signals "underlay" and avoids
+  collisions with the parent name (which lives in a different netns but could
+  cause confusion in logs and debugging).
+
+### Idempotency and Reconciliation
+
+The marker address (`172.16.1.1/32`) detection mechanism already used for
+physical NICs applies identically to macvlan/ipvlan children:
+
+- If the marker is found on the expected interface in the router netns, the
+  underlay is already configured — no-op.
+- If the marker is found on a **different** interface (e.g. the operator changed
+  `parentDevice`), return `UnderlayExistsError` to signal that the netns must be
+  rebuilt.
+- If no marker is found, provision the interface.
+
+### Underlay Change Detection
+
+Changing the underlay interface type or parent device is a destructive operation
+that requires a netns rebuild. The controller detects this via the
+`UnderlayExistsError` returned by `SetupUnderlay` when the configured underlay
+doesn't match the desired one. This triggers `HandleNonRecoverableError`, which
+deletes the netns and lets the next reconciliation rebuild it from scratch.
+
+### Removal of `--underlay-from-multus` Flag
+
+The `--underlay-from-multus` controller flag becomes unnecessary. Its current
+purpose is to tell the controller "don't validate `nics` — Multus will provide
+the underlay interface." With the new API, the `type` field is the single source
+of truth for how the underlay is provisioned. The flag is removed.
+
+### Changes Required
+
+| Component | Current | Proposed | Effort |
+|-----------|---------|----------|--------|
+| `UnderlaySpec` | `Nics []string` | `UnderlayInterface *UnderlayInterface` | API type change |
+| New types | — | `UnderlayInterface`, `PhysicalInterface`, `MacvlanInterface`, `IpvlanInterface` | New Go types |
+| CEL validation | NIC name pattern on items | Discriminated-union match (type ↔ sub-struct) | New validation rule |
+| `--underlay-from-multus` flag | Boolean flag in `cmd/hostcontroller/main.go` | Removed | Delete flag + wiring |
+| `SetupUnderlay()` | Moves physical NIC | Switch on type: move NIC / create macvlan / create ipvlan | Extend function |
+| `UnderlayParams` | `UnderlayInterface string` | Carries full `UnderlayInterface` struct | Struct change |
+| `APItoHostConfig()` | Reads `Nics[0]` + `underlayFromMultus` | Reads `UnderlayInterface.Type` + sub-struct fields | Conversion update |
+| Webhook validation | NIC name format | Type/sub-struct consistency | Update webhook |
+| Helm values schema | `nics` list | `underlayInterface` block | Values schema change |
+| Helm templates | Renders `nics` | Renders `underlayInterface` with type | Template update |
+| E2E test setup | `CreateMacvlanNad` for Multus underlay | Direct `underlayInterface` in CRD | Test simplification |
+| Documentation | Describes `nics` + Multus flag | Describes three interface modes | Doc rewrite |
+
+### Migration Path
+
+Since this is a `v1alpha1` API, no automatic migration is provided. The
+migration is a one-time CRD update:
+
+| Current configuration | New configuration |
+|----------------------|-------------------|
+| `nics: [eth1]` | `underlayInterface: {type: physical, physical: {interfaceName: eth1}}` |
+| `nics: []` + `--underlay-from-multus=true` + Multus NAD for underlay | `underlayInterface: {type: macvlan, macvlan: {parentDevice: eth1, mode: bridge}}` |
+
+The release notes will include a migration guide with examples for both paths.
+
+### Test Plan
+
+- **Unit tests**: `UnderlayInterface` CEL validation — verify that:
+  - `type: physical` with `physical` set is accepted.
+  - `type: macvlan` with `macvlan` set is accepted.
+  - `type: ipvlan` with `ipvlan` set is accepted.
+  - Type/sub-struct mismatch is rejected with a clear message.
+  - Missing sub-struct is rejected.
+  - Multiple sub-structs set simultaneously is rejected.
+- **Unit tests**: `SetupUnderlay` with macvlan and ipvlan modes — verify
+  interface creation, parent device lookup, namespace move, marker assignment,
+  and idempotent re-runs (using network namespace mocks or netns test fixtures).
+- **Integration tests**: In a real (non-mock) netns environment, verify:
+  - macvlan child is created from the parent and moved into the target netns.
+  - ipvlan child is created from the parent and moved into the target netns.
+  - Parent device remains in the host netns and is functional.
+  - FRR discovers the interface inside the netns.
+  - `HasUnderlayInterface` correctly detects the provisioned interface.
+- **Reconciliation tests**: Verify that changing the underlay type (e.g.
+  `physical` to `macvlan`) triggers `UnderlayExistsError` and the controller
+  handles it via netns rebuild.
+- **E2E tests**: Full traffic test with each interface type:
+  - `physical`: existing E2E coverage applies.
+  - `macvlan`: underlay traffic flows through the macvlan child; VXLAN tunnels
+    establish and carry EVPN routes.
+  - `ipvlan`: underlay traffic flows through the ipvlan child; verify that
+    shared MAC does not interfere with EVPN Type-2 route advertisement.
+- **Migration test**: Apply an Underlay with the old `nics` field, upgrade the
+  controller, apply the new `underlayInterface` field, verify convergence.
+
+### Graduation Criteria
+
+#### Alpha
+
+- `UnderlayInterface` type and sub-structs added to the API with CEL
+  validation.
+- `Nics` field removed from `UnderlaySpec`.
+- `--underlay-from-multus` flag removed from the controller.
+- `SetupUnderlay` extended to handle `physical`, `macvlan`, and `ipvlan` modes.
+- `physical` mode is functionally equivalent to the current `nics` behavior.
+- Basic unit and integration tests for all three modes.
+
+#### Beta
+
+- E2E tests covering all three modes with real traffic verification.
+- Helm chart and operator bindata updated with new values schema.
+- Migration guide published in release notes.
+- macvlan and ipvlan modes validated in at least one real-hardware environment
+  (not just Kind/containerlab).
+
+#### GA
+
+- Production validation across multiple deployment environments and NIC
+  vendors.
+- Performance benchmarks comparing physical, macvlan, and ipvlan modes
+  published.
+- Documentation covers mode selection guidance (when to use each mode).
+
+## Drawbacks
+
+- **Breaking API change.** Operators must update their Underlay CRD when
+  upgrading. Since this is `v1alpha1` and the migration is a straightforward
+  field rename, this is acceptable.
+- **Slightly more verbose YAML.** The nested sub-struct adds one level of
+  indentation compared to `nics: [eth1]`. This is the intentional trade-off for
+  type safety — every field visible in the YAML is relevant to the selected
+  mode.
+- **macvlan/ipvlan have known kernel constraints.** macvlan children cannot
+  communicate with the parent on the same host. ipvlan children share the
+  parent's MAC address, which affects ARP behavior. These are Linux kernel
+  properties, not API design issues, but they must be documented so operators
+  make informed choices.
+
+## Alternatives
+
+### Alternative 1: Flat Discriminated Union (Single Struct, No Sub-Structs)
+
+Use a `type` enum with mode-specific fields as optional flat fields on the same
+struct:
+
+```yaml
+underlayInterface:
+  parentDevice: eth1
+  type: macvlan
+  macvlanMode: bridge
+```
+
+```go
+type UnderlayInterface struct {
+    ParentDevice string       `json:"parentDevice"`
+    Type         string       `json:"type"`
+    MacvlanMode  *MacvlanMode `json:"macvlanMode,omitempty"`
+    IpvlanMode   *IpvlanMode  `json:"ipvlanMode,omitempty"`
+}
+```
+
+**Why not chosen:**
+
+- **Unused fields leak into the YAML.** `macvlanMode` appears in the struct
+  even when `type: physical`. Operators see it in `kubectl explain` and wonder
+  if they should set it. Conditional field relevance is a source of confusion.
+- **Conditional validation.** "macvlanMode required when type=macvlan AND
+  forbidden when type=physical" is a chain of rules. The sub-struct pattern
+  makes invalid combinations structurally impossible.
+- **Naming ambiguity.** `parentDevice` means "device to move" for `physical`
+  and "device to derive from" for `macvlan`/`ipvlan`. The sub-struct pattern
+  uses `interfaceName` for physical and `parentDevice` for macvlan/ipvlan,
+  matching the semantic difference.
+- **Extensibility.** Adding SR-IOV would add `numVFs`, `resourceName`,
+  `pfName`, etc. as flat optional fields — the struct grows unwieldy. With
+  sub-structs, `Sriov *SriovInterface` is self-contained.
+
+### Alternative 2: One-of Sub-Structs Without Type Enum
+
+Use mutually exclusive sub-struct pointers without an explicit `type`
+discriminator, following the Kubernetes `VolumeSource` pattern:
+
+```yaml
+underlayInterface:
+  macvlan:
+    parentDevice: eth1
+    mode: bridge
+```
+
+```go
+type UnderlayInterface struct {
+    Physical *PhysicalInterface `json:"physical,omitempty"`
+    Macvlan  *MacvlanInterface  `json:"macvlan,omitempty"`
+    Ipvlan   *IpvlanInterface   `json:"ipvlan,omitempty"`
+}
+```
+
+**Why not chosen:**
+
+- **No explicit discriminator.** Code must check which pointer is non-nil to
+  determine the type. A `Type` enum makes switch statements clean and
+  serialization unambiguous.
+- **Inconsistent with existing API.** The `HostMaster` struct in L2VNI already
+  uses the type-enum + sub-struct pattern. Mixing two different union patterns
+  in the same API surface creates inconsistency.
+- **JSON round-trip ambiguity.** Without a discriminator, a malformed resource
+  with two sub-structs set is harder to diagnose — the error is "exactly one
+  must be set" rather than "the sub-struct must match the type."
+
+### Alternative 3: Keep Multus for Underlay
+
+Continue using Multus `NetworkAttachmentDefinition` to plumb the underlay
+interface into the router pod.
+
+**Why not chosen:**
+
+- **Incompatible with named netns.** Multus operates on pod network namespaces
+  managed by the container runtime. With `hostNetwork: true` pods or Podman
+  quadlets, the router does not have a runtime-managed netns for Multus to
+  target.
+- **Split configuration.** The underlay intent is split across the Underlay CRD,
+  a `NetworkAttachmentDefinition`, and a controller flag. This makes the system
+  harder to reason about and debug.
+- **External dependency.** Multus is an optional cluster component. Requiring it
+  for router underlay connectivity adds a dependency that not all deployments
+  want.
+
+## Implementation History
+
+- 2026-04-21: Initial proposal drafted.

--- a/enhancements/controller-provisioned-underlay-interfaces.md
+++ b/enhancements/controller-provisioned-underlay-interfaces.md
@@ -1,0 +1,497 @@
+# Controller-Provisioned Underlay Interfaces
+
+## Summary
+
+Add a `CNI` provisioning mode to the `interfaces` union introduced by
+[PR #341](https://github.com/openperouter/openperouter/pull/341), so the
+controller can invoke any CNI plugin via
+[libcni](https://pkg.go.dev/github.com/containernetworking/cni/libcni)
+to provision underlay interfaces in the router netns. Replaces the removed
+Multus-based underlay integration.
+
+## Motivation
+
+### Goals
+
+- **Replace the removed Multus underlay integration.** The router resiliency
+  work removed the `--underlay-from-multus` controller flag and all associated
+  code paths. With the persistent named netns model (see
+  [router-resiliency.md](router-resiliency.md)), the router runs as a
+  `hostNetwork` pod or a Podman quadlet — neither integrates with Multus CNI,
+  which operates on pod network namespaces managed by the container runtime.
+  Users who relied on Multus-based macvlan underlay for NIC sharing currently
+  have **no alternative**.
+
+- **Flexible NIC sharing and IPAM.** Operators need to choose how the
+  underlay NIC is shared (macvlan, ipvlan, SR-IOV, bridge, OVS) and how IPs
+  are assigned (static, DHCP, pool-based) based on their network environment.
+
+- **Work in both Kubernetes and host/systemd modes.** Operators can
+  provision CNI-based underlay interfaces regardless of the deployment
+  mode. The same interface types and IPAM options are available in both
+  environments.
+
+- **Support day-0 operations.** New deployments should be able to install
+  OpenPERouter and have underlay interfaces provisioned automatically on
+  first startup, without manual pre-configuration of network devices on
+  each node.
+
+- **Consistent API pattern.** Extend the discriminated-union pattern already
+  established by `UnderlayInterface` and `HostMaster` in the L2VNI CRD, so
+  operators encounter a familiar structure across the API surface.
+
+### Non-Goals
+
+- **Implementing per-interface-type provisioning logic in the controller.**
+  Macvlan, ipvlan, SR-IOV, OVS, and bridge interface creation is delegated
+  entirely to CNI plugins. The controller invokes the plugin; the plugin
+  handles netlink operations.
+
+- **Redundant router instances.** NIC sharing via CNI plugins (e.g. macvlan)
+  is a prerequisite for running multiple router instances per node, but the
+  multi-instance design itself is a separate enhancement.
+
+- **Plugin-specific field validation.** The controller validates structural
+  plugin JSON config correctness and plugin binary existence, but does not
+  validate plugin-specific fields (e.g. checking `master` device exists
+  for macvlan).
+
+## User Stories
+
+#### Story 1: Day-0 Setup
+
+As an operator deploying OpenPERouter for the first time, I want underlay
+interfaces to be provisioned automatically on first startup, so that I
+don't need to manually pre-configure network devices on each node.
+
+#### Story 2: Single-File Configuration
+
+As an operator, I want to define the entire underlay configuration —
+including how the interface is created and how IPs are assigned — in a
+single configuration file, so that I don't need to manage multiple
+configuration artifacts per node.
+
+#### Story 3: Migrating from Multus
+
+As an operator who previously used Multus to plumb the underlay NIC into
+the router pod, I want a replacement that restores NIC sharing without
+Multus, so that I can upgrade to the named netns deployment model without
+requiring a dedicated physical NIC.
+
+#### Story 4: Shared NIC
+
+As an operator on hardware with limited NICs, I want the host and the
+router to share the same physical NIC, so that I don't need a dedicated
+NIC for underlay traffic.
+
+#### Story 5: MAC-Restricted Networks
+
+As an operator on a network that limits the number of MAC addresses per
+port, I want the router's underlay interface to share the physical NIC's
+MAC address, so that only one MAC appears on the wire.
+
+## Proposal
+
+### Overview
+
+The API improvements enhancement replaces `UnderlaySpec.Nics []string` with
+`Interfaces []UnderlayInterface` — a discriminated-union slice whose `type`
+field selects how each underlay link is obtained. It defines the first mode
+(`NetworkDevice`); this enhancement adds `CNI`.
+
+After this enhancement, the two modes are:
+
+| Mode | Behavior | Host NIC availability |
+|------|----------|----------------------|
+| `NetworkDevice` | Moves an existing host device into the router netns | Device is exclusively owned by the router |
+| `CNIDevice` (this enhancement) | Invokes a CNI plugin to provision an interface in the router netns | Depends on the plugin (e.g. macvlan keeps parent on host) |
+
+### Supported CNI Plugins
+
+Any CNI plugin that operates solely on the network namespace — without
+requiring extra host paths mounted into the router pod — works out of the
+box. Plugins that depend on external sockets or host directories (e.g.
+SR-IOV, OVS) require a modified deployment to mount those paths.
+
+We should ensure we only allow a subset of CNIs - the ones listed in the
+table below.
+
+**Known to work without extra mounts:**
+
+| Category | Plugins |
+|----------|---------|
+| Interface | `macvlan`, `ipvlan`, `vlan`, `host-device` |
+
+### API
+
+The CNI plugin configuration is embedded directly in the Underlay spec
+via `RawConfig`. The config source is a discriminated union — additional
+source variants (e.g. referencing external NADs or filesystem config files)
+can be added later if a concrete user need emerges.
+
+The `rawConfig` field is **immutable** — once the Underlay is created, the
+CNI configuration cannot be updated in place. To change it, the operator
+must delete and recreate the Underlay. This eliminates the need for
+config-drift reconciliation (DEL the old interface, ADD with the new
+config) and avoids a class of partial-failure states where the old
+interface is torn down but the new one fails to provision.
+
+#### Examples
+
+##### CNI with macvlan
+
+Replaces Multus-based underlay — the parent NIC stays on the host.
+
+```yaml
+interfaces:
+  - type: CNI
+    cniDevice:
+      type: RawConfig
+      rawConfig:
+        cniVersion: "1.0.0"
+        name: macvlan-underlay
+        plugins:
+          - type: macvlan
+            master: eth1
+            mode: bridge
+```
+
+##### CNI with ipvlan
+
+Shared MAC — useful when MAC learning is constrained (e.g. cloud or campus
+port-security):
+
+```yaml
+interfaces:
+  - type: CNI
+    cniDevice:
+      type: RawConfig
+      rawConfig:
+        cniVersion: "1.0.0"
+        name: ipvlan-underlay
+        plugins:
+          - type: ipvlan
+            master: eth1
+            mode: l2
+```
+
+##### CNI with custom interface name
+
+```yaml
+interfaces:
+  - type: CNI
+    cniDevice:
+      type: RawConfig
+      rawConfig:
+        cniVersion: "1.0.0"
+        name: macvlan-underlay
+        plugins:
+          - type: macvlan
+            master: eth1
+            mode: bridge
+      interfaceName: underlay0
+```
+
+When `interfaceName` is omitted, it defaults to `net1`.
+
+### Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| CNI plugin binaries not installed on host | Clear error at reconcile time with plugin name and search path. Host/systemd package bundles common plugins. |
+| CNI cache lost but interface exists | Group ID 4242 detection still identifies the interface. IPAM lease may leak — document as a known edge case. |
+| CNI ADD is not idempotent (calling twice fails) | Controller checks `GetNetworkListCachedResult()` before `AddNetworkList()`. If cache is lost, existing interface detected via group ID. |
+| CNI DEL fails during teardown | DEL errors are logged but do not block teardown. CNI spec mandates plugins handle repeated DEL calls gracefully. |
+| `runtimeConfig` keys silently stripped by `libcni` | `libcni` only forwards keys the plugin declares in its `"capabilities"` block. Document prominently; consider logging a warning when `runtimeConfig` is set but the config has no capabilities. |
+| Operator forgets to set the sub-struct matching the type | CEL validation rejects the resource at admission time. |
+| `containernetworking/cni` dependency version conflicts | Pin to `v1.2.x` in `go.mod`. This version targets CNI spec 1.0.0+ (required for CHECK support and capabilities filtering). Minimal transitive dependencies. |
+
+## Design Details
+
+### API Types
+
+```go
+// UnderlayInterface defines how the router obtains a single underlay link.
+// Exactly one of the sub-structs must match the type field.
+//
+// +union
+type UnderlayInterface struct {
+	// +kubebuilder:validation:Enum=NetworkDevice;CNI
+	// +required
+	// +unionDiscriminator
+	Type string `json:"type,omitempty"`
+
+	// networkDevice moves an existing host network device into the router
+	// netns. When IPAM is configured, the controller assigns deterministic
+	// per-node IPs from CIDR pools.
+	// +optional
+	NetworkDevice *NetworkDeviceConfig `json:"networkDevice,omitempty"`
+
+	// cniDevice invokes a CNI plugin to provision an interface in the router
+	// netns. IPAM is handled by the CNI plugin.
+	// +optional
+	CNIDevice *CNIDeviceConfig `json:"cniDevice,omitempty"`
+}
+
+// NetworkDeviceConfig specifies which host network device to move into
+// the router netns, and optional IPAM configuration.
+type NetworkDeviceConfig struct {
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z][a-zA-Z0-9._-]*$`
+	// +kubebuilder:validation:MaxLength=15
+	// +required
+	InterfaceName string `json:"interfaceName,omitempty"`
+
+	// +optional
+	IPAM *InterfaceIPAM `json:"ipam,omitempty"`
+}
+
+// CNIDeviceConfig specifies how to invoke a CNI plugin to provision
+// an underlay interface. The config source is a discriminated union —
+// additional source variants (e.g. NAD reference, filesystem path)
+// can be added later if a concrete user need emerges.
+//
+// +union
+// +kubebuilder:validation:XValidation:rule="self.type == 'RawConfig' ? has(self.rawConfig) : true",message="rawConfig is required when type is RawConfig"
+// +kubebuilder:validation:XValidation:rule="self.type != 'RawConfig' ? !has(self.rawConfig) : true",message="rawConfig must not be set when type is not RawConfig"
+// +kubebuilder:validation:XValidation:rule="oldSelf.rawConfig == self.rawConfig",message="rawConfig is immutable; delete and recreate the Underlay to change it"
+type CNIDeviceConfig struct {
+	// +kubebuilder:validation:Enum=RawConfig
+	// +required
+	// +unionDiscriminator
+	Type string `json:"type,omitempty"`
+
+	// rawConfig embeds a CNI config JSON blob directly in this spec.
+	// Immutable once set — delete and recreate the Underlay to change.
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Type=object
+	// +optional
+	RawConfig *apiextensionsv1.JSON `json:"rawConfig,omitempty"`
+
+	// interfaceName is passed as CNI_IFNAME. Defaults to "net1".
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z][a-zA-Z0-9._-]*$`
+	// +kubebuilder:validation:MaxLength=15
+	// +kubebuilder:default=net1
+	// +optional
+	InterfaceName string `json:"interfaceName,omitempty"`
+
+	// runtimeConfig is opaque JSON passed as CapabilityArgs to libcni.
+	// libcni performs capabilities filtering: only keys that the plugin
+	// declares in its "capabilities" config block are forwarded.
+	// Undeclared keys are silently stripped. Well-known capabilities:
+	// ips, mac, bandwidth, portMappings, ipRanges, deviceID.
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Type=object
+	// +optional
+	RuntimeConfig *apiextensionsv1.JSON `json:"runtimeConfig,omitempty"`
+}
+
+// InterfaceIPAM configures IP address management for a NetworkDevice
+// interface. CNI interfaces delegate IPAM to the CNI plugin.
+//
+// +union
+type InterfaceIPAM struct {
+	// +kubebuilder:validation:Enum=Native
+	// +required
+	// +unionDiscriminator
+	Type string `json:"type,omitempty"`
+
+	// +optional
+	Native *NativeIPAM `json:"native,omitempty"`
+}
+
+// NativeIPAM derives per-node IP addresses from CIDR pools using the node
+// index. Each node gets the (nodeIndex+1)th address from each pool (the +1
+// offset skips the network address, matching the RouterID convention).
+// Unlike tunnelEndpoint.cidrs (which assigns /32 or /128 host routes),
+// Native IPAM preserves the original pool mask — e.g. 192.168.1.0/24
+// assigns 192.168.1.<nodeIndex+1>/24, because the underlay is a shared L2
+// subnet with the ToR switch.
+type NativeIPAM struct {
+	// At most one IPv4 and one IPv6 CIDR (dual-stack).
+	// +kubebuilder:validation:MinItems=1
+	// +kubebuilder:validation:MaxItems=2
+	CIDRs []string `json:"cidrs"`
+}
+```
+
+### Controller Provisioning Flow
+
+The controller's reconciliation pipeline is extended to handle the `CNI`
+type. The provisioning logic runs in the same phase where it currently
+moves host devices.
+
+#### CNI Mode
+
+The controller invokes CNI ADD / CHECK / DEL via `libcni` as part of the
+underlay reconciliation mechanism:
+
+- **CNI ADD** — provisions the interface in the router netns. The
+  controller resolves (and validates) the config source, parses the
+  config, merges `runtimeConfig` capabilities, and calls
+  `AddNetworkList`.
+- **CNI CHECK** — validates that a previously-provisioned interface is
+  still correctly configured. The controller uses the CNI cache together
+  with CNI CHECK to determine whether the underlay interfaces need to
+  be rebuilt.
+- **CNI DEL** — tears down CNI-provisioned interfaces. Called during
+  `HandleNonRecoverableError` / router netns rebuild. The CNI cache is
+  also cleared on rebuild to ensure the new instance starts from
+  scratch.
+
+IPAM is fully delegated to the CNI plugin configured in the config. The
+controller extracts assigned IPs from the CNI result.
+
+### Test Plan
+
+- **Integration tests — CNI invocation**: In a real (non-mock) netns
+  environment, with a mock CNI plugin binary that returns canned
+  results, verify:
+  - Config source resolution: RawConfig embedded bytes parsed into
+    config.
+  - CNI ADD with valid config returns assigned IPs.
+  - CNI DEL with cached result calls `DelNetworkList` successfully.
+  - `runtimeConfig` merging: `CapabilityArgs` populated correctly.
+  - Capability filtering: `ips` and `mac` capabilities forwarded when
+    declared; silently stripped when not declared.
+  - Dual-stack: both IPv4 and IPv6 IPs extracted from mock result.
+  - Idempotency: second call with existing cache returns cached result.
+  - Error paths: malformed JSON, missing plugin binary, CNI ADD
+    failure.
+  - Delete when no cache exists → succeeds gracefully.
+- **Reconciliation tests**: Verify:
+  - Type change (`NetworkDevice` → `CNI`) triggers rebuild.
+  - Config source change triggers rebuild.
+  - Cached CNI result → no re-invocation.
+  - CNI ADD fails → error propagated to status.
+  - CNI DEL fails during teardown → logged, teardown continues.
+- **E2E tests — CNI provisioning**:
+  - Macvlan: interface provisioned in router netns, end-to-end
+    traffic flows through VXLAN tunnels and EVPN routes.
+- **E2E tests — teardown**:
+  - Underlay CR deletion: CNI DEL called, interface removed from router
+    netns, IPAM resources released.
+  - Netns rebuild (`HandleNonRecoverableError`): CNI DEL called, cache
+    cleared, fresh CNI ADD on new netns provisions interface correctly.
+- **E2E tests — self-healing**:
+  - Interface missing but cache present: CNI CHECK detects the
+    mismatch, controller re-provisions the interface via CNI ADD
+    without operator intervention.
+  - Cache lost but interface exists: controller detects interface via
+    group ID, treats as existing (no duplicate provisioning).
+  - Persistence across router pod restart: cache survives on hostPath,
+    interface remains in named netns, no re-provisioning needed.
+
+### Implementation
+
+- `CNIDeviceConfig` type added to the API;
+  `UnderlayInterface` enum extended with `CNI`.
+- CEL validation rules for `CNIDeviceConfig`
+  (RawConfig required/forbidden, immutability).
+- CNI invocation layer (`internal/cni/invoker.go`) wrapping `libcni`:
+  config resolution from `RawConfig`, `runtimeConfig` merging, cache
+  management, `AddNetworkList`/`DelNetworkList`.
+- `SetupCNIUnderlay` provisioning function: resolve config → invoke
+  CNI → set group ID 4242 → extract IPs.
+- CNI DEL path in `HandleNonRecoverableError`.
+- CNI CHECK path when reconciling the underlay, to ensure it is
+  properly configured.
+- Startup validation: embedded JSON parse, plugin binary existence.
+- Integration tests: CNI ADD/DEL, runtimeConfig/capability filtering,
+  idempotency (cache hit), dual-stack IP extraction, error paths.
+- E2E tests: macvlan provisioning, persistence across restart.
+- Package (RPM/deb/tarball) bundles statically-linked CNI plugin
+  binaries: `macvlan`, `ipvlan`, which are made available on the
+  controller pod.
+- Installation path: `/opt/openperouter/cni/bin/` (plugins).
+- Controller's `CNI_PATH` includes `/opt/openperouter/cni/bin/` by
+  default.
+- `--cni-bin-dir` flag for custom plugin paths.
+- Migration guide published in release notes.
+
+## Drawbacks
+
+- **Slightly more verbose YAML.** The nested sub-struct adds indentation
+  compared to `nics: [eth1]`. This is the trade-off for type safety.
+- **Operational dependency on CNI plugin binaries.** Most Kubernetes
+  clusters already have these. Host/systemd mode bundles them in the
+  package.
+- **IPAM is fully delegated.** For CNI interfaces, the controller has no
+  visibility into IPAM allocation failures beyond what the plugin
+  reports.
+
+## Alternatives
+
+### Alternative 1: Flat Discriminated Union (Single Struct, No Sub-Structs)
+
+```yaml
+interfaces:
+  - type: CNI
+    nadName: macvlan-underlay
+    nadNamespace: default
+```
+
+**Why not chosen:** Unused fields leak into the YAML when using a
+different type. Conditional validation is harder than structural
+impossibility. The sub-struct pattern is already established by
+`NetworkDevice`.
+
+### Alternative 2: One-of Sub-Structs Without Type Enum
+
+```yaml
+interfaces:
+  - cniDevice:
+      type: RawConfig
+      rawConfig: { ... }
+```
+
+**Why not chosen:** No explicit discriminator — code must check which
+pointer is non-nil. A `Type` enum makes switch statements clean and
+serialization unambiguous. Inconsistent with the existing `+union` /
+`+unionDiscriminator` pattern used by `HostMaster` in L2VNI.
+
+### Alternative 3: Direct Macvlan/Ipvlan Provisioning via Netlink (Discarded)
+
+The original proposal added `Macvlan` and `Ipvlan` modes requiring
+per-type netlink code in the controller.
+
+**Why discarded:** Per-type netlink code for each interface type. IPAM
+reimplementation. No config reuse from existing CNI configs. New
+interface types (SR-IOV, OVS, bridge) would each need controller code.
+The CNI approach handles all types through a single invocation path,
+and the host-mode package bundles the common plugins.
+
+## Future Work
+
+### NetworkDevice Mode Provisioning
+
+Investigate replacing the current netlink-based NetworkDevice
+provisioning (move device, assign group ID, set UP, optional IPAM) with
+a `host-device` CNI plugin invocation. This would unify both
+provisioning paths under CNI. Must account for day-0 installs where the
+`host-device` plugin binary may not yet be present on the node.
+
+### NetworkDevice IPAM
+
+Add IPAM support for NetworkDevice mode by re-using the same
+deterministic CIDR-based allocation mechanism that VTEP IPs use today.
+Pursue if a concrete user need emerges — operators can already achieve
+per-node IPs via CNI with `static` IPAM and per-node `addresses`.
+
+A use case for this would be using EVPN in cloud platforms, which
+essentially are MAC-Restricted Networks; the user would have to use
+ipvlan (or other alternatives that share the MAC of the lower device),
+which do not play well with DHCP - some sort of cluster wide IPAM would
+be required. Integrating with whereabouts would be an option, but given
+it requires API access, day0 would not be possible.
+
+## Implementation History
+
+- 2026-04-21: Initial proposal drafted (Macvlan/Ipvlan via netlink).
+- 2026-06-24: Revised to replace Macvlan/Ipvlan with CNI plugin
+  invocation.
+- 2026-06-25: Added CNI config source union (RawConfig); API and Path
+  variants deferred until user need emerges.
+- 2026-06-29: Flattened RawConfig — removed wrapper struct, rawConfig
+  field is now directly `apiextensionsv1.JSON` (eliminates redundant
+  `rawConfig.config` nesting level). Made rawConfig immutable via CEL
+  transition rule.

--- a/enhancements/controller-provisioned-underlay-interfaces.md
+++ b/enhancements/controller-provisioned-underlay-interfaces.md
@@ -96,6 +96,12 @@ As an operator whose network infrastructure requires specific IP
 assignments per router, I want to assign a deterministic static IP to
 each node's underlay interface from a single configuration.
 
+#### Story 7: DHCP-Managed Networks
+
+As an operator whose network uses DHCP for IP management, I want the
+router's underlay interface to obtain its IP via DHCP from the existing
+infrastructure, with a stable identity across restarts.
+
 ## Proposal
 
 ### Overview
@@ -127,7 +133,7 @@ table below.
 | Category | Plugins |
 |----------|---------|
 | Interface | `macvlan`, `ipvlan`, `vlan`, `host-device` |
-| IPAM | `static` |
+| IPAM | `dhcp`, `static` |
 
 ### API
 
@@ -251,6 +257,109 @@ interfaces:
 
 When `interfaceName` is omitted, it defaults to `net1`.
 
+##### CNI with DHCP and pinned MAC
+
+When the operator wants the router's underlay IP assigned by a DHCP server,
+the config uses `dhcp` IPAM. Because macvlan generates a random MAC on
+every CNI ADD invocation, the DHCP server would assign a different IP after
+each netns rebuild — breaking BGP sessions and EVPN routes. To ensure IP
+stability, the operator **must pin the MAC address** by passing a per-node
+MAC via `runtimeConfig.mac`.
+
+The macvlan plugin natively supports the `mac` capability
+([source](https://github.com/containernetworking/plugins/blob/33cc6bd63968280b330b00468afbb66161aaa6bd/plugins/main/macvlan/macvlan.go#L48)):
+it sets the MAC on the link **during interface creation**, before IPAM runs.
+The DHCP DISCOVER is sent with the pinned MAC — no plugin chaining with
+`tuning` is needed.
+
+This requires one Underlay per node (same pattern as static IPs):
+
+```yaml
+apiVersion: openpe.openperouter.github.io/v1alpha1
+kind: Underlay
+metadata:
+  name: underlay-worker-0
+spec:
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/hostname: worker-0
+  asn: 64514
+  interfaces:
+    - type: CNI
+      cniDevice:
+        type: RawConfig
+        rawConfig:
+          cniVersion: "1.0.0"
+          name: macvlan-dhcp
+          plugins:
+            - type: macvlan
+              master: eth1
+              mode: bridge
+              capabilities:
+                mac: true
+              ipam:
+                type: dhcp
+        runtimeConfig:
+          mac: "02:42:c0:a8:01:0a"
+  tunnelEndpoint:
+    cidrs:
+      - "100.65.0.0/24"
+  neighbors:
+    - address: 192.168.1.1
+      asn: 65000
+```
+
+Repeat for each node with a different `nodeSelector` and MAC.
+
+###### Enabling CNI runtime parameters
+
+Some CNI use cases require runtime parameters that vary per node — for
+example, pinning a specific MAC address so the DHCP server assigns a
+stable IP. The Underlay spec supports this through two fields that work
+together:
+
+1. **`capabilities` in the plugin config** — declares which runtime
+   parameters the plugin accepts. The CNI specification requires plugins
+   to explicitly opt in to each capability. For example, to accept a MAC
+   address, the macvlan plugin config must include
+   `"capabilities": {"mac": true}`.
+
+2. **`runtimeConfig` in the Underlay spec** — passes the actual values.
+   The controller forwards this as `CapabilityArgs` to `libcni`, which
+   only delivers keys that the plugin declared in step 1. Undeclared
+   keys are silently stripped — the plugin never sees them.
+
+In the DHCP+MAC pinning example above, both pieces are present: the
+plugin config declares `"capabilities": {"mac": true}`, and
+`runtimeConfig` passes `"mac": "02:42:c0:a8:01:0a"`. Without the
+capability declaration, `libcni` would strip the `mac` key and macvlan
+would generate a random MAC on each invocation.
+
+Well-known capability keys include `ips`, `mac`, `bandwidth`,
+`portMappings`, `ipRanges`, and `deviceID`. See the
+[CNI conventions](https://www.cni.dev/docs/conventions/) for the full
+list. The controller enforces no schema on `runtimeConfig`.
+
+###### DHCP prerequisites
+
+**DHCP daemon:** The CNI `dhcp` IPAM plugin requires a DHCP daemon
+process running on each node (`dhcp daemon` or via systemd socket
+activation at `/run/cni/dhcp.sock`). See
+[CNI DHCP plugin docs](https://www.cni.dev/plugins/current/ipam/dhcp/)
+for setup.
+
+**Lease lifecycle across restarts:**
+- **Router pod restart (netns preserved):** The CNI cache survives on
+  the persistent hostPath. The controller skips re-invocation. The DHCP
+  daemon continues renewing the existing lease.
+- **Netns rebuild (CNI DEL + ADD):** The controller calls CNI DEL
+  (releases the DHCP lease), then CNI ADD. With a pinned MAC, the
+  server should assign the same IP (if using reservations or sticky
+  leases).
+- **DHCP daemon restart:** The daemon loses in-memory lease state. If
+  the lease expires before recovery, the IP may be lost. Mitigate with
+  systemd socket activation for automatic daemon restart.
+
 ### Risks and Mitigations
 
 | Risk | Mitigation |
@@ -260,6 +369,9 @@ When `interfaceName` is omitted, it defaults to `net1`.
 | CNI ADD is not idempotent (calling twice fails) | Controller checks `GetNetworkListCachedResult()` before `AddNetworkList()`. If cache is lost, existing interface detected via group ID. |
 | CNI DEL fails during teardown | DEL errors are logged but do not block teardown. CNI spec mandates plugins handle repeated DEL calls gracefully. |
 | `runtimeConfig` keys silently stripped by `libcni` | `libcni` only forwards keys the plugin declares in its `"capabilities"` block. Document prominently; consider logging a warning when `runtimeConfig` is set but the config has no capabilities. |
+| DHCP IPAM: macvlan random MAC causes IP instability | Document that DHCP with macvlan requires MAC pinning via `runtimeConfig.mac`. |
+| DHCP IPAM: DHCP daemon not running | CNI ADD fails immediately with a socket connection error. Document the daemon requirement. |
+| DHCP IPAM: lease expires during daemon downtime | Mitigate with systemd socket activation for fast daemon recovery and long lease times. |
 | Operator forgets to set the sub-struct matching the type | CEL validation rejects the resource at admission time. |
 | `containernetworking/cni` dependency version conflicts | Pin to `v1.2.x` in `go.mod`. This version targets CNI spec 1.0.0+ (required for CHECK support and capabilities filtering). Minimal transitive dependencies. |
 
@@ -396,7 +508,8 @@ underlay reconciliation mechanism:
   scratch.
 
 IPAM is fully delegated to the CNI plugin configured in the config. The
-controller extracts assigned IPs from the CNI result.
+controller extracts assigned IPs from the CNI result; common IPAM plugins
+include `static` and `dhcp`.
 
 ### Test Plan
 
@@ -425,6 +538,9 @@ controller extracts assigned IPs from the CNI result.
   - Macvlan with static IPAM (`static` with `addresses`):
     interface provisioned, IP assigned, end-to-end traffic flows
     through VXLAN tunnels and EVPN routes.
+  - Macvlan with DHCP IPAM and pinned MAC: correct MAC, correct IP,
+    end-to-end traffic flows through VXLAN tunnels and EVPN routes.
+  - DHCP without MAC pinning (negative): random MAC after rebuild.
 - **E2E tests — teardown**:
   - Underlay CR deletion: CNI DEL called, interface removed from router
     netns, IPAM resources released.
@@ -456,10 +572,11 @@ controller extracts assigned IPs from the CNI result.
 - Startup validation: embedded JSON parse, plugin binary existence.
 - Integration tests: CNI ADD/DEL, runtimeConfig/capability filtering,
   idempotency (cache hit), dual-stack IP extraction, error paths.
-- E2E tests: macvlan with static IPAM, persistence across restart.
+- E2E tests: static IPs, DHCP+MAC pinning, persistence across
+  restart.
 - Package (RPM/deb/tarball) bundles statically-linked CNI plugin
-  binaries: `macvlan`, `ipvlan`, `static`, which are made available
-  on the controller pod.
+  binaries: `macvlan`, `ipvlan`, `static`, `dhcp`, which are made
+  available on the controller pod.
 - Installation path: `/opt/openperouter/cni/bin/` (plugins).
 - Controller's `CNI_PATH` includes `/opt/openperouter/cni/bin/` by
   default.

--- a/enhancements/controller-provisioned-underlay-interfaces.md
+++ b/enhancements/controller-provisioned-underlay-interfaces.md
@@ -645,6 +645,21 @@ a `host-device` CNI plugin invocation. This would unify both
 provisioning paths under CNI. Must account for day-0 installs where the
 `host-device` plugin binary may not yet be present on the node.
 
+### Bonded Underlay (Link Aggregation)
+
+Operators whose infrastructure requires link aggregation for redundancy
+or bandwidth need a bond interface for the underlay. Moving a
+pre-existing host bond into the router netns via `NetworkDevice` is not
+possible — the bond's member interfaces remain in the host netns and the
+bond breaks.
+
+Integrate with
+[k8snetworkplumbingwg/bond-cni](https://github.com/k8snetworkplumbingwg/bond-cni)
+as an additional supported CNI interface plugin. With `bond-cni` invoked
+via `CNI` mode, the bond is created directly inside the router netns with
+its member interfaces already in place, so the BGP session survives a
+single link failure.
+
 ### NetworkDevice IPAM
 
 Add IPAM support for NetworkDevice mode by re-using the same

--- a/enhancements/controller-provisioned-underlay-interfaces.md
+++ b/enhancements/controller-provisioned-underlay-interfaces.md
@@ -90,6 +90,12 @@ As an operator on a network that limits the number of MAC addresses per
 port, I want the router's underlay interface to share the physical NIC's
 MAC address, so that only one MAC appears on the wire.
 
+#### Story 6: Per-Node Static IP Assignment
+
+As an operator whose network infrastructure requires specific IP
+assignments per router, I want to assign a deterministic static IP to
+each node's underlay interface from a single configuration.
+
 ## Proposal
 
 ### Overview
@@ -121,6 +127,7 @@ table below.
 | Category | Plugins |
 |----------|---------|
 | Interface | `macvlan`, `ipvlan`, `vlan`, `host-device` |
+| IPAM | `static` |
 
 ### API
 
@@ -154,6 +161,10 @@ interfaces:
           - type: macvlan
             master: eth1
             mode: bridge
+            ipam:
+              type: static
+              addresses:
+                - address: "192.168.1.10/24"
 ```
 
 ##### CNI with ipvlan
@@ -175,6 +186,48 @@ interfaces:
             mode: l2
 ```
 
+##### CNI with per-node static IP
+
+Because each node needs a different IP, the operator creates **one Underlay
+per node** with a `nodeSelector` targeting that node and the node-specific
+IP in the `static` IPAM `addresses` list:
+
+```yaml
+apiVersion: openpe.openperouter.github.io/v1alpha1
+kind: Underlay
+metadata:
+  name: underlay-worker-0
+spec:
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/hostname: worker-0
+  asn: 64514
+  interfaces:
+    - type: CNI
+      cniDevice:
+        type: RawConfig
+        rawConfig:
+          cniVersion: "1.0.0"
+          name: macvlan-static
+          plugins:
+            - type: macvlan
+              master: eth1
+              mode: bridge
+              ipam:
+                type: static
+                addresses:
+                  - address: "192.168.1.10/24"
+  tunnelEndpoint:
+    cidrs:
+      - "100.65.0.0/24"
+  neighbors:
+    - address: 192.168.1.1
+      asn: 65000
+```
+
+Repeat for each node with a different `nodeSelector` and IP — only the
+`addresses` entry differs.
+
 ##### CNI with custom interface name
 
 ```yaml
@@ -189,6 +242,10 @@ interfaces:
           - type: macvlan
             master: eth1
             mode: bridge
+            ipam:
+              type: static
+              addresses:
+                - address: "192.168.1.10/24"
       interfaceName: underlay0
 ```
 
@@ -365,8 +422,9 @@ controller extracts assigned IPs from the CNI result.
   - CNI ADD fails → error propagated to status.
   - CNI DEL fails during teardown → logged, teardown continues.
 - **E2E tests — CNI provisioning**:
-  - Macvlan: interface provisioned in router netns, end-to-end
-    traffic flows through VXLAN tunnels and EVPN routes.
+  - Macvlan with static IPAM (`static` with `addresses`):
+    interface provisioned, IP assigned, end-to-end traffic flows
+    through VXLAN tunnels and EVPN routes.
 - **E2E tests — teardown**:
   - Underlay CR deletion: CNI DEL called, interface removed from router
     netns, IPAM resources released.
@@ -398,10 +456,10 @@ controller extracts assigned IPs from the CNI result.
 - Startup validation: embedded JSON parse, plugin binary existence.
 - Integration tests: CNI ADD/DEL, runtimeConfig/capability filtering,
   idempotency (cache hit), dual-stack IP extraction, error paths.
-- E2E tests: macvlan provisioning, persistence across restart.
+- E2E tests: macvlan with static IPAM, persistence across restart.
 - Package (RPM/deb/tarball) bundles statically-linked CNI plugin
-  binaries: `macvlan`, `ipvlan`, which are made available on the
-  controller pod.
+  binaries: `macvlan`, `ipvlan`, `static`, which are made available
+  on the controller pod.
 - Installation path: `/opt/openperouter/cni/bin/` (plugins).
 - Controller's `CNI_PATH` includes `/opt/openperouter/cni/bin/` by
   default.


### PR DESCRIPTION


<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature

/kind design

> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
Propose replacing `nics []string` and `--underlay-from-multus` with a discriminated-union `underlayInterface` field (physical | macvlan | ipvlan) to support named netns deployments where Multus cannot attach interfaces.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.