### PR TITLE
fix(e2e): handle neighbor entry GC race in bridge refresh test

### DIFF
--- a/e2etests/tests/bridgerefresh.go
+++ b/e2etests/tests/bridgerefresh.go
@@ -4,6 +4,7 @@ package tests
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -295,6 +296,11 @@ var _ = Describe("BridgeRefresher E2E - Type 2 Route Persistence", Ordered, func
 					return checkType2RouteExists(cs, migratingPodIPOnly, vtepIPOnly, l2VNI)
 				}, 3*time.Minute, 5*time.Second).ShouldNot(HaveOccurred())
 
+				By("Verifying neighbor entry exists on the router before migration")
+				Eventually(func() error {
+					return checkNeighborExists(cs, migratingPodIPOnly, l2VNI, migratingPod.Spec.NodeName)
+				}, time.Minute, 2*time.Second).ShouldNot(HaveOccurred())
+
 				By("Deleting migrating pod (simulating pod eviction/migration)")
 				err = cs.CoreV1().Pods(testNamespace).Delete(
 					context.Background(),
@@ -316,7 +322,11 @@ var _ = Describe("BridgeRefresher E2E - Type 2 Route Persistence", Ordered, func
 				// This is important to trigger the deadlock situation described in https://github.com/FRRouting/frr/issues/14156
 				By("Waiting for neighbor entry to go STALE on the router on the same node")
 				Eventually(func() error {
-					return checkNeighborStale(cs, migratingPodIPOnly, l2VNI, migratingPod.Spec.NodeName)
+					err := checkNeighborStale(cs, migratingPodIPOnly, l2VNI, migratingPod.Spec.NodeName)
+					if errors.Is(err, ErrNoNeighborEntry) { // if the neighbor entry is expired no need to wait
+						return nil
+					}
+					return err
 				}, 3*time.Minute, 2*time.Second).ShouldNot(HaveOccurred())
 
 				By("Recreating migrating pod on node B (the other node) with same IP")
@@ -370,6 +380,28 @@ func checkType2RouteExists(cs clientset.Interface, podIP, vtepIP string, vni int
 	return nil
 }
 
+var ErrNoNeighborEntry = errors.New("no neighbor entry")
+
+func checkNeighborExists(cs clientset.Interface, podIP string, vni int, nodeName string) error {
+	bridgeDev := fmt.Sprintf("br-pe-%d", vni)
+	currentRouters, err := openperouter.Get(cs, HostMode)
+	if err != nil {
+		return err
+	}
+	exec, err := openperouter.ExecutorForNode(currentRouters, nodeName)
+	if err != nil {
+		return err
+	}
+	out, err := exec.Exec("ip", "neigh", "show", podIP, "dev", bridgeDev)
+	if err != nil {
+		return fmt.Errorf("failed to check neighbor on router %s: %w", exec.Name(), err)
+	}
+	if strings.TrimSpace(out) == "" {
+		return fmt.Errorf("no neighbor entry for %s on %s in router %s", podIP, bridgeDev, exec.Name())
+	}
+	return nil
+}
+
 func checkNeighborStale(cs clientset.Interface, podIP string, vni int, nodeName string) error {
 	bridgeDev := fmt.Sprintf("br-pe-%d", vni)
 	currentRouters, err := openperouter.Get(cs, HostMode)
@@ -386,11 +418,10 @@ func checkNeighborStale(cs clientset.Interface, podIP string, vni int, nodeName 
 	}
 	out = strings.TrimSpace(out)
 	if out == "" {
-		return fmt.Errorf("no neighbor entry for %s on %s in router %s", podIP, bridgeDev, exec.Name())
+		return fmt.Errorf("%w for %s on %s in router %s", ErrNoNeighborEntry, podIP, bridgeDev, exec.Name())
 	}
 	if strings.Contains(out, "STALE") || strings.Contains(out, "FAILED") {
 		return nil
 	}
 	return fmt.Errorf("neighbor %s on %s in router %s is not STALE yet: %s", podIP, bridgeDev, exec.Name(), out)
 }
-


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
/kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

The IPv6 migration test timed out waiting for a STALE neighbor entry
because the kernel NDP state machine (STALE->DELAY->FAILED->GC) completed
in ~8 seconds, faster than the test polling interval via podman exec.

Introduce ErrNoNeighborEntry sentinel so callers can distinguish
"entry was GC'd" from other failures, and treat a missing entry as
success. Also verify the neighbor entry exists before pod deletion
to confirm it was learned and not simply never created.


**Special notes for your reviewer**:

Spotted in https://github.com/openperouter/openperouter/actions/runs/24882543505/job/72855481022?pr=310



**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
