### PR TITLE
fix(e2e): reconfigure leafkind for iBGP in BGP internal session test

### DIFF
--- a/e2etests/tests/sessions.go
+++ b/e2etests/tests/sessions.go
@@ -575,6 +575,7 @@ var _ = Describe("Underlay external and internal configuration", Ordered, func()
 
 	AfterEach(func() {
 		dumpIfFails(cs)
+		resetLeafKindConfig(nodes)
 		err := Updater.CleanAll()
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -589,6 +590,9 @@ var _ = Describe("Underlay external and internal configuration", Ordered, func()
 	}
 
 	It("peers with the tor with BGP external", func() {
+		By("ensuring leafkind expects eBGP with PE ASN 64514")
+		resetLeafKindConfig(nodes)
+
 		underlay := *infra.Underlay.DeepCopy()
 		underlay.Spec.Neighbors[0].ASN = 0
 		underlay.Spec.Neighbors[0].Type = "external"
@@ -602,6 +606,9 @@ var _ = Describe("Underlay external and internal configuration", Ordered, func()
 	})
 
 	It("peers with the tor with BGP internal", func() {
+		By("reconfiguring leafkind for iBGP (PERouterASN=64512)")
+		ibgpForLeafKind(nodes)
+
 		underlay := *infra.Underlay.DeepCopy()
 		underlay.Spec.ASN = 64512
 		underlay.Spec.Neighbors[0].ASN = 0
@@ -616,9 +623,11 @@ var _ = Describe("Underlay external and internal configuration", Ordered, func()
 	})
 
 	It("peers with the tor with iBGP with ASN number", func() {
+		By("reconfiguring leafkind for iBGP (PERouterASN=64512)")
+		ibgpForLeafKind(nodes)
+
 		underlay := *infra.Underlay.DeepCopy()
-		underlay.Spec.Neighbors[0].ASN = 64512
-		underlay.Spec.Neighbors[0].Type = ""
+		underlay.Spec.ASN = 64512
 		err := Updater.Update(config.Resources{
 			Underlays: []v1alpha1.Underlay{
 				underlay,


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>

/kind bug

> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
The "peers with the tor with BGP internal" test changes the PE ASN to 64512 (matching leafkind's ASN) but never reconfigures leafkind's FRR to expect the new ASN. Leafkind keeps `remote-as 64514` while the PE now opens with ASN 64512, causing a permanent ASN mismatch and Idle BGP state.

Fix all three session tests to explicitly configure leafkind:
- external: resetLeafKindConfig to set PERouterASN=64514
- internal: ibgpForLeafKind to set PERouterASN=64512
- iBGP with ASN number: ibgpForLeafKind + set PE ASN to 64512 so it actually tests iBGP (previously kept PE at 64514, making it eBGP)

Add resetLeafKindConfig in AfterEach to restore defaults for subsequent tests.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
