### PR TITLE
frr: switch logging from file to stdout

### DIFF
--- a/charts/openperouter/templates/router.yaml
+++ b/charts/openperouter/templates/router.yaml
@@ -93,7 +93,7 @@ data:
     frr defaults traditional
     hostname Router
     line vty
-    log file /etc/frr/frr.log informational
+    log stdout informational
   vtysh.conf: |
     service integrated-vtysh-config
 ---
@@ -156,20 +156,11 @@ spec:
             mountPath: /var/run/frr
           - name: frrconfig
             mountPath: /etc/frr
-        # The command is FRR's default entrypoint & waiting for the log file to appear and tailing it.
-        # If the log file isn't created in 60 seconds the tail fails and the container is restarted.
-        # This workaround is needed to have the frr logs as part of kubectl logs -c frr < k8s-frr-podname >.
         command:
           - /bin/sh
           - -c
           - |
-            /sbin/tini -- /usr/lib/frr/docker-start &
-            attempts=0
-            until [[ -f /etc/frr/frr.log || $attempts -eq 60 ]]; do
-              sleep 1
-              attempts=$(( $attempts + 1 ))
-            done
-            tail -f /etc/frr/frr.log
+            exec /sbin/tini -- /usr/lib/frr/docker-start
         {{- with .Values.openperouter.frr.resources }}
         resources:
           {{- toYaml . | nindent 12 }}

--- a/config/all-in-one/crio.yaml
+++ b/config/all-in-one/crio.yaml
@@ -1225,7 +1225,7 @@ data:
     frr defaults traditional
     hostname Router
     line vty
-    log file /etc/frr/frr.log informational
+    log stdout informational
   vtysh.conf: |
     service integrated-vtysh-config
 kind: ConfigMap
@@ -1489,13 +1489,7 @@ spec:
         - /bin/sh
         - -c
         - |
-          /sbin/tini -- /usr/lib/frr/docker-start &
-          attempts=0
-          until [[ -f /etc/frr/frr.log || $attempts -eq 60 ]]; do
-            sleep 1
-            attempts=$(( $attempts + 1 ))
-          done
-          tail -f /etc/frr/frr.log
+          exec /sbin/tini -- /usr/lib/frr/docker-start
         env:
         - name: TINI_SUBREAPER
           value: "true"

--- a/config/all-in-one/openpe.yaml
+++ b/config/all-in-one/openpe.yaml
@@ -1225,7 +1225,7 @@ data:
     frr defaults traditional
     hostname Router
     line vty
-    log file /etc/frr/frr.log informational
+    log stdout informational
   vtysh.conf: |
     service integrated-vtysh-config
 kind: ConfigMap
@@ -1486,13 +1486,7 @@ spec:
         - /bin/sh
         - -c
         - |
-          /sbin/tini -- /usr/lib/frr/docker-start &
-          attempts=0
-          until [[ -f /etc/frr/frr.log || $attempts -eq 60 ]]; do
-            sleep 1
-            attempts=$(( $attempts + 1 ))
-          done
-          tail -f /etc/frr/frr.log
+          exec /sbin/tini -- /usr/lib/frr/docker-start
         env:
         - name: TINI_SUBREAPER
           value: "true"

--- a/config/pods/frr-cm.yaml
+++ b/config/pods/frr-cm.yaml
@@ -95,4 +95,4 @@ data:
     frr defaults traditional
     hostname Router
     line vty
-    log file /etc/frr/frr.log informational
+    log stdout informational

--- a/config/pods/perouter.yaml
+++ b/config/pods/perouter.yaml
@@ -38,20 +38,11 @@ spec:
             mountPath: /var/run/frr
           - name: frrconfig
             mountPath: /etc/frr
-        # The command is FRR's default entrypoint & waiting for the log file to appear and tailing it.
-        # If the log file isn't created in 60 seconds the tail fails and the container is restarted.
-        # This workaround is needed to have the frr logs as part of kubectl logs -c frr < k8s-frr-podname >.
         command:
           - /bin/sh
           - -c
           - |
-            /sbin/tini -- /usr/lib/frr/docker-start &
-            attempts=0
-            until [[ -f /etc/frr/frr.log || $attempts -eq 60 ]]; do
-              sleep 1
-              attempts=$(( $attempts + 1 ))
-            done
-            tail -f /etc/frr/frr.log
+            exec /sbin/tini -- /usr/lib/frr/docker-start
       - name: reloader
         image: router:latest
         imagePullPolicy: IfNotPresent

--- a/internal/frr/templates/frr.tmpl
+++ b/internal/frr/templates/frr.tmpl
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log {{.Loglevel}}
+log stdout {{.Loglevel}}
 log timestamp precision 3
 {{- if eq .Loglevel "debug" }}
 debug zebra events

