### PR TITLE
Stop forcing VRF on disconnected L2VNIs

### DIFF
--- a/api/v1alpha1/l2vni_types.go
+++ b/api/v1alpha1/l2vni_types.go
@@ -143,15 +143,6 @@ type L2VNI struct {
 	Status *L2VNIStatus `json:"status,omitempty"`
 }
 
-// VRFName returns the name to be used for the
-// vrf corresponding to the object.
-func (v L2VNI) VRFName() string {
-	if v.Spec.VRF != nil && *v.Spec.VRF != "" {
-		return *v.Spec.VRF
-	}
-	return v.Name
-}
-
 // +kubebuilder:object:root=true
 
 // VNIList contains a list of VNI.

--- a/e2etests/tests/evpn_l2.go
+++ b/e2etests/tests/evpn_l2.go
@@ -350,6 +350,105 @@ var _ = Describe("Routes between bgp and the fabric with Underlay in ipv4", Orde
 
 })
 
+var _ = Describe("Disconnected L2VNI east/west traffic", Ordered, func() {
+	const (
+		testNamespace             = "test-disconnected-l2"
+		linuxBridgeHostAttachment = "linux-bridge"
+		firstPodIP                = "192.171.30.2"
+		secondPodIP               = "192.171.30.3"
+	)
+
+	var cs clientset.Interface
+
+	l2vniDisconnected := v1alpha1.L2VNI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "disconnected",
+			Namespace: openperouter.Namespace,
+		},
+		Spec: v1alpha1.L2VNISpec{
+			VNI: 300,
+			HostMaster: &v1alpha1.HostMaster{
+				Type: linuxBridgeHostAttachment,
+				LinuxBridge: &v1alpha1.LinuxBridgeConfig{
+					AutoCreate: new(true),
+				},
+			},
+		},
+	}
+
+	BeforeAll(func() {
+		err := Updater.CleanAll()
+		Expect(err).NotTo(HaveOccurred())
+
+		cs = k8sclient.New()
+
+		err = Updater.Update(config.Resources{
+			Underlays: []v1alpha1.Underlay{
+				infra.Underlay,
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterAll(func() {
+		err := Updater.CleanAll()
+		Expect(err).NotTo(HaveOccurred())
+		By("waiting for all router pods to be ready after removing the underlay")
+		Eventually(func() error {
+			routers, err := openperouter.Get(cs, HostMode)
+			if err != nil {
+				return err
+			}
+			return openperouter.AreReady(routers)
+		}, 2*time.Minute, time.Second).ShouldNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		dumpIfFails(cs)
+		err := Updater.CleanButUnderlay()
+		Expect(err).NotTo(HaveOccurred())
+		err = k8s.DeleteNamespace(cs, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should allow pod-to-pod L2 connectivity without a VRF", func() {
+		nodes, err := k8s.GetNodes(cs)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(nodes)).To(BeNumerically(">=", 2))
+
+		err = Updater.Update(config.Resources{
+			L2VNIs: []v1alpha1.L2VNI{
+				l2vniDisconnected,
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = k8s.CreateNamespace(cs, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		nadObj, err := k8s.CreateMacvlanNad("300", testNamespace, "br-hs-300", []string{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating two pods on different nodes")
+		firstPod, err := k8s.CreateAgnhostPod(cs, "pod1", testNamespace,
+			k8s.WithNad(nadObj.Name, testNamespace, []string{firstPodIP + "/24"}),
+			k8s.OnNode(nodes[0].Name))
+		Expect(err).NotTo(HaveOccurred())
+		secondPod, err := k8s.CreateAgnhostPod(cs, "pod2", testNamespace,
+			k8s.WithNad(nadObj.Name, testNamespace, []string{secondPodIP + "/24"}),
+			k8s.OnNode(nodes[1].Name))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("removing the default gateway via the primary interface")
+		Expect(removeGatewayFromPod(firstPod)).To(Succeed())
+		Expect(removeGatewayFromPod(secondPod)).To(Succeed())
+
+		By("checking bidirectional L2 reachability")
+		canPingFromPod(executor.ForPod(firstPod.Namespace, firstPod.Name, "agnhost"), secondPodIP)
+		canPingFromPod(executor.ForPod(secondPod.Namespace, secondPod.Name, "agnhost"), firstPodIP)
+	})
+})
+
 func removeGatewayFromPod(pod *corev1.Pod) error {
 	exec := executor.ForPod(pod.Namespace, pod.Name, "agnhost")
 

--- a/e2etests/tests/hostconfiguration.go
+++ b/e2etests/tests/hostconfiguration.go
@@ -758,7 +758,7 @@ var _ = ginkgo.Describe("Router Host configuration", func() {
 
 				vtepIP := vtepIPForPod(cs, underlay.Spec.EVPN.VTEPCIDR, p)
 				validateConfig(l2vniParams{
-					VRF:       l2vni300.Name,
+					VRF:       "",
 					VNI:       300,
 					VXLanPort: 4789,
 					VTEPIP:    vtepIP,
@@ -792,14 +792,14 @@ var _ = ginkgo.Describe("Router Host configuration", func() {
 
 				vtepIP := vtepIPForPod(cs, underlay.Spec.EVPN.VTEPCIDR, p)
 				validateConfig(l2vniParams{
-					VRF:       l2vni300.Name,
+					VRF:       "",
 					VNI:       300,
 					VXLanPort: 4789,
 					VTEPIP:    vtepIP,
 				}, l2VNIConfiguredTestSelector, p)
 
 				validateConfig(l2vniParams{
-					VRF:          l2vni400.Name,
+					VRF:          *l2vni400.Spec.VRF,
 					VNI:          400,
 					VXLanPort:    4789,
 					VTEPIP:       vtepIP,
@@ -816,7 +816,7 @@ var _ = ginkgo.Describe("Router Host configuration", func() {
 
 				vtepIP := vtepIPForPod(cs, underlay.Spec.EVPN.VTEPCIDR, p)
 				validateConfig(l2vniParams{
-					VRF:          l2vni400.Name,
+					VRF:          *l2vni400.Spec.VRF,
 					VNI:          400,
 					VXLanPort:    4789,
 					VTEPIP:       vtepIP,
@@ -825,7 +825,7 @@ var _ = ginkgo.Describe("Router Host configuration", func() {
 
 				ginkgo.By(fmt.Sprintf("validating VNI is deleted for pod %s", p.Name))
 				validateConfig(l2vniParams{
-					VRF:       l2vni300.Name,
+					VRF:       "",
 					VNI:       300,
 					VXLanPort: 4789,
 					VTEPIP:    vtepIP,
@@ -865,7 +865,7 @@ var _ = ginkgo.Describe("Router Host configuration", func() {
 
 				vtepIP := vtepIPForPod(cs, underlay.Spec.EVPN.VTEPCIDR, p)
 				validateConfig(l2vniParams{
-					VRF:       l2vni300.Name,
+					VRF:       "",
 					VNI:       300,
 					VXLanPort: 4789,
 					VTEPIP:    vtepIP,
@@ -884,7 +884,7 @@ var _ = ginkgo.Describe("Router Host configuration", func() {
 				vtepIP := vtepIPForPod(cs, underlay.Spec.EVPN.VTEPCIDR, p)
 
 				validateConfig(l2vniParams{
-					VRF:       l2vni300.Name,
+					VRF:       "",
 					VNI:       600,
 					VXLanPort: 4789,
 					VTEPIP:    vtepIP,
@@ -951,12 +951,12 @@ var _ = ginkgo.Describe("Router Host configuration", func() {
 				},
 			})).To(Succeed())
 			l2VNI300Params := l2vniParams{
-				VRF:       l2vni300.Name,
+				VRF:       "",
 				VNI:       300,
 				VXLanPort: 4789,
 			}
 			l2VNI400Params := l2vniParams{
-				VRF:          l2vni400.Name,
+				VRF:          *l2vni400.Spec.VRF,
 				VNI:          400,
 				VXLanPort:    4789,
 				L2GatewayIPs: l2vni400.Spec.L2GatewayIPs,

--- a/internal/conversion/frr_conversion.go
+++ b/internal/conversion/frr_conversion.go
@@ -489,7 +489,7 @@ func vrfsWithL2Gateways(l2vnis []v1alpha1.L2VNI) map[string][]string {
 	res := make(map[string][]string)
 	for _, l2vni := range l2vnis {
 		if len(l2vni.Spec.L2GatewayIPs) > 0 {
-			res[l2vni.VRFName()] = l2vni.Spec.L2GatewayIPs
+			res[*l2vni.Spec.VRF] = l2vni.Spec.L2GatewayIPs
 		}
 	}
 	return res

--- a/internal/conversion/host_conversion.go
+++ b/internal/conversion/host_conversion.go
@@ -108,31 +108,40 @@ func APItoHostConfig(nodeIndex int, targetNS string, apiConfig APIConfigData) (H
 
 	res.L2VNIs = []hostnetwork.L2VNIParams{}
 	for _, l2vni := range apiConfig.L2VNIs {
-		vni := hostnetwork.L2VNIParams{
-			VNIParams: hostnetwork.VNIParams{
-				VRF:       l2vni.VRFName(),
-				TargetNS:  targetNS,
-				VTEPIP:    res.Underlay.EVPN.VtepIP,
-				VNI:       l2vni.Spec.VNI,
-				VXLanPort: l2vni.Spec.VXLanPort,
-			},
+		vni, err := convertL2VNI(l2vni, targetNS, res.Underlay.EVPN.VtepIP)
+		if err != nil {
+			return HostConfigData{}, err
 		}
-		if len(l2vni.Spec.L2GatewayIPs) > 0 {
-			vni.L2GatewayIPs = make([]string, len(l2vni.Spec.L2GatewayIPs))
-			copy(vni.L2GatewayIPs, l2vni.Spec.L2GatewayIPs)
-		}
-		if l2vni.Spec.HostMaster != nil {
-			hm, err := convertHostMaster(&l2vni)
-			if err != nil {
-				return HostConfigData{}, err
-			}
-			vni.HostMaster = hm
-		}
-
 		res.L2VNIs = append(res.L2VNIs, vni)
 	}
 
 	return res, nil
+}
+
+func convertL2VNI(l2vni v1alpha1.L2VNI, targetNS string, vtepIP string) (hostnetwork.L2VNIParams, error) {
+	vni := hostnetwork.L2VNIParams{
+		VNIParams: hostnetwork.VNIParams{
+			TargetNS:  targetNS,
+			VTEPIP:    vtepIP,
+			VNI:       l2vni.Spec.VNI,
+			VXLanPort: l2vni.Spec.VXLanPort,
+		},
+	}
+	if hasVRF(l2vni) {
+		vni.VRF = *l2vni.Spec.VRF
+	}
+	if len(l2vni.Spec.L2GatewayIPs) > 0 {
+		vni.L2GatewayIPs = make([]string, len(l2vni.Spec.L2GatewayIPs))
+		copy(vni.L2GatewayIPs, l2vni.Spec.L2GatewayIPs)
+	}
+	if l2vni.Spec.HostMaster != nil {
+		hm, err := convertHostMaster(&l2vni)
+		if err != nil {
+			return hostnetwork.L2VNIParams{}, err
+		}
+		vni.HostMaster = hm
+	}
+	return vni, nil
 }
 
 func convertHostMaster(l2vni *v1alpha1.L2VNI) (*hostnetwork.HostMaster, error) {

--- a/internal/conversion/host_conversion_test.go
+++ b/internal/conversion/host_conversion_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openperouter/openperouter/api/v1alpha1"
 	"github.com/openperouter/openperouter/internal/hostnetwork"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestAPItoHostConfig(t *testing.T) {
@@ -251,6 +252,45 @@ func TestAPItoHostConfig(t *testing.T) {
 			wantL2VNIParams: []hostnetwork.L2VNIParams{
 				{
 					VNIParams: hostnetwork.VNIParams{
+						TargetNS:  "namespace",
+						VTEPIP:    "10.0.0.0/32",
+						VNI:       200,
+						VXLanPort: new(int32(4789)),
+					},
+					L2GatewayIPs: nil,
+					HostMaster:   nil,
+				},
+			},
+			wantPassthrough: nil,
+			wantErr:         false,
+		},
+		{
+			name:      "disconnected l2 vni gets empty VRF in host config",
+			nodeIndex: 0,
+			targetNS:  "namespace",
+			underlays: []v1alpha1.Underlay{
+				{Spec: v1alpha1.UnderlaySpec{Nics: []string{"eth0"}, EVPN: &v1alpha1.EVPNConfig{VTEPCIDR: new("10.0.0.0/24")}}},
+			},
+			vnis: []v1alpha1.L3VNI{},
+			l2vnis: []v1alpha1.L2VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-l2vni"},
+					Spec:       v1alpha1.L2VNISpec{VNI: 200, VXLanPort: new(int32(4789))},
+				},
+			},
+			l3Passthrough: []v1alpha1.L3Passthrough{},
+			wantUnderlay: hostnetwork.UnderlayParams{
+				UnderlayInterfaces: []string{"eth0"},
+				TargetNS:           "namespace",
+				EVPN: &hostnetwork.UnderlayEVPNParams{
+					VtepIP: "10.0.0.0/32",
+				},
+			},
+			wantL3VNIParams: []hostnetwork.L3VNIParams{},
+			wantL2VNIParams: []hostnetwork.L2VNIParams{
+				{
+					VNIParams: hostnetwork.VNIParams{
+						VRF:       "",
 						TargetNS:  "namespace",
 						VTEPIP:    "10.0.0.0/32",
 						VNI:       200,

--- a/internal/conversion/validate_vni.go
+++ b/internal/conversion/validate_vni.go
@@ -132,7 +132,10 @@ func ValidateVRFs(l2Vnis []v1alpha1.L2VNI, l3Vnis []v1alpha1.L3VNI) error {
 	v4SubnetsForVRF := map[string]subnets{}
 	v6SubnetsForVRF := map[string]subnets{}
 	for _, l2vni := range l2Vnis {
-		vrfName := l2vni.VRFName()
+		if !hasVRF(l2vni) {
+			continue
+		}
+		vrfName := *l2vni.Spec.VRF
 		source := fmt.Sprintf("L2VNI %s", types.NamespacedName{Namespace: l2vni.Namespace, Name: l2vni.Name})
 		if subnet := v4SubnetForL2(l2vni); subnet != nil {
 			v4SubnetsForVRF[vrfName] = append(v4SubnetsForVRF[vrfName], subnetWithSource{source, subnet})
@@ -194,11 +197,14 @@ func vnisFromL3VNIs(l3vnis []v1alpha1.L3VNI) []VNI {
 func vnisFromL2VNIs(l2vnis []v1alpha1.L2VNI) []VNI {
 	result := make([]VNI, len(l2vnis))
 	for i, l2vni := range l2vnis {
-		result[i] = VNI{
-			name:    l2vni.Name,
-			vni:     uint32(l2vni.Spec.VNI),
-			vrfName: l2vni.VRFName(),
+		v := VNI{
+			name: l2vni.Name,
+			vni:  uint32(l2vni.Spec.VNI),
 		}
+		if hasVRF(l2vni) {
+			v.vrfName = *l2vni.Spec.VRF
+		}
+		result[i] = v
 	}
 	return result
 }
@@ -208,8 +214,10 @@ func validateVNIs(vnis []VNI) error {
 	existingVNIs := map[uint32]string{} // a map between the given VNI number and the VNI instance it's configured in
 
 	for _, vni := range vnis {
-		if err := isValidInterfaceName(vni.vrfName); err != nil {
-			return fmt.Errorf("invalid vrf name for vni %s: %s - %w", vni.name, vni.vrfName, err)
+		if vni.vrfName != "" {
+			if err := isValidInterfaceName(vni.vrfName); err != nil {
+				return fmt.Errorf("invalid vrf name for vni %s: %s - %w", vni.name, vni.vrfName, err)
+			}
 		}
 
 		existingVNI, ok := existingVNIs[vni.vni]

--- a/internal/conversion/validate_vni_test.go
+++ b/internal/conversion/validate_vni_test.go
@@ -324,6 +324,18 @@ func TestValidateL2VNIs(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "disconnected L2VNI with long name passes validation",
+			vnis: []v1alpha1.L2VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "this-name-is-too-long-for-iface"},
+					Spec: v1alpha1.L2VNISpec{
+						VNI: 1001,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "ivalid L2GatewayIPs dual-stack both ipv4",
 			vnis: []v1alpha1.L2VNI{
 				{
@@ -580,6 +592,27 @@ func TestValidateVRFs(t *testing.T) {
 						HostSession: &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv6: new("2000::1/64")}},
 					},
 					Status: &v1alpha1.L3VNIStatus{},
+				},
+			},
+		},
+		{
+			name: "disconnected L2VNI is skipped in subnet overlap checks",
+			l2vnis: []v1alpha1.L2VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"},
+					Spec: v1alpha1.L2VNISpec{
+						VNI: 1001,
+					},
+				},
+			},
+			l3vnis: []v1alpha1.L3VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"},
+					Spec: v1alpha1.L3VNISpec{
+						VNI:         1002,
+						VRF:         "vni1",
+						HostSession: &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
+					},
 				},
 			},
 		},

--- a/internal/hostnetwork/bridge.go
+++ b/internal/hostnetwork/bridge.go
@@ -13,13 +13,19 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-// setupBridge creates the bridge if not exists, enslaves it to the provided
-// vrf, and applies any bridge options before bringing the link up.
+// setupBridge creates the bridge, optionally enslaves it to the provided
+// vrf, applies any bridge options, and brings the link up.
 func setupBridge(params VNIParams, vrf *netlink.Vrf, opts ...NetlinkOption) (*netlink.Bridge, error) {
 	name := BridgeName(params.VNI)
-	bridge, err := createBridge(name, vrf.Index)
+	bridge, err := createBridge(name)
 	if err != nil {
 		return nil, err
+	}
+
+	if vrf != nil {
+		if err := ensureBridgeMaster(bridge, vrf.Index); err != nil {
+			return nil, err
+		}
 	}
 
 	for _, opt := range opts {
@@ -35,17 +41,12 @@ func setupBridge(params VNIParams, vrf *netlink.Vrf, opts ...NetlinkOption) (*ne
 	return bridge, nil
 }
 
-// create bridge creates a bridge with the given name, enslaved
-// to the provided vrf.
-func createBridge(name string, vrfIndex int) (*netlink.Bridge, error) {
-
+func createBridge(name string) (*netlink.Bridge, error) {
 	toCreate := &netlink.Bridge{LinkAttrs: netlink.LinkAttrs{
-		Name:        name,
-		MasterIndex: vrfIndex,
+		Name: name,
 	}}
 
 	link, err := netlink.LinkByName(name)
-	// link does not exist, let's create it
 	if errors.As(err, &netlink.LinkNotFoundError{}) {
 		if err := netlink.LinkAdd(toCreate); err != nil {
 			return nil, fmt.Errorf("could not create bridge %s: %w", name, err)
@@ -57,11 +58,11 @@ func createBridge(name string, vrfIndex int) (*netlink.Bridge, error) {
 	}
 
 	bridge, ok := link.(*netlink.Bridge)
-	if ok && bridge.MasterIndex == vrfIndex { // link exists, nothing to do here
+	if ok {
 		return bridge, nil
 	}
 
-	// link exists but it's not a bridge, or wrong vrf. Let's delete and create
+	// link exists but it's not a bridge, delete and recreate
 	err = netlink.LinkDel(link)
 	if err != nil {
 		return nil, fmt.Errorf("failed to delete link %v: %w", link, err)
@@ -71,6 +72,17 @@ func createBridge(name string, vrfIndex int) (*netlink.Bridge, error) {
 	}
 
 	return toCreate, nil
+}
+
+func ensureBridgeMaster(bridge *netlink.Bridge, masterIndex int) error {
+	if bridge.MasterIndex == masterIndex {
+		return nil
+	}
+	if err := netlink.LinkSetMasterByIndex(bridge, masterIndex); err != nil {
+		return fmt.Errorf("could not enslave bridge %s to VRF (index %d): %w", bridge.Name, masterIndex, err)
+	}
+	bridge.MasterIndex = masterIndex
+	return nil
 }
 
 const (

--- a/internal/hostnetwork/vni.go
+++ b/internal/hostnetwork/vni.go
@@ -285,9 +285,9 @@ func setupHostMaster(ctx context.Context, params L2VNIParams, hostVeth netlink.L
 
 // setupVNI sets up the configuration required by FRR to
 // serve a given VNI in the target namespace. This includes:
-// - a linux VRF
-// - a linux Bridge enslaved to the given VRF
-// - a VXLan interface enslaved to the given VRF
+// - a linux VRF (only when params.VRF is non-empty)
+// - a linux Bridge, enslaved to the VRF when one exists
+// - a VXLan interface
 //
 // Additionally, it creates a veth pair and moves one leg in the target
 // namespace.
@@ -306,10 +306,14 @@ func setupVNI(ctx context.Context, params VNIParams, options ...NetlinkOption) e
 
 	if err := netnamespace.In(ns, func() error {
 
-		slog.DebugContext(ctx, "setting up vrf", "vrf", params.VRF)
-		vrf, err := setupVRF(params.VRF)
-		if err != nil {
-			return err
+		var vrf *netlink.Vrf
+		if params.VRF != "" {
+			slog.DebugContext(ctx, "setting up vrf", "vrf", params.VRF)
+			var err error
+			vrf, err = setupVRF(params.VRF)
+			if err != nil {
+				return err
+			}
 		}
 
 		slog.DebugContext(ctx, "setting up bridge")

--- a/internal/hostnetwork/vni_test.go
+++ b/internal/hostnetwork/vni_test.go
@@ -507,6 +507,19 @@ var _ = Describe("L2 VNI configuration", func() {
 				Type: BridgeLinkType,
 			},
 		}),
+		Entry("disconnected L2VNI (no VRF)", L2VNIParams{
+			VNIParams: VNIParams{
+				VRF:       "",
+				TargetNS:  testNSPath(),
+				VTEPIP:    "192.170.0.13/32",
+				VNI:       500,
+				VXLanPort: new(int32(4789)),
+			},
+			HostMaster: &HostMaster{
+				Name: new(bridgeName),
+				Type: BridgeLinkType,
+			},
+		}),
 	)
 
 	It("should set veth MTU to underlay MTU minus VXLan overhead when an underlay interface is configured", func() {
@@ -712,17 +725,26 @@ func validateVNI(g Gomega, params VNIParams) {
 	addrGenModeNone := checkAddrGenModeNone(vxlan)
 	g.Expect(addrGenModeNone).To(BeTrue())
 
-	vrfLink, err := netlink.LinkByName(params.VRF)
-	g.Expect(err).NotTo(HaveOccurred(), "vrf not found", params.VRF)
-
-	vrf := vrfLink.(*netlink.Vrf)
-	g.Expect(vrf.OperState).To(BeEquivalentTo(netlink.OperUp))
-
 	bridgeLink, err := netlink.LinkByName(BridgeName(params.VNI))
 	g.Expect(err).NotTo(HaveOccurred(), "bridge not found", BridgeName(params.VNI))
 
 	bridge := bridgeLink.(*netlink.Bridge)
 	g.Expect(bridge.OperState).To(BeEquivalentTo(netlink.OperUp))
+
+	if params.VRF == "" {
+		g.Expect(bridge.MasterIndex).To(BeZero(), "disconnected bridge should not be enslaved to a VRF")
+
+		err = checkVXLanConfigured(vxlan, bridge.Index, vtepDev.Attrs().Index, params)
+		g.Expect(err).NotTo(HaveOccurred())
+		return
+	}
+
+	vrfLink, err := netlink.LinkByName(params.VRF)
+	g.Expect(err).NotTo(HaveOccurred(), "vrf not found", params.VRF)
+
+	vrf, isVrf := vrfLink.(*netlink.Vrf)
+	g.Expect(isVrf).To(BeTrue(), "link %s is not a VRF", params.VRF)
+	g.Expect(vrf.OperState).To(BeEquivalentTo(netlink.OperUp))
 
 	g.Expect(bridge.MasterIndex).To(Equal(vrf.Index))
 
@@ -758,7 +780,9 @@ func checkLinkExists(g Gomega, name string) {
 
 func validateVNIIsNotConfigured(g Gomega, params VNIParams) {
 	checkLinkdeleted(g, vxLanNameFromVNI(params.VNI))
-	checkLinkdeleted(g, params.VRF)
+	if params.VRF != "" {
+		checkLinkdeleted(g, params.VRF)
+	}
 	checkLinkdeleted(g, BridgeName(params.VNI))
 
 	vethNames := vethNamesFromVNI(params.VNI)

--- a/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2026-05-27T21:03:12Z"
+    createdAt: "2026-05-31T12:13:28Z"
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: openperouter-operator.v0.0.0


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:
Stop calling `VRFName()` for disconnected L2VNIs (no `spec.vrf`) across
validation and host configuration. Disconnected L2VNIs provide east-west
L2 forwarding only and should not be associated with a VRF.

Uses the `hasVRF` helper introduced in #332 to guard all three callers:
- `vnisFromL2VNIs`: skip VRF name interface validation
- `ValidateVRFs`: skip per-VRF subnet overlap checks
- `APItoHostConfig`: skip Linux VRF creation in host config

**Special notes for your reviewer**:
Follow-up to #332 as discussed with @maiqueb. The `VRFName()` method
still falls back to `v.Name` for disconnected L2VNIs, but it is no
longer called in that case.

**Release note**:

```release-note
Allow L2VNIs without a VRF to operate as pure L2 east-west overlays. 
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.