### PR TITLE
webhook(l2vni): reject l2gatewayip on disconnected L2VNI

### DIFF
--- a/e2etests/tests/evpn_l2.go
+++ b/e2etests/tests/evpn_l2.go
@@ -382,7 +382,7 @@ var _ = Describe("Routes between bgp and the fabric - vtepInterface", func() {
 		redistributeConnectedForLeafKind(nodes)
 
 		l2VniRedWithGateway := l2VniRed.DeepCopy()
-		l2VniRedWithGateway.Spec.VRF = nil
+		l2VniRedWithGateway.Spec.VRF = ptr.To("red")
 		l2VniRedWithGateway.Spec.L2GatewayIPs = []string{"192.171.24.1/24"}
 		l2VniRedWithGateway.Spec.HostMaster = &v1alpha1.HostMaster{
 			Type: linuxBridgeHostAttachment,

--- a/e2etests/tests/hostconfiguration.go
+++ b/e2etests/tests/hostconfiguration.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
 )
 
 var ValidatorPath string
@@ -727,6 +728,7 @@ var _ = ginkgo.Describe("Router Host configuration", func() {
 			},
 			Spec: v1alpha1.L2VNISpec{
 				VNI:          400,
+				VRF:          ptr.To("second"),
 				L2GatewayIPs: []string{"192.168.1.4/24"},
 			},
 		}

--- a/e2etests/tests/webhooks.go
+++ b/e2etests/tests/webhooks.go
@@ -229,6 +229,17 @@ var _ = Describe("Webhooks", func() {
 					VXLanPort: 4789,
 				},
 			}}, "duplicate vni"),