--- a/internal/frr/testdata/TestBFDEnabled.golden
+++ b/internal/frr/testdata/TestBFDEnabled.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestBFDProfile.golden
+++ b/internal/frr/testdata/TestBFDProfile.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestBasic.golden
+++ b/internal/frr/testdata/TestBasic.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestBasicWithASNRT.golden
+++ b/internal/frr/testdata/TestBasicWithASNRT.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestBasicWithIPRT.golden
+++ b/internal/frr/testdata/TestBasicWithIPRT.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestDualStack.golden
+++ b/internal/frr/testdata/TestDualStack.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestDualStackWithRT.golden
+++ b/internal/frr/testdata/TestDualStackWithRT.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestEmpty.golden
+++ b/internal/frr/testdata/TestEmpty.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestIPv6Only.golden
+++ b/internal/frr/testdata/TestIPv6Only.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestIPv6OnlyWithRT.golden
+++ b/internal/frr/testdata/TestIPv6OnlyWithRT.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestL3VNIWithoutLocalNeighborAndAdvertise.golden
+++ b/internal/frr/testdata/TestL3VNIWithoutLocalNeighborAndAdvertise.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestNoVNIs.golden
+++ b/internal/frr/testdata/TestNoVNIs.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestPassthroughDual.golden
+++ b/internal/frr/testdata/TestPassthroughDual.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestPassthroughNoEVPN.golden
+++ b/internal/frr/testdata/TestPassthroughNoEVPN.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestPassthroughV4.golden
+++ b/internal/frr/testdata/TestPassthroughV4.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestRawConfig.golden
+++ b/internal/frr/testdata/TestRawConfig.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log 
+log stdout 
 log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default

--- a/operator/bindata/deployment/openperouter/templates/router.yaml
+++ b/operator/bindata/deployment/openperouter/templates/router.yaml
@@ -93,7 +93,7 @@ data:
     frr defaults traditional
     hostname Router
     line vty
-    log file /etc/frr/frr.log informational
+    log stdout informational
   vtysh.conf: |
     service integrated-vtysh-config
 ---
@@ -156,20 +156,11 @@ spec:
             mountPath: /var/run/frr
           - name: frrconfig
             mountPath: /etc/frr
-        # The command is FRR's default entrypoint & waiting for the log file to appear and tailing it.
-        # If the log file isn't created in 60 seconds the tail fails and the container is restarted.
-        # This workaround is needed to have the frr logs as part of kubectl logs -c frr < k8s-frr-podname >.
         command:
           - /bin/sh
           - -c
           - |
-            /sbin/tini -- /usr/lib/frr/docker-start &
-            attempts=0
-            until [[ -f /etc/frr/frr.log || $attempts -eq 60 ]]; do
-              sleep 1
-              attempts=$(( $attempts + 1 ))
-            done
-            tail -f /etc/frr/frr.log
+            exec /sbin/tini -- /usr/lib/frr/docker-start
         {{- with .Values.openperouter.frr.resources }}
         resources:
           {{- toYaml . | nindent 12 }}

--- a/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2026-04-20T11:18:46Z"
+    createdAt: "2026-04-21T16:41:05Z"
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: openperouter-operator.v0.0.0

--- a/systemdmode/frrconfig/frr.conf
+++ b/systemdmode/frrconfig/frr.conf
@@ -4,5 +4,5 @@ frr version 8.0
 frr defaults traditional
 hostname Router
 line vty
-log file /etc/frr/frr.log informational
+log stdout informational
 

--- a/systemdmode/quadlets/frr.container
+++ b/systemdmode/quadlets/frr.container
@@ -42,15 +42,8 @@ PodmanArgs=--pidfile=/etc/perouter/frr/frr.pid
 Entrypoint=/bin/bash
 
 # Container startup command
-# This complex command does the following:
-# 1. Changes permissions on /var/run/frr for socket access
-# 2. Starts FRR via tini process supervisor in background
-# 3. Waits up to 60 seconds for FRR to create its log file
-# 4. Tails the FRR log to keep the container running
-#
-# Note: $$ escaping is required to prevent systemd variable expansion
-# Shell variables must use $$ syntax (e.g., $$attempts not $attempts)
-Exec=-c "chmod -R a+rw /var/run/frr && /sbin/tini -- /usr/lib/frr/docker-start & attempts=0; until [[ -f /etc/frr/frr.log || $$attempts -eq 60 ]]; do sleep 1; attempts=$$(( $$attempts + 1 )); done; tail -f /etc/frr/frr.log"
+# Changes permissions on /var/run/frr for socket access, then starts FRR via tini.
+Exec=-c "chmod -R a+rw /var/run/frr && exec /sbin/tini -- /usr/lib/frr/docker-start"
 
 [Service]
 # Restart policy - restart container if it fails


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:

Switches FRR logging from `log file /etc/frr/frr.log` to `log stdout`, so FRR writes directly to container stdout. This removes the log file polling/tailing workaround from the FRR container entrypoint — logs now appear natively in `kubectl logs`.

The entrypoint is simplified to just `exec /sbin/tini -- /usr/lib/frr/docker-start`.

**Special notes for your reviewer**:

N/A

**Release note**:

```release-note
Switch FRR logging from file to stdout, simplifying the container entrypoint and enabling native kubectl logs support.
```