### PR TITLE
fix: use fresh pod list in AfterEach rollout check

### DIFF
--- a/e2etests/tests/hostconfiguration.go
+++ b/e2etests/tests/hostconfiguration.go
@@ -81,6 +81,9 @@ var _ = ginkgo.Describe("Router Host configuration", func() {
 
 	ginkgo.AfterEach(func() {
 		dumpIfFails(cs)
+		currentPods, err := openperouter.RouterPods(cs)
+		Expect(err).NotTo(HaveOccurred())
+
 		Expect(Updater.CleanAll()).To(Succeed())
 		ginkgo.By("waiting for the router pod to rollout after removing the underlay")
 		Eventually(func() error {
@@ -88,7 +91,7 @@ var _ = ginkgo.Describe("Router Host configuration", func() {
 			if err != nil {
 				return err
 			}
-			return podsRolled(cs, routerPods, newRouterPods)
+			return podsRolled(cs, currentPods, newRouterPods)
 		}, time.Minute, time.Second).ShouldNot(HaveOccurred())
 	})
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

Fixing CI flakes.
Tests that trigger mid-test rollouts leave routerPods stale. Fetch current pods before cleanup so podsRolled compares against what's actually running.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