+			Entry("when trying to create an L2VNI with l2gatewayips but no VRF", []v1alpha1.L2VNI{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "l2vni-no-vrf-gw",
+					Namespace: openperouter.Namespace,
+				},
+				Spec: v1alpha1.L2VNISpec{
+					VNI:          213,
+					VXLanPort:    4789,
+					L2GatewayIPs: []string{"10.100.0.1/24"},
+				},
+			}}, "l2gatewayips cannot be set without spec.vrf"),
 			Entry("when trying to create an L2VNI with an invalid IPv4 address", []v1alpha1.L2VNI{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "l2-invalid-ip4",
@@ -236,6 +247,7 @@ var _ = Describe("Webhooks", func() {
 				},
 				Spec: v1alpha1.L2VNISpec{
 					VNI:          201,
+					VRF:          ptr.To("test-vrf-2"),
 					VXLanPort:    4789,
 					L2GatewayIPs: []string{"not-an-ip-address"},
 				},
@@ -247,6 +259,7 @@ var _ = Describe("Webhooks", func() {
 				},
 				Spec: v1alpha1.L2VNISpec{
 					VNI:          202,
+					VRF:          ptr.To("test-vrf-2"),
 					VXLanPort:    4789,
 					L2GatewayIPs: []string{"256.256.256.256/24"},
 				},
@@ -258,6 +271,7 @@ var _ = Describe("Webhooks", func() {
 				},
 				Spec: v1alpha1.L2VNISpec{
 					VNI:          203,
+					VRF:          ptr.To("test-vrf-2"),
 					VXLanPort:    4789,
 					L2GatewayIPs: []string{"192.168.1.1/24", "invalid-ip"},
 				},
@@ -269,6 +283,7 @@ var _ = Describe("Webhooks", func() {
 				},
 				Spec: v1alpha1.L2VNISpec{
 					VNI:          204,
+					VRF:          ptr.To("test-vrf-2"),
 					VXLanPort:    4789,
 					L2GatewayIPs: []string{"192.168.1.1/24", "2001:db8::1/64", "10.0.0.1/24"},
 				},
@@ -280,6 +295,7 @@ var _ = Describe("Webhooks", func() {
 				},
 				Spec: v1alpha1.L2VNISpec{
 					VNI:          205,
+					VRF:          ptr.To("test-vrf-2"),
 					VXLanPort:    4789,
 					L2GatewayIPs: []string{"192.168.1.1/24", "10.0.0.1/24"},
 				},
@@ -291,6 +307,7 @@ var _ = Describe("Webhooks", func() {
 				},
 				Spec: v1alpha1.L2VNISpec{
 					VNI:          206,
+					VRF:          ptr.To("test-vrf-2"),
 					VXLanPort:    4789,
 					L2GatewayIPs: []string{"2001:db8::1/64", "2001:db9::1/64"},
 				},
@@ -389,6 +406,7 @@ var _ = Describe("Webhooks", func() {
 				},
 				Spec: v1alpha1.L2VNISpec{
 					VNI:          210,
+					VRF:          ptr.To("test-vrf-2"),
 					VXLanPort:    4789,
 					L2GatewayIPs: []string{"192.168.1.1/24"},
 				},
@@ -407,6 +425,7 @@ var _ = Describe("Webhooks", func() {
 				},
 				Spec: v1alpha1.L2VNISpec{
 					VNI:          211,
+					VRF:          ptr.To("test-vrf-2"),
 					VXLanPort:    4789,
 					L2GatewayIPs: []string{"2001:db8::1/64"},
 				},
@@ -425,6 +444,7 @@ var _ = Describe("Webhooks", func() {
 				},
 				Spec: v1alpha1.L2VNISpec{
 					VNI:          212,
+					VRF:          ptr.To("test-vrf-2"),
 					VXLanPort:    4789,
 					L2GatewayIPs: []string{"192.168.1.1/24", "2001:db8::1/64"},
 				},
@@ -445,6 +465,7 @@ var _ = Describe("Webhooks", func() {
 				},
 				Spec: v1alpha1.L2VNISpec{
 					VNI:          300,
+					VRF:          ptr.To("test-vrf-2"),
 					VXLanPort:    4789,
 					L2GatewayIPs: []string{"192.168.10.1/24"},
 				},

--- a/internal/conversion/validate_vni.go
+++ b/internal/conversion/validate_vni.go
@@ -80,6 +80,9 @@ func ValidateL2VNIs(l2Vnis []v1alpha1.L2VNI) error {
 				return err
 			}
 		}
+		if len(vni.Spec.L2GatewayIPs) > 0 && !hasVRF(vni) {
+			return fmt.Errorf("l2gatewayips cannot be set without spec.vrf for vni %q", vni.Name)
+		}
 		if len(vni.Spec.L2GatewayIPs) > 0 {
 			_, err := ipfamily.ForCIDRStrings(vni.Spec.L2GatewayIPs...)
 			if err != nil {
@@ -238,6 +241,10 @@ func cidrsOverlap(cidr1, cidr2 string) (bool, error) {
 	}
 
 	return false, nil
+}
+
+func hasVRF(l2vni v1alpha1.L2VNI) bool {
+	return l2vni.Spec.VRF != nil && *l2vni.Spec.VRF != ""
 }
 
 func isValidInterfaceName(name string) error {

--- a/internal/conversion/validate_vni_test.go
+++ b/internal/conversion/validate_vni_test.go
@@ -273,6 +273,7 @@ func TestValidateL2VNIs(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "vni1"},
 					Spec: v1alpha1.L2VNISpec{
 						VNI:          1001,
+						VRF:          ptr.To("test-vrf"),
 						L2GatewayIPs: []string{"192.168.1.0/24"},
 					},
 					Status: v1alpha1.L2VNIStatus{},
@@ -287,6 +288,7 @@ func TestValidateL2VNIs(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "vni1"},
 					Spec: v1alpha1.L2VNISpec{
 						VNI:          1001,
+						VRF:          ptr.To("test-vrf"),
 						L2GatewayIPs: []string{"2001:db8::/64"},
 					},
 					Status: v1alpha1.L2VNIStatus{},
@@ -301,6 +303,7 @@ func TestValidateL2VNIs(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "vni1"},
 					Spec: v1alpha1.L2VNISpec{
 						VNI:          1001,
+						VRF:          ptr.To("test-vrf"),
 						L2GatewayIPs: []string{"192.168.1.0/24", "2001:db8::/64"},
 					},
 					Status: v1alpha1.L2VNIStatus{},
@@ -309,12 +312,26 @@ func TestValidateL2VNIs(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "l2gatewayips without VRF",
+			vnis: []v1alpha1.L2VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni1"},
+					Spec: v1alpha1.L2VNISpec{
+						VNI:          1001,
+						L2GatewayIPs: []string{"192.168.1.0/24"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "ivalid L2GatewayIPs dual-stack both ipv4",
 			vnis: []v1alpha1.L2VNI{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "vni1"},
 					Spec: v1alpha1.L2VNISpec{
 						VNI:          1001,
+						VRF:          ptr.To("test-vrf"),
 						L2GatewayIPs: []string{"192.168.1.0/24", "192.168.2.0/24"},
 					},
 					Status: v1alpha1.L2VNIStatus{},
@@ -329,6 +346,7 @@ func TestValidateL2VNIs(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "vni1"},
 					Spec: v1alpha1.L2VNISpec{
 						VNI:          1001,
+						VRF:          ptr.To("test-vrf"),
 						L2GatewayIPs: []string{"2002:db8::/64", "2001:db8::/64"},
 					},
 					Status: v1alpha1.L2VNIStatus{},
@@ -343,6 +361,7 @@ func TestValidateL2VNIs(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "vni1"},
 					Spec: v1alpha1.L2VNISpec{
 						VNI:          1001,
+						VRF:          ptr.To("test-vrf"),
 						L2GatewayIPs: []string{"invalid-cidr-format"},
 					},
 					Status: v1alpha1.L2VNIStatus{},


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:
Add validation in `ValidateL2VNIs` to reject L2VNIs that have l2gatewayips set without a VRF. Also adds an `IsDisconnected()` helper to the L2VNI API type.

A disconnected L2VNI (no spec.vrf) provides east-west L2 forwarding only.
Setting l2gatewayips without a VRF creates unreachable gateway IPs since there is no L3VNI to route traffic.

Fixes: #280

**Special notes for your reviewer**:

**Release note**:

```release-note
reject l2gatewayip on disconnected L2VNI
```
