### PR TITLE
Remove hostNetwork, hostPID, and privileged from controller pod

### DIFF
--- a/charts/openperouter/README.md
+++ b/charts/openperouter/README.md
@@ -27,7 +27,6 @@ Kubernetes: `>= 1.19.0-0`
 | fullnameOverride | string | `""` |  |
 | nameOverride | string | `""` |  |
 | openperouter.affinity | object | `{}` |  |
-| openperouter.controller.healthProbePort | int | `9081` | Health probe port for liveness and readiness checks |
 | openperouter.controller.resources | object | `{}` |  |
 | openperouter.cri | string | `"containerd"` |  |
 | openperouter.frr.image.pullPolicy | string | `""` |  |

--- a/charts/openperouter/templates/controller.yaml
+++ b/charts/openperouter/templates/controller.yaml
@@ -47,9 +47,6 @@ spec:
         {{- with .Values.openperouter.logLevel }}
         - --loglevel={{ . }}
         {{- end }}
-        {{- with .Values.openperouter.controller.healthProbePort }}
-        - --health-probe-bind-address=:{{ . }}
-        {{- end }}
         {{- if eq .Values.openperouter.cri "containerd" }}
         - --crisocket=/containerd.sock
         {{- end }}
@@ -79,13 +76,13 @@ spec:
         {{- end }}
         name: controller
         ports:
-        - containerPort: {{ .Values.openperouter.controller.healthProbePort | default 9081 }}
+        - containerPort: 9081
           name: health
           protocol: TCP
         readinessProbe:
           httpGet:
             path: /readyz
-            port: {{ .Values.openperouter.controller.healthProbePort | default 9081 }}
+            port: 9081
           initialDelaySeconds: 5
           periodSeconds: 10
           timeoutSeconds: 1
@@ -93,7 +90,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: {{ .Values.openperouter.controller.healthProbePort | default 9081 }}
+            port: 9081
           initialDelaySeconds: 15
           periodSeconds: 20
           timeoutSeconds: 1
@@ -108,8 +105,8 @@ spec:
             - NET_ADMIN
             - NET_RAW
             - SYS_ADMIN
-            - NET_BIND_SERVICE
-          privileged: true
+          seccompProfile:
+            type: Unconfined
         volumeMounts:
         {{- if eq .Values.openperouter.cri "containerd" }}
         - mountPath: /containerd.sock
@@ -124,6 +121,8 @@ spec:
         - mountPath: /run/netns
           mountPropagation: HostToContainer
           name: runns
+        - mountPath: /run/host-netns/net
+          name: host-netns
         - mountPath: /etc/frr/
           mountPropagation: HostToContainer
           name: frr-config
@@ -132,8 +131,6 @@ spec:
           mountPropagation: HostToContainer
         - mountPath: /var/run/frr
           name: frr-sockets
-      hostNetwork: true
-      hostPID: true
       tolerations:
       {{- if .Values.openperouter.runOnMaster }}
       - effect: NoSchedule
@@ -150,6 +147,10 @@ spec:
       priorityClassName: {{ . | quote }}
       {{- end }}
       volumes:
+      - hostPath:
+          path: /proc/1/ns/net
+          type: File
+        name: host-netns
       - hostPath:
           path: /run/netns
         name: runns

--- a/charts/openperouter/values.yaml
+++ b/charts/openperouter/values.yaml
@@ -50,8 +50,6 @@ openperouter:
   labels: {}
   controller:
     resources: {}
-    # -- Health probe port for liveness and readiness checks
-    healthProbePort: 9081
   nodemarker:
     resources: {}
   # frr contains configuration specific to the perouter FRR container,

