### PR TITLE
fix: enable ipv6 forwarding in PE FRR config

### DIFF
--- a/internal/frr/templates/frr.tmpl
+++ b/internal/frr/templates/frr.tmpl
@@ -18,6 +18,7 @@ debug bfd zebra
 hostname {{.Hostname}}
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+ipv6 forwarding
 
 {{- range .VNIs }}
 vrf {{ .VRF }}

--- a/internal/frr/testdata/TestBFDEnabled.golden
+++ b/internal/frr/testdata/TestBFDEnabled.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+ipv6 forwarding
 
 route-map allowall permit 1
 router bgp 64512

--- a/internal/frr/testdata/TestBFDProfile.golden
+++ b/internal/frr/testdata/TestBFDProfile.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+ipv6 forwarding
 bfd
   profile foo
     receive-interval 43

--- a/internal/frr/testdata/TestBasic.golden
+++ b/internal/frr/testdata/TestBasic.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+ipv6 forwarding
 vrf red
   vni 100
 exit-vrf

--- a/internal/frr/testdata/TestBasicWithASNRT.golden
+++ b/internal/frr/testdata/TestBasicWithASNRT.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+ipv6 forwarding
 vrf red
   vni 100
 exit-vrf

--- a/internal/frr/testdata/TestBasicWithIPRT.golden
+++ b/internal/frr/testdata/TestBasicWithIPRT.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+ipv6 forwarding
 vrf red
   vni 100
 exit-vrf

--- a/internal/frr/testdata/TestDualStack.golden
+++ b/internal/frr/testdata/TestDualStack.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+ipv6 forwarding
 vrf red
   vni 100
 exit-vrf

--- a/internal/frr/testdata/TestDualStackWithRT.golden
+++ b/internal/frr/testdata/TestDualStackWithRT.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+ipv6 forwarding
 vrf red
   vni 100
 exit-vrf

--- a/internal/frr/testdata/TestEmpty.golden
+++ b/internal/frr/testdata/TestEmpty.golden
@@ -3,5 +3,6 @@ log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+ipv6 forwarding
 
 route-map allowall permit 1

--- a/internal/frr/testdata/TestExternal.golden
+++ b/internal/frr/testdata/TestExternal.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+ipv6 forwarding
 vrf red
   vni 100
 exit-vrf

--- a/internal/frr/testdata/TestIPv6Only.golden
+++ b/internal/frr/testdata/TestIPv6Only.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+ipv6 forwarding
 vrf red
   vni 100
 exit-vrf

--- a/internal/frr/testdata/TestIPv6OnlyWithRT.golden
+++ b/internal/frr/testdata/TestIPv6OnlyWithRT.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+ipv6 forwarding
 vrf red
   vni 100
 exit-vrf

--- a/internal/frr/testdata/TestInternal.golden
+++ b/internal/frr/testdata/TestInternal.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+ipv6 forwarding
 vrf red
   vni 100
 exit-vrf

--- a/internal/frr/testdata/TestL3VNIWithoutLocalNeighborAndAdvertise.golden
+++ b/internal/frr/testdata/TestL3VNIWithoutLocalNeighborAndAdvertise.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+ipv6 forwarding
 vrf red
   vni 100
 exit-vrf

--- a/internal/frr/testdata/TestNoVNIs.golden
+++ b/internal/frr/testdata/TestNoVNIs.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+ipv6 forwarding
 
 route-map allowall permit 1
 router bgp 64512

--- a/internal/frr/testdata/TestPassthroughDual.golden
+++ b/internal/frr/testdata/TestPassthroughDual.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+ipv6 forwarding
 
 route-map allowall permit 1
 router bgp 64512

--- a/internal/frr/testdata/TestPassthroughExternal.golden
+++ b/internal/frr/testdata/TestPassthroughExternal.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+ipv6 forwarding
 
 route-map allowall permit 1
 router bgp 64512

--- a/internal/frr/testdata/TestPassthroughNoEVPN.golden
+++ b/internal/frr/testdata/TestPassthroughNoEVPN.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+ipv6 forwarding
 
 route-map allowall permit 1
 router bgp 64512

--- a/internal/frr/testdata/TestPassthroughV4.golden
+++ b/internal/frr/testdata/TestPassthroughV4.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+ipv6 forwarding
 
 route-map allowall permit 1
 router bgp 64512

--- a/internal/frr/testdata/TestRawConfig.golden
+++ b/internal/frr/testdata/TestRawConfig.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname hostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+ipv6 forwarding
 
 route-map allowall permit 1
 router bgp 64512


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>

> /kind bug

> /kind cleanup
> /kind feature
> /kind design

/kind flake

> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

## Summary                                                                                                                                                
- Add ipv6 forwarding to the PE router's FRR config template (frr.tmpl) — zebra defaults IPv6 forwarding to off and actively overrides the kernel sysctl to match, so the controller's `sysctl.IPv6Forwarding()` gets undone by zebra on startup/reload
                                                                                                                                                  
## Root cause      
FRR treats IPv4 and IPv6 forwarding asymmetrically: ip forwarding is implicitly on, but ipv6 forwarding must be explicitly declared - otherwise zebra sets `net.ipv6.conf.all.forwarding=0` in the kernel.

The controller does set the sysctl via `sysctl.Ensure()` in host_config.go, but zebra overrides it because:
1. The reconcile loop pushes the FRR config first - via `configureFRR()` - then sets sysctls (via `configureInterfaces()`)
2. Zebra syncs kernel state to match its config — no ipv6 forwarding in the config means `forwarding=0`
3. The race between zebra's sysctl override and the controller's sysctl set explains the flakiness
                                                                                                                                                  
Both leaf templates (leaf.tmpl, leafkind.tmpl) already had ipv6 forwarding. Only the PE router template was missing it.
                                                                                                                                                  
## Test plan                                                                                                                                       
- Existing golden file tests verify ipv6 forwarding is present in all generated FRR configs
- Dual-stack E2E test (should create two pods connected to the l2 overlay -- for dual stack) should pass consistently                 

**Special notes for your reviewer**:
Fixes: #342 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Add ipv6 forwarding to PE FRR config - zebra was overriding the controller's sysctl, breaking IPv6 traffic.
```