--- a/cmd/hostcontroller/main.go
+++ b/cmd/hostcontroller/main.go
@@ -51,6 +51,7 @@ import (
 	"github.com/openperouter/openperouter/internal/filewatcher"
 	"github.com/openperouter/openperouter/internal/hostnetwork"
 	"github.com/openperouter/openperouter/internal/logging"
+	"github.com/openperouter/openperouter/internal/netnamespace"
 	"github.com/openperouter/openperouter/internal/pods"
 	"github.com/openperouter/openperouter/internal/staticconfiguration"
 	"github.com/openperouter/openperouter/internal/systemdctl"
@@ -85,7 +86,8 @@ type hostModeParameters struct {
 }
 
 type k8sModeParameters struct {
-	criSocket string
+	criSocket     string
+	hostNetNSPath string
 }
 
 type parameters struct {
@@ -119,6 +121,8 @@ func main() {
 	flag.StringVar(&args.nodeName, "nodename", "", "The name of the node the controller runs on")
 	flag.StringVar(&args.namespace, "namespace", "", "The namespace the controller runs in")
 	flag.StringVar(&k8sModeParams.criSocket, "crisocket", "/containerd.sock", "the location of the cri socket")
+	flag.StringVar(&k8sModeParams.hostNetNSPath, "host-netns-path",
+		"/run/host-netns/net", "the path to the mounted host network namespace")
 
 	flag.DurationVar(&hostModeParams.k8sWaitInterval, "k8s-wait-timeout", time.Minute,
 		"K8s API server waiting interval time")
@@ -171,6 +175,12 @@ func runK8sMode(
 	k8sModeParams k8sModeParameters,
 	logger *slog.Logger,
 ) {
+	// Initialize host network namespace handle from mounted path
+	if err := netnamespace.InitHostNS(k8sModeParams.hostNetNSPath); err != nil {
+		logger.Error("unable to initialize host network namespace", "path", k8sModeParams.hostNetNSPath, "error", err)
+		os.Exit(1)
+	}
+
 	// K8s mode: setup k8s-based reconciler and start
 	k8sConfig, err := config.GetConfig()
 	if err != nil {

--- a/config/all-in-one/crio.yaml
+++ b/config/all-in-one/crio.yaml
@@ -1464,12 +1464,12 @@ spec:
         operator: Exists
       volumes:
       - hostPath:
+          path: /var/run/crio
+        name: varrun
+      - hostPath:
           path: /proc/1/ns/net
           type: File
         name: host-netns
-      - hostPath:
-          path: /var/run/crio
-        name: varrun
       - hostPath:
           path: /run/netns
         name: runns

--- a/config/all-in-one/crio.yaml
+++ b/config/all-in-one/crio.yaml
@@ -1432,8 +1432,8 @@ spec:
             - NET_ADMIN
             - NET_RAW
             - SYS_ADMIN
-            - NET_BIND_SERVICE
-          privileged: true
+          seccompProfile:
+            type: Unconfined
         volumeMounts:
         - mountPath: /crio.sock
           name: varrun
@@ -1444,6 +1444,8 @@ spec:
         - mountPath: /run/netns
           mountPropagation: HostToContainer
           name: runns
+        - mountPath: /run/host-netns/net
+          name: host-netns
         - mountPath: /etc/frr/
           mountPropagation: HostToContainer
           name: frr-config
@@ -1452,8 +1454,6 @@ spec:
           name: ovs-var-run
         - mountPath: /var/run/frr
           name: frr-sockets
-      hostNetwork: true
-      hostPID: true
       serviceAccountName: controller
       tolerations:
       - effect: NoSchedule
@@ -1463,6 +1463,10 @@ spec:
         key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
+      - hostPath:
+          path: /proc/1/ns/net
+          type: File
+        name: host-netns
       - hostPath:
           path: /var/run/crio
         name: varrun

--- a/config/all-in-one/openpe.yaml
+++ b/config/all-in-one/openpe.yaml
@@ -1432,8 +1432,8 @@ spec:
             - NET_ADMIN
             - NET_RAW
             - SYS_ADMIN
-            - NET_BIND_SERVICE
-          privileged: true
+          seccompProfile:
+            type: Unconfined
         volumeMounts:
         - mountPath: /containerd.sock
           name: varrun
@@ -1441,6 +1441,8 @@ spec:
         - mountPath: /run/netns
           mountPropagation: HostToContainer
           name: runns
+        - mountPath: /run/host-netns/net
+          name: host-netns
         - mountPath: /etc/frr/
           mountPropagation: HostToContainer
           name: frr-config
@@ -1449,8 +1451,6 @@ spec:
           name: ovs-var-run
         - mountPath: /var/run/frr
           name: frr-sockets
-      hostNetwork: true
-      hostPID: true
       serviceAccountName: controller
       tolerations:
       - effect: NoSchedule
@@ -1460,6 +1460,10 @@ spec:
         key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
+      - hostPath:
+          path: /proc/1/ns/net
+          type: File
+        name: host-netns
       - hostPath:
           path: /run/netns
         name: runns

--- a/config/pods/controller.yaml
+++ b/config/pods/controller.yaml
@@ -57,8 +57,9 @@ spec:
           failureThreshold: 3
         securityContext:
           capabilities:
-            add: ["NET_ADMIN", "NET_RAW", "SYS_ADMIN", "NET_BIND_SERVICE"]
-          privileged: true
+            add: ["NET_ADMIN", "NET_RAW", "SYS_ADMIN"]
+          seccompProfile:
+            type: Unconfined
         env:
         - name: NODE_NAME
           valueFrom:
@@ -75,6 +76,8 @@ spec:
         - mountPath: /run/netns
           name: runns
           mountPropagation: HostToContainer
+        - mountPath: /run/host-netns/net
+          name: host-netns
         - mountPath: /etc/frr/
           name: frr-config
           mountPropagation: HostToContainer
@@ -91,6 +94,10 @@ spec:
             cpu: 10m
             memory: 64Mi
       volumes:
+      - name: host-netns
+        hostPath:
+          path: /proc/1/ns/net
+          type: File
       - name: runns
         hostPath:
           path: /run/netns
@@ -116,5 +123,3 @@ spec:
         key: node-role.kubernetes.io/control-plane
         operator: Exists
       serviceAccountName: controller
-      hostNetwork: true
-      hostPID: true

--- a/internal/hostnetwork/link_properties.go
+++ b/internal/hostnetwork/link_properties.go
@@ -179,20 +179,25 @@ func moveInterfaceToNamespace(ctx context.Context, intf string, ns netns.NsHandl
 		return fmt.Errorf("moveInterfaceToNamespace: Failed to execute in ns %s: %w", intf, err)
 	}
 
-	link, err := netlink.LinkByName(intf)
-	if err != nil {
-		return fmt.Errorf("moveInterfaceToNamespace: Failed to find link %s: %w", intf, err)
-	}
+	var addresses []netlink.Addr
+	if err := netnamespace.InHost(func() error {
+		link, err := netlink.LinkByName(intf)
+		if err != nil {
+			return fmt.Errorf("moveInterfaceToNamespace: Failed to find link %s: %w", intf, err)
+		}
 
-	addresses, err := netlink.AddrList(link, netlink.FAMILY_ALL)
-	if err != nil {
-		return fmt.Errorf("moveInterfaceToNamespace: Failed to get addresses for intf %s: %w", link.Attrs().Name, err)
-	}
+		addresses, err = netlink.AddrList(link, netlink.FAMILY_ALL)
+		if err != nil {
+			return fmt.Errorf("moveInterfaceToNamespace: Failed to get addresses for intf %s: %w", link.Attrs().Name, err)
+		}
 
-	slog.DebugContext(ctx, "addresses before moving", "addresses", addresses)
-	err = netlink.LinkSetNsFd(link, int(ns))
-	if err != nil {
-		return fmt.Errorf("moveInterfaceToNamespace: Failed to move %s to network namespace %s: %w", link.Attrs().Name, ns.String(), err)
+		slog.DebugContext(ctx, "addresses before moving", "addresses", addresses)
+		if err := netlink.LinkSetNsFd(link, int(ns)); err != nil {
+			return fmt.Errorf("moveInterfaceToNamespace: Failed to move %s to network namespace %s: %w", link.Attrs().Name, ns.String(), err)
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 	if err := netnamespace.In(ns, func() error {
 		nsLink, err := netlink.LinkByName(intf)

--- a/internal/hostnetwork/passthrough.go
+++ b/internal/hostnetwork/passthrough.go
@@ -40,14 +40,14 @@ func SetupPassthrough(ctx context.Context, params PassthroughParams) error {
 		}
 	}()
 
-	hostVeth, err := netlink.LinkByName(PassthroughNames.HostSide)
-	if errors.As(err, &netlink.LinkNotFoundError{}) {
-		return fmt.Errorf("SetupPassthrough: host veth %s does not exist, cannot setup Passthrough", PassthroughNames.HostSide)
-	}
-
-	err = assignIPsToInterface(hostVeth, params.HostVeth.HostIPv4, params.HostVeth.HostIPv6)
-	if err != nil {
-		return fmt.Errorf("failed to assign IPs to host veth: %w", err)
+	if err := netnamespace.InHost(func() error {
+		hostVeth, err := netlink.LinkByName(PassthroughNames.HostSide)
+		if errors.As(err, &netlink.LinkNotFoundError{}) {
+			return fmt.Errorf("SetupPassthrough: host veth %s does not exist, cannot setup Passthrough", PassthroughNames.HostSide)
+		}
+		return assignIPsToInterface(hostVeth, params.HostVeth.HostIPv4, params.HostVeth.HostIPv6)
+	}); err != nil {
+		return err
 	}
 
 	if err := netnamespace.In(ns, func() error {
@@ -68,7 +68,9 @@ func SetupPassthrough(ctx context.Context, params PassthroughParams) error {
 }
 
 func RemovePassthrough(targetNS string) error {
-	if err := removeLinkByName(PassthroughNames.HostSide); err != nil {
+	if err := netnamespace.InHost(func() error {
+		return removeLinkByName(PassthroughNames.HostSide)
+	}); err != nil {
 		return fmt.Errorf("RemovePassthrough: failed to remove host link %s: %w", PassthroughNames.HostSide, err)
 	}
 

--- a/internal/hostnetwork/suite_test.go
+++ b/internal/hostnetwork/suite_test.go
@@ -9,7 +9,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/openperouter/openperouter/internal/netnamespace"
 )
+
+var _ = BeforeSuite(func() {
+	Expect(netnamespace.InitHostNS("/proc/self/ns/net")).To(Succeed())
+})
 
 func TestAPIs(t *testing.T) {
 	if testing.Short() {

--- a/internal/hostnetwork/veth.go
+++ b/internal/hostnetwork/veth.go
@@ -42,12 +42,19 @@ func setupNamespacedVeth(ctx context.Context, vethNames VethNames, namespace str
 	logger := slog.Default().With("host side", vethNames.HostSide, "pe side", vethNames.NamespaceSide)
 	logger.DebugContext(ctx, "setting up veth")
 
-	hostSide, err := createVeth(ctx, logger, vethNames)
-	if err != nil {
-		return fmt.Errorf("could not create veth for %s - %s: %w", vethNames.HostSide, vethNames.NamespaceSide, err)
-	}
-	if err = netlink.LinkSetUp(hostSide); err != nil {
-		return fmt.Errorf("could not set link up for host leg %s: %v", hostSide.Attrs().Name, err)
+	var hostSide *netlink.Veth
+	if err := netnamespace.InHost(func() error {
+		var err error
+		hostSide, err = createVeth(ctx, logger, vethNames)
+		if err != nil {
+			return fmt.Errorf("could not create veth for %s - %s: %w", vethNames.HostSide, vethNames.NamespaceSide, err)
+		}
+		if err = netlink.LinkSetUp(hostSide); err != nil {
+			return fmt.Errorf("could not set link up for host leg %s: %v", hostSide.Attrs().Name, err)
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	// Let's try to look into the namespace
@@ -66,24 +73,27 @@ func setupNamespacedVeth(ctx context.Context, vethNames VethNames, namespace str
 		return nil
 	}
 
-	// Not in the namespace, let's try locally
-	peerIndex, err := netlink.VethPeerIndex(hostSide)
-	if err != nil {
-		return fmt.Errorf("could not find peer veth for %s: %w", vethNames.HostSide, err)
+	// Not in the namespace, let's move peer from host NS
+	if err := netnamespace.InHost(func() error {
+		peerIndex, err := netlink.VethPeerIndex(hostSide)
+		if err != nil {
+			return fmt.Errorf("could not find peer veth for %s: %w", vethNames.HostSide, err)
+		}
+		nsSide, err := netlink.LinkByIndex(peerIndex)
+		if errors.As(err, &netlink.LinkNotFoundError{}) {
+			return fmt.Errorf("peer veth not found by index for %s: %w", vethNames.HostSide, err)
+		}
+		if err != nil {
+			return fmt.Errorf("could not find peer by index for %s: %w", vethNames.HostSide, err)
+		}
+		if err = netlink.LinkSetNsFd(nsSide, int(targetNS)); err != nil {
+			return fmt.Errorf("setupUnderlay: Failed to move %s to network namespace %s: %w", nsSide.Attrs().Name, targetNS.String(), err)
+		}
+		slog.DebugContext(ctx, "pe leg moved to ns", "pe veth", nsSide.Attrs().Name)
+		return nil
+	}); err != nil {
+		return err
 	}
-	nsSide, err := netlink.LinkByIndex(peerIndex)
-	if errors.As(err, &netlink.LinkNotFoundError{}) {
-		return fmt.Errorf("peer veth not found by index for %s: %w", vethNames.HostSide, err)
-	}
-
-	if err != nil {
-		return fmt.Errorf("could not find peer by index for %s: %w", vethNames.HostSide, err)
-	}
-
-	if err = netlink.LinkSetNsFd(nsSide, int(targetNS)); err != nil {
-		return fmt.Errorf("setupUnderlay: Failed to move %s to network namespace %s: %w", nsSide.Attrs().Name, targetNS.String(), err)
-	}
-	slog.DebugContext(ctx, "pe leg moved to ns", "pe veth", nsSide.Attrs().Name)
 
 	if err := netnamespace.In(targetNS, func() error {
 		nsSideLink, err := netlink.LinkByName(vethNames.NamespaceSide)

--- a/internal/hostnetwork/vni.go
+++ b/internal/hostnetwork/vni.go
@@ -101,14 +101,14 @@ func SetupL3VNI(ctx context.Context, params L3VNIParams) error {
 		}
 	}()
 
-	hostVeth, err := netlink.LinkByName(vethNames.HostSide)
-	if errors.As(err, &netlink.LinkNotFoundError{}) {
-		return fmt.Errorf("SetupL3VNI: host veth %s does not exist, cannot setup L3 VNI", vethNames.HostSide)
-	}
-
-	err = assignIPsToInterface(hostVeth, params.HostVeth.HostIPv4, params.HostVeth.HostIPv6)
-	if err != nil {
-		return fmt.Errorf("failed to assign IPs to host veth: %w", err)
+	if err := netnamespace.InHost(func() error {
+		hostVeth, err := netlink.LinkByName(vethNames.HostSide)
+		if errors.As(err, &netlink.LinkNotFoundError{}) {
+			return fmt.Errorf("SetupL3VNI: host veth %s does not exist, cannot setup L3 VNI", vethNames.HostSide)
+		}
+		return assignIPsToInterface(hostVeth, params.HostVeth.HostIPv4, params.HostVeth.HostIPv6)
+	}); err != nil {
+		return err
 	}
 
 	if err := netnamespace.In(ns, func() error {
@@ -165,19 +165,24 @@ func SetupL2VNI(ctx context.Context, params L2VNIParams) error {
 		}
 	}()
 
-	hostVeth, err := netlink.LinkByName(vethNames.HostSide)
-	if errors.As(err, &netlink.LinkNotFoundError{}) {
-		return fmt.Errorf("SetupL2VNI: host veth %s does not exist, cannot setup L2 VNI", vethNames.HostSide)
-	}
-	if err != nil {
-		return fmt.Errorf("SetupL2VNI: failed to get host veth %s: %w", vethNames.HostSide, err)
-	}
-	slog.Info("SetupL2VNI: found host veth", "name", vethNames.HostSide, "index", hostVeth.Attrs().Index)
-
-	if params.HostMaster != nil {
-		if err := setupHostMaster(ctx, params, hostVeth); err != nil {
-			return err
+	if err := netnamespace.InHost(func() error {
+		hostVeth, err := netlink.LinkByName(vethNames.HostSide)
+		if errors.As(err, &netlink.LinkNotFoundError{}) {
+			return fmt.Errorf("SetupL2VNI: host veth %s does not exist, cannot setup L2 VNI", vethNames.HostSide)
 		}
+		if err != nil {
+			return fmt.Errorf("SetupL2VNI: failed to get host veth %s: %w", vethNames.HostSide, err)
+		}
+		slog.Info("SetupL2VNI: found host veth", "name", vethNames.HostSide, "index", hostVeth.Attrs().Index)
+
+		if params.HostMaster != nil {
+			if err := setupHostMaster(ctx, params, hostVeth); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	if err := netnamespace.In(ns, func() error {
@@ -302,8 +307,13 @@ func RemoveNonConfiguredVNIs(targetNS string, params []VNIParams) error {
 		vrfs[p.VRF] = true
 		vnis[p.VNI] = true
 	}
-
-	failedDeletes := removeHostSideVNIs(vnis)
+	var failedDeletes []error
+	if err := netnamespace.InHost(func() error {
+		failedDeletes = removeHostSideVNIs(vnis)
+		return nil
+	}); err != nil {
+		return err
+	}
 
 	ns, err := netns.GetFromPath(targetNS)
 	if err != nil {

--- a/internal/hostnetwork/vni.go
+++ b/internal/hostnetwork/vni.go
@@ -165,7 +165,18 @@ func SetupL2VNI(ctx context.Context, params L2VNIParams) error {
 		}
 	}()
 
-	if err := netnamespace.InHost(func() error {
+	if err := setupL2VNIHostSide(ctx, params, vethNames); err != nil {
+		return err
+	}
+
+	if err := setupL2VNINamespaceSide(ns, params, vethNames); err != nil {
+		return err
+	}
+	return nil
+}
+
+func setupL2VNIHostSide(ctx context.Context, params L2VNIParams, vethNames VethNames) error {
+	return netnamespace.InHost(func() error {
 		hostVeth, err := netlink.LinkByName(vethNames.HostSide)
 		if errors.As(err, &netlink.LinkNotFoundError{}) {
 			return fmt.Errorf("SetupL2VNI: host veth %s does not exist, cannot setup L2 VNI", vethNames.HostSide)
@@ -181,11 +192,11 @@ func SetupL2VNI(ctx context.Context, params L2VNIParams) error {
 			}
 		}
 		return nil
-	}); err != nil {
-		return err
-	}
+	})
+}
 
-	if err := netnamespace.In(ns, func() error {
+func setupL2VNINamespaceSide(ns netns.NsHandle, params L2VNIParams, vethNames VethNames) error {
+	return netnamespace.In(ns, func() error {
 		peVeth, err := netlink.LinkByName(vethNames.NamespaceSide)
 		if err != nil {
 			return fmt.Errorf("could not find peer veth %s in namespace %s: %w", vethNames.NamespaceSide, params.TargetNS, err)
@@ -212,10 +223,7 @@ func SetupL2VNI(ctx context.Context, params L2VNIParams) error {
 		}
 
 		return nil
-	}); err != nil {
-		return err
-	}
-	return nil
+	})
 }
 
 func setupHostMaster(ctx context.Context, params L2VNIParams, hostVeth netlink.Link) error {

--- a/internal/netnamespace/netnamespace.go
+++ b/internal/netnamespace/netnamespace.go
@@ -10,6 +10,29 @@ import (
 	"github.com/vishvananda/netns"
 )
 
+var hostNS netns.NsHandle
+
+// InitHostNS opens the host network namespace from the given path
+// and stores it for use by InHost(). Must be called once at startup.
+func InitHostNS(path string) error {
+	ns, err := netns.GetFromPath(path)
+	if err != nil {
+		return fmt.Errorf("failed to open host network namespace from %s: %w", path, err)
+	}
+	hostNS = ns
+	return nil
+}
+
+// InHost executes the given function inside the host network namespace.
+func InHost(fn func() error) error {
+	return In(hostNS, fn)
+}
+
+// HostNS returns the stored host network namespace handle.
+func HostNS() netns.NsHandle {
+	return hostNS
+}
+
 type SetNamespaceError string
 
 func (i SetNamespaceError) Error() string {

--- a/internal/netnamespace/netnamespace.go
+++ b/internal/netnamespace/netnamespace.go
@@ -25,6 +25,9 @@ func InitHostNS(path string) error {
 
 // InHost executes the given function inside the host network namespace.
 func InHost(fn func() error) error {
+	if hostNS == 0 {
+		return fmt.Errorf("host network namespace not initialized; call InitHostNS first")
+	}
 	return In(hostNS, fn)
 }
 

--- a/operator/bindata/deployment/openperouter/README.md
+++ b/operator/bindata/deployment/openperouter/README.md
@@ -27,7 +27,6 @@ Kubernetes: `>= 1.19.0-0`
 | fullnameOverride | string | `""` |  |
 | nameOverride | string | `""` |  |
 | openperouter.affinity | object | `{}` |  |
-| openperouter.controller.healthProbePort | int | `9081` | Health probe port for liveness and readiness checks |
 | openperouter.controller.resources | object | `{}` |  |
 | openperouter.cri | string | `"containerd"` |  |
 | openperouter.frr.image.pullPolicy | string | `""` |  |

--- a/operator/bindata/deployment/openperouter/templates/controller.yaml
+++ b/operator/bindata/deployment/openperouter/templates/controller.yaml
@@ -47,9 +47,6 @@ spec:
         {{- with .Values.openperouter.logLevel }}
         - --loglevel={{ . }}
         {{- end }}
-        {{- with .Values.openperouter.controller.healthProbePort }}
-        - --health-probe-bind-address=:{{ . }}
-        {{- end }}
         {{- if eq .Values.openperouter.cri "containerd" }}
         - --crisocket=/containerd.sock
         {{- end }}
@@ -79,13 +76,13 @@ spec:
         {{- end }}
         name: controller
         ports:
-        - containerPort: {{ .Values.openperouter.controller.healthProbePort | default 9081 }}
+        - containerPort: 9081
           name: health
           protocol: TCP
         readinessProbe:
           httpGet:
             path: /readyz
-            port: {{ .Values.openperouter.controller.healthProbePort | default 9081 }}
+            port: 9081
           initialDelaySeconds: 5
           periodSeconds: 10
           timeoutSeconds: 1
@@ -93,7 +90,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: {{ .Values.openperouter.controller.healthProbePort | default 9081 }}
+            port: 9081
           initialDelaySeconds: 15
           periodSeconds: 20
           timeoutSeconds: 1
@@ -108,8 +105,8 @@ spec:
             - NET_ADMIN
             - NET_RAW
             - SYS_ADMIN
-            - NET_BIND_SERVICE
-          privileged: true
+          seccompProfile:
+            type: Unconfined
         volumeMounts:
         {{- if eq .Values.openperouter.cri "containerd" }}
         - mountPath: /containerd.sock
@@ -124,6 +121,8 @@ spec:
         - mountPath: /run/netns
           mountPropagation: HostToContainer
           name: runns
+        - mountPath: /run/host-netns/net
+          name: host-netns
         - mountPath: /etc/frr/
           mountPropagation: HostToContainer
           name: frr-config
@@ -132,8 +131,6 @@ spec:
           mountPropagation: HostToContainer
         - mountPath: /var/run/frr
           name: frr-sockets
-      hostNetwork: true
-      hostPID: true
       tolerations:
       {{- if .Values.openperouter.runOnMaster }}
       - effect: NoSchedule
@@ -150,6 +147,10 @@ spec:
       priorityClassName: {{ . | quote }}
       {{- end }}
       volumes:
+      - hostPath:
+          path: /proc/1/ns/net
+          type: File
+        name: host-netns
       - hostPath:
           path: /run/netns
         name: runns

--- a/operator/bindata/deployment/openperouter/values.yaml
+++ b/operator/bindata/deployment/openperouter/values.yaml
@@ -50,8 +50,6 @@ openperouter:
   labels: {}
   controller:
     resources: {}
-    # -- Health probe port for liveness and readiness checks
-    healthProbePort: 9081
   nodemarker:
     resources: {}
   # frr contains configuration specific to the perouter FRR container,

--- a/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2026-04-24T08:59:47Z"
+    createdAt: "2026-04-24T09:28:33Z"
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: openperouter-operator.v0.0.0

--- a/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2026-04-22T08:50:06Z"
+    createdAt: "2026-04-24T08:59:47Z"
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: openperouter-operator.v0.0.0


### PR DESCRIPTION
## Summary

- Remove `hostNetwork: true`, `hostPID: true`, and `privileged: true` from the controller DaemonSet (K8s mode only)
- Mount host network namespace via `/proc/1/ns/net` and enter it explicitly using a new `InHost()` wrapper for netlink operations that need it
- Replace `privileged: true` with explicit capabilities (`NET_ADMIN`, `NET_RAW`, `SYS_ADMIN`) and `seccompProfile: Unconfined` (required for `setns()`)
- Simplify health probes: remove configurable `healthProbePort` Helm value and `--health-probe-bind-address` flag since port conflicts are no longer possible without host networking
- Drop `NET_BIND_SERVICE` capability (port 9081 is unprivileged)

## Test plan

- [ ] `make lint` passes
- [ ] `go build ./...` compiles
- [ ] Unit tests pass (`go test ./internal/hostnetwork/... -tags runasroot`)
- [ ] Controller pod starts without `hostNetwork`, `hostPID`, or `privileged`
- [ ] Health/readiness probes pass on pod IP
- [ ] VNI setup creates veths with host leg in host NS, PE leg in router NS
- [ ] Underlay interface moves to router NS correctly
- [ ] E2E test suite passes: `make e2etests`
- [ ] Verify on clusters with SELinux/AppArmor enforcing

🤖 Generated with [Claude Code](https://claude.com/claude-code)