### PR TITLE
WIP: Reduce complexity of APItoFRR

### DIFF
--- a/internal/conversion/api.go
+++ b/internal/conversion/api.go
@@ -3,6 +3,8 @@
 package conversion
 
 import (
+	"errors"
+
 	"github.com/openperouter/openperouter/api/v1alpha1"
 	"github.com/openperouter/openperouter/internal/hostnetwork"
 )
@@ -42,4 +44,26 @@ func MergeAPIConfigs(configs ...APIConfigData) (APIConfigData, error) {
 	}
 
 	return merged, nil
+}
+
+// validateAPIConfigData flags invalid config data.
+func validateAPIConfigData(config APIConfigData) error {
+	if len(config.Underlays) > 1 {
+		return errors.New("multiple underlays defined")
+	}
+	if len(config.Underlays) == 0 {
+		return FRREmptyConfigError("no underlays provided")
+	}
+	if len(config.L3Passthrough) > 1 {
+		return errors.New("multiple passthroughs defined, can have only one")
+	}
+
+	underlay := config.Underlays[0]
+	if len(config.L3VNIs) > 0 && underlay.Spec.EVPN == nil {
+		return errors.New("EVPN configuration is required when L3 VNIs are defined")
+	}
+	if len(config.L2VNIs) > 0 && underlay.Spec.EVPN == nil {
+		return errors.New("EVPN configuration is required when L2 VNIs are defined")
+	}
+	return nil
 }

--- a/internal/conversion/frr_conversion.go
+++ b/internal/conversion/frr_conversion.go
@@ -3,7 +3,6 @@
 package conversion
 
 import (
-	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -28,106 +27,142 @@ func (e FRREmptyConfigError) Error() string {
 	return string(e)
 }
 
+// APItoFRR converts API custom resources into an frr.Config.
 func APItoFRR(config APIConfigData, nodeIndex int, logLevel string) (frr.Config, error) {
-	if len(config.Underlays) > 1 {
-		return frr.Config{}, errors.New("multiple underlays defined")
-	}
-	if len(config.L3Passthrough) > 1 {
-		return frr.Config{}, errors.New("multiple passthrough defined, can have only one")
-	}
-
 	rawSnippets := rawConfigSnippets(config.RawFRRConfigs)
-	// if we have raw config, we apply it regardless of the rest of the configuration
-	if len(rawSnippets) > 0 && len(config.Underlays) == 0 {
-		slog.Info("no underlay provided, applying raw configuration only")
-		return frr.Config{
-			Loglevel:  logLevel,
-			RawConfig: rawSnippets,
-		}, nil
-	}
-
+	// If we have raw config, we apply it regardless of the rest of the
+	// configuration. Otherwise, the FRR conversion rejects an empty underlay.
 	if len(config.Underlays) == 0 {
+		if len(rawSnippets) > 0 {
+			slog.Info("no underlay provided, applying raw configuration only")
+			return frr.Config{
+				Loglevel:  logLevel,
+				RawConfig: rawSnippets,
+			}, nil
+		}
 		return frr.Config{}, FRREmptyConfigError("no underlays provided")
 	}
 
-	underlay := config.Underlays[0]
-
-	underlayNeighbors := []frr.NeighborConfig{}
-	bfdProfiles := []frr.BFDProfile{}
-	for _, n := range underlay.Spec.Neighbors {
-		frrNeigh, err := neighborToFRR(n)
-		if err != nil {
-			return frr.Config{}, fmt.Errorf("failed to translate underlay neighbor to frr, err: %w", err)
-		}
-
-		bfdProfile := bfdProfileForNeighbor(n)
-		underlayNeighbors = append(underlayNeighbors, *frrNeigh)
-		if bfdProfile != nil {
-			bfdProfiles = append(bfdProfiles, *bfdProfile)
-		}
+	// Common validation between the FRR and Host config conversion layer.
+	if err := validateAPIConfigData(config); err != nil {
+		return frr.Config{}, err
 	}
+
+	underlay := config.Underlays[0]
 
 	routerID, err := routerIDFromUnderlay(underlay, nodeIndex)
 	if err != nil {
 		return frr.Config{}, fmt.Errorf("failed to get routerID: %w", err)
 	}
 
+	underlayNeighbors, err := convertUnderlayNeighborConfig(underlay)
+	if err != nil {
+		return frr.Config{}, err
+	}
+
+	underlayConfigEVPN, err := convertUnderlayEVPN(underlay, nodeIndex)
+	if err != nil {
+		return frr.Config{}, err
+	}
+
 	underlayConfig := frr.UnderlayConfig{
 		MyASN:     underlay.Spec.ASN,
 		RouterID:  routerID,
 		Neighbors: underlayNeighbors,
+		EVPN:      underlayConfigEVPN,
 	}
 
-	var passthroughConfig *frr.PassthroughConfig
-	if len(config.L3Passthrough) > 0 {
-		passthrough, err := passthroughToFRR(config.L3Passthrough[0], nodeIndex)
-		if err != nil {
-			return frr.Config{}, fmt.Errorf("failed to translate passthrough to frr: %w", err)
-		}
-		passthroughConfig = passthrough
+	passthroughConfig, err := convertPassthroughConfig(config.L3Passthrough, nodeIndex)
+	if err != nil {
+		return frr.Config{}, err
 	}
 
-	if len(config.L3VNIs) > 0 && underlay.Spec.EVPN == nil {
-		return frr.Config{}, fmt.Errorf("EVPN configuration is required when L3 VNIs are defined")
-	}
-
-	if underlay.Spec.EVPN == nil {
-		return frr.Config{
-			Underlay:    underlayConfig,
-			Passthrough: passthroughConfig,
-			BFDProfiles: bfdProfiles,
-			Loglevel:    logLevel,
-			VNIs:        []frr.L3VNIConfig{},
-			RawConfig:   rawSnippets,
-		}, nil
-	}
-
-	underlayConfig.EVPN = &frr.UnderlayEvpn{}
-	if underlay.Spec.EVPN.VTEPCIDR != "" {
-		vtepIP, err := ipam.VTEPIp(underlay.Spec.EVPN.VTEPCIDR, nodeIndex)
-		if err != nil {
-			return frr.Config{}, fmt.Errorf("failed to get vtep ip, cidr %s, nodeIndex %d: %w", underlay.Spec.EVPN.VTEPCIDR, nodeIndex, err)
-		}
-		underlayConfig.EVPN.VTEP = vtepIP.String()
-	}
-
-	vniConfigs := []frr.L3VNIConfig{}
-	for _, vni := range config.L3VNIs {
-		frrVNI, err := l3vniToFRR(vni, routerID, underlay.Spec.ASN, nodeIndex)
-		if err != nil {
-			return frr.Config{}, fmt.Errorf("failed to translate vni to frr: %w, vni %v", err, vni)
-		}
-		vniConfigs = append(vniConfigs, frrVNI...)
+	vniConfigs, err := convertVNIConfigs(underlay, config.L3VNIs, routerID, nodeIndex)
+	if err != nil {
+		return frr.Config{}, err
 	}
 
 	return frr.Config{
 		Underlay:    underlayConfig,
 		VNIs:        vniConfigs,
 		Passthrough: passthroughConfig,
-		BFDProfiles: bfdProfiles,
+		BFDProfiles: convertUnderlayBFDProfiles(underlay),
 		Loglevel:    logLevel,
 		RawConfig:   rawSnippets,
 	}, nil
+}
+
+// convertUnderlayNeighborConfig converts the underlay's Neighbor API resources to a slice of NeighborConfig.
+// It is a helper for APItoFRR to keep cognitive complexity light.
+func convertUnderlayNeighborConfig(underlay v1alpha1.Underlay) ([]frr.NeighborConfig, error) {
+	underlayNeighbors := []frr.NeighborConfig{}
+	for _, n := range underlay.Spec.Neighbors {
+		frrNeigh, err := neighborToFRR(n)
+		if err != nil {
+			return nil, fmt.Errorf("failed to translate underlay neighbor to frr, err: %w", err)
+		}
+		underlayNeighbors = append(underlayNeighbors, *frrNeigh)
+	}
+	return underlayNeighbors, nil
+}
+
+// convertUnderlayBFDProfiles converts the underlay's Neighbor API resources to a slice of BFDProfile.
+// It is a helper for APItoFRR to keep cognitive complexity light.
+func convertUnderlayBFDProfiles(underlay v1alpha1.Underlay) []frr.BFDProfile {
+	bfdProfiles := []frr.BFDProfile{}
+	for _, n := range underlay.Spec.Neighbors {
+		bfdProfile := bfdProfileForNeighbor(n)
+		if bfdProfile != nil {
+			bfdProfiles = append(bfdProfiles, *bfdProfile)
+		}
+	}
+	return bfdProfiles
+}
+
+// convertPassthroughConfig converts the L3Passthrough API resources to a pointer of PassthroughConfig.
+// It is a helper for APItoFRR to keep cognitive complexity light.
+func convertPassthroughConfig(l3Passthrough []v1alpha1.L3Passthrough, nodeIndex int) (*frr.PassthroughConfig, error) {
+	if len(l3Passthrough) == 0 {
+		return nil, nil
+	}
+	passthroughConfig, err := passthroughToFRR(l3Passthrough[0], nodeIndex)
+	if err != nil {
+		return nil, fmt.Errorf("failed to translate passthrough to frr: %w", err)
+	}
+	return passthroughConfig, nil
+}
+
+// convertUnderlayEVPN converts the API custom resources to a pointer of UnderlayEVPN.
+// It is a helper for APItoFRR to keep cognitive complexity light.
+func convertUnderlayEVPN(underlay v1alpha1.Underlay, nodeIndex int) (*frr.UnderlayEvpn, error) {
+	if underlay.Spec.EVPN == nil {
+		return nil, nil
+	}
+	underlayConfigEVPN := &frr.UnderlayEvpn{}
+	if underlay.Spec.EVPN.VTEPCIDR != "" {
+		vtepIP, err := ipam.VTEPIp(underlay.Spec.EVPN.VTEPCIDR, nodeIndex)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get vtep ip, cidr %s, nodeIndex %d: %w",
+				underlay.Spec.EVPN.VTEPCIDR, nodeIndex, err)
+		}
+		underlayConfigEVPN.VTEP = vtepIP.String()
+	}
+	return underlayConfigEVPN, nil
+}
+
+// convertVNIConfigs converts the API custom resources to a slice of []L3VNIConfig (EVPN).
+// It is a helper for APItoFRR to keep cognitive complexity light.
+func convertVNIConfigs(underlay v1alpha1.Underlay, l3VNIs []v1alpha1.L3VNI, routerID string,
+	nodeIndex int) ([]frr.L3VNIConfig, error) {
+	vniConfigs := []frr.L3VNIConfig{}
+	for _, vni := range l3VNIs {
+		frrVNI, err := l3vniToFRR(vni, routerID, underlay.Spec.ASN, nodeIndex)
+		if err != nil {
+			return nil, fmt.Errorf("failed to translate vni to frr: %w, vni %v", err, vni)
+		}
+		vniConfigs = append(vniConfigs, frrVNI...)
+	}
+	return vniConfigs, nil
 }
 
 func rawConfigSnippets(rawFRRConfigs []v1alpha1.RawFRRConfig) []frr.RawFRRSnippet {

--- a/internal/conversion/host_conversion.go
+++ b/internal/conversion/host_conversion.go
@@ -3,6 +3,7 @@
 package conversion
 
 import (
+	"errors"
 	"fmt"
 	"net"
 
@@ -12,89 +13,147 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func APItoHostConfig(nodeIndex int, targetNS string, underlayFromMultus bool, apiConfig APIConfigData) (HostConfigData, error) {
-	res := HostConfigData{
-		L3VNIs: []hostnetwork.L3VNIParams{},
-		L2VNIs: []hostnetwork.L2VNIParams{},
-	}
-	if len(apiConfig.Underlays) > 1 {
-		return res, fmt.Errorf("can't have more than one underlay")
-	}
-	if len(apiConfig.L3Passthrough) > 1 {
-		return res, fmt.Errorf("can't have more than one passthrough")
-	}
+// APItoHostConfig converts API custom resources into configuration that is applied to the underlying OS.
+func APItoHostConfig(nodeIndex int, targetNS string, underlayFromMultus bool,
+	apiConfig APIConfigData) (HostConfigData, error) {
+	// Contrary to the FRR conversion, the Host conversion always accepts an empty underlay.
 	if len(apiConfig.Underlays) == 0 {
-		return res, nil
+		return HostConfigData{
+			L3VNIs: []hostnetwork.L3VNIParams{},
+			L2VNIs: []hostnetwork.L2VNIParams{},
+		}, nil
+	}
+
+	// Common validation between the FRR and Host config conversion layer.
+	if err := validateAPIConfigData(apiConfig); err != nil {
+		return HostConfigData{}, err
 	}
 
 	underlay := apiConfig.Underlays[0]
 
+	underlayInterface, err := getUnderlayInterfaceForHost(underlay, underlayFromMultus)
+	if err != nil {
+		return HostConfigData{}, err
+	}
+
+	l3Passthrough, err := convertPassthroughConfigForHost(apiConfig.L3Passthrough, targetNS, nodeIndex)
+	if err != nil {
+		return HostConfigData{}, err
+	}
+
+	underlayConfigEVPN, err := convertUnderlayEVPNForHost(underlay, nodeIndex)
+	if err != nil {
+		return HostConfigData{}, err
+	}
+
+	l3VNIs, err := convertL3VNIsForHost(
+		underlay,
+		apiConfig.L3VNIs,
+		underlayConfigEVPN.VtepIP,
+		targetNS,
+		nodeIndex)
+	if err != nil {
+		return HostConfigData{}, err
+	}
+
+	l2VNIs, err := convertL2VNIsForHost(
+		underlay,
+		apiConfig.L2VNIs,
+		underlayConfigEVPN.VtepIP,
+		targetNS)
+	if err != nil {
+		return HostConfigData{}, err
+	}
+
+	return HostConfigData{
+		Underlay: hostnetwork.UnderlayParams{
+			TargetNS:          targetNS,
+			UnderlayInterface: underlayInterface,
+			EVPN:              underlayConfigEVPN,
+		},
+		L3VNIs:        l3VNIs,
+		L2VNIs:        l2VNIs,
+		L3Passthrough: l3Passthrough,
+	}, nil
+}
+
+// getUnderlayInterfaceForHost returns the underlay interface name from the Underlay spec.
+// It is a helper for APItoHostConfig to keep cognitive complexity light.
+func getUnderlayInterfaceForHost(underlay v1alpha1.Underlay, underlayFromMultus bool) (string, error) {
 	if len(underlay.Spec.Nics) == 0 && !underlayFromMultus {
-		return res, fmt.Errorf("underlay interface must be specified when Multus is not enabled")
+		return "", errors.New("underlay interface must be specified when Multus is not enabled")
 	}
 
-	res.Underlay = hostnetwork.UnderlayParams{
-		TargetNS: targetNS,
-	}
+	underlayInterface := ""
 	if len(underlay.Spec.Nics) > 0 {
-		res.Underlay.UnderlayInterface = underlay.Spec.Nics[0]
+		underlayInterface = underlay.Spec.Nics[0]
 	}
+	return underlayInterface, nil
+}
 
-	if len(apiConfig.L3Passthrough) == 1 {
-		vethIPs, err := ipam.VethIPsFromPool(apiConfig.L3Passthrough[0].Spec.HostSession.LocalCIDR.IPv4, apiConfig.L3Passthrough[0].Spec.HostSession.LocalCIDR.IPv6, nodeIndex)
-		if err != nil {
-			return res, fmt.Errorf("failed to get veth ips, cidr %v, nodeIndex %d", apiConfig.L3Passthrough[0].Spec.HostSession.LocalCIDR, nodeIndex)
-		}
-
-		res.L3Passthrough = &hostnetwork.PassthroughParams{
-			TargetNS: targetNS,
-			HostVeth: hostnetwork.Veth{
-				HostIPv4: ipNetToString(vethIPs.Ipv4.HostSide),
-				NSIPv4:   ipNetToString(vethIPs.Ipv4.PeSide),
-				HostIPv6: ipNetToString(vethIPs.Ipv6.HostSide),
-				NSIPv6:   ipNetToString(vethIPs.Ipv6.PeSide),
-			},
-		}
-	}
-
-	// EVPN is required when VNIs are defined, but EVPN without VNIs is allowed
-	// (e.g., for preparation or advanced BGP EVPN use cases)
-	if underlay.Spec.EVPN == nil && (len(apiConfig.L3VNIs) > 0 || len(apiConfig.L2VNIs) > 0) {
-		return res, fmt.Errorf("underlay EVPN configuration is required when L3 or L2 VNIs are defined")
-	}
-
+// convertL2VNIsForHost converts the L2VNI API resources into a slice of L2VNIParams for host network
+// configuration (EVPN). It is a helper for APItoHostConfig to keep cognitive complexity light.
+func convertL2VNIsForHost(underlay v1alpha1.Underlay, l2VNIs []v1alpha1.L2VNI,
+	vtepIP, targetNS string) ([]hostnetwork.L2VNIParams, error) {
 	if underlay.Spec.EVPN == nil {
-		return res, nil
+		return []hostnetwork.L2VNIParams{}, nil
 	}
-
-	res.Underlay.EVPN = &hostnetwork.UnderlayEVPNParams{}
-	if underlay.Spec.EVPN.VTEPCIDR != "" {
-		vtepIP, err := ipam.VTEPIp(underlay.Spec.EVPN.VTEPCIDR, nodeIndex)
-		if err != nil {
-			return res, fmt.Errorf("failed to get vtep ip, cidr %s, nodeIndex %d: %w", underlay.Spec.EVPN.VTEPCIDR, nodeIndex, err)
+	hostVNIs := []hostnetwork.L2VNIParams{}
+	for _, l2vni := range l2VNIs {
+		vni := hostnetwork.L2VNIParams{
+			VNIParams: hostnetwork.VNIParams{
+				VRF:           l2vni.VRFName(),
+				TargetNS:      targetNS,
+				VTEPIP:        vtepIP,
+				VTEPInterface: underlay.Spec.EVPN.VTEPInterface,
+				VNI:           int(l2vni.Spec.VNI),
+				VXLanPort:     int(l2vni.Spec.VXLanPort),
+			},
+			L2GatewayIPs: l2vni.Spec.L2GatewayIPs,
 		}
-		res.Underlay.EVPN.VtepIP = vtepIP.String()
+		if l2vni.Spec.HostMaster != nil {
+			hm, err := convertHostMaster(&l2vni)
+			if err != nil {
+				return nil, err
+			}
+			vni.HostMaster = hm
+		}
+		hostVNIs = append(hostVNIs, vni)
 	}
+	return hostVNIs, nil
+}
 
-	for _, vni := range apiConfig.L3VNIs {
+// convertL3VNIsForHost converts the L3VNI API resources into a slice of L3VNIParams for host network
+// configuration (EVPN). It is a helper for APItoHostConfig to keep cognitive complexity light.
+func convertL3VNIsForHost(underlay v1alpha1.Underlay, l3VNIs []v1alpha1.L3VNI,
+	vtepIP, targetNS string, nodeIndex int) ([]hostnetwork.L3VNIParams, error) {
+	if underlay.Spec.EVPN == nil {
+		return []hostnetwork.L3VNIParams{}, nil
+	}
+	hostVNIs := []hostnetwork.L3VNIParams{}
+	for _, vni := range l3VNIs {
 		v := hostnetwork.L3VNIParams{
 			VNIParams: hostnetwork.VNIParams{
 				VRF:           vni.Spec.VRF,
 				TargetNS:      targetNS,
-				VTEPIP:        res.Underlay.EVPN.VtepIP,
+				VTEPIP:        vtepIP,
 				VTEPInterface: underlay.Spec.EVPN.VTEPInterface,
 				VNI:           int(vni.Spec.VNI),
 				VXLanPort:     int(vni.Spec.VXLanPort),
 			},
 		}
 		if vni.Spec.HostSession == nil {
-			res.L3VNIs = append(res.L3VNIs, v)
+			hostVNIs = append(hostVNIs, v)
 			continue
 		}
 
-		vethIPs, err := ipam.VethIPsFromPool(vni.Spec.HostSession.LocalCIDR.IPv4, vni.Spec.HostSession.LocalCIDR.IPv6, nodeIndex)
+		vethIPs, err := ipam.VethIPsFromPool(
+			vni.Spec.HostSession.LocalCIDR.IPv4,
+			vni.Spec.HostSession.LocalCIDR.IPv6,
+			nodeIndex)
 		if err != nil {
-			return res, fmt.Errorf("failed to get veth ips, cidr %v, nodeIndex %d", vni.Spec.HostSession.LocalCIDR, nodeIndex)
+			return nil, fmt.Errorf("failed to get veth ips, cidr %v, nodeIndex %d, err: %w",
+				vni.Spec.HostSession.LocalCIDR, nodeIndex, err)
 		}
 
 		v.HostVeth = &hostnetwork.Veth{
@@ -104,37 +163,57 @@ func APItoHostConfig(nodeIndex int, targetNS string, underlayFromMultus bool, ap
 			NSIPv6:   ipNetToString(vethIPs.Ipv6.PeSide),
 		}
 
-		res.L3VNIs = append(res.L3VNIs, v)
+		hostVNIs = append(hostVNIs, v)
+	}
+	return hostVNIs, nil
+}
+
+// convertUnderlayEVPNForHost converts the EVPN underlay VTEP CIDR into UnderlayEVPNParams.
+// It is a helper for APItoHostConfig to keep cognitive complexity light.
+func convertUnderlayEVPNForHost(underlay v1alpha1.Underlay, nodeIndex int) (hostnetwork.UnderlayEVPNParams, error) {
+	if underlay.Spec.EVPN == nil {
+		return hostnetwork.UnderlayEVPNParams{}, nil
+	}
+	if underlay.Spec.EVPN.VTEPCIDR == "" {
+		return hostnetwork.UnderlayEVPNParams{}, nil
 	}
 
-	res.L2VNIs = []hostnetwork.L2VNIParams{}
-	for _, l2vni := range apiConfig.L2VNIs {
-		vni := hostnetwork.L2VNIParams{
-			VNIParams: hostnetwork.VNIParams{
-				VRF:           l2vni.VRFName(),
-				TargetNS:      targetNS,
-				VTEPIP:        res.Underlay.EVPN.VtepIP,
-				VTEPInterface: underlay.Spec.EVPN.VTEPInterface,
-				VNI:           int(l2vni.Spec.VNI),
-				VXLanPort:     int(l2vni.Spec.VXLanPort),
-			},
-		}
-		if len(l2vni.Spec.L2GatewayIPs) > 0 {
-			vni.L2GatewayIPs = make([]string, len(l2vni.Spec.L2GatewayIPs))
-			copy(vni.L2GatewayIPs, l2vni.Spec.L2GatewayIPs)
-		}
-		if l2vni.Spec.HostMaster != nil {
-			hm, err := convertHostMaster(&l2vni)
-			if err != nil {
-				return HostConfigData{}, err
-			}
-			vni.HostMaster = hm
-		}
+	vtepIP, err := ipam.VTEPIp(underlay.Spec.EVPN.VTEPCIDR, nodeIndex)
+	if err != nil {
+		return hostnetwork.UnderlayEVPNParams{}, fmt.Errorf("failed to get vtep ip, cidr %s, nodeIndex %d: %w",
+			underlay.Spec.EVPN.VTEPCIDR, nodeIndex, err)
+	}
+	return hostnetwork.UnderlayEVPNParams{
+		VtepIP: vtepIP.String(),
+	}, nil
+}
 
-		res.L2VNIs = append(res.L2VNIs, vni)
+// convertPassthroughConfigForHost converts the L3Passthrough API resources into PassthroughParams for host network
+// configuration. It is a helper for APItoHostConfig to keep cognitive complexity light.
+func convertPassthroughConfigForHost(l3Passthrough []v1alpha1.L3Passthrough, targetNS string,
+	nodeIndex int) (*hostnetwork.PassthroughParams, error) {
+	if len(l3Passthrough) != 1 {
+		return nil, nil
+	}
+	vethIPs, err := ipam.VethIPsFromPool(
+		l3Passthrough[0].Spec.HostSession.LocalCIDR.IPv4,
+		l3Passthrough[0].Spec.HostSession.LocalCIDR.IPv6,
+		nodeIndex,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get veth ips, cidr %v, nodeIndex %d, err: %w",
+			l3Passthrough[0].Spec.HostSession.LocalCIDR, nodeIndex, err)
 	}
 
-	return res, nil
+	return &hostnetwork.PassthroughParams{
+		TargetNS: targetNS,
+		HostVeth: hostnetwork.Veth{
+			HostIPv4: ipNetToString(vethIPs.Ipv4.HostSide),
+			NSIPv4:   ipNetToString(vethIPs.Ipv4.PeSide),
+			HostIPv6: ipNetToString(vethIPs.Ipv6.HostSide),
+			NSIPv6:   ipNetToString(vethIPs.Ipv6.PeSide),
+		},
+	}, nil
 }
 
 func convertHostMaster(l2vni *v1alpha1.L2VNI) (*hostnetwork.HostMaster, error) {

--- a/internal/conversion/host_conversion_test.go
+++ b/internal/conversion/host_conversion_test.go
@@ -48,14 +48,7 @@ func TestAPItoHostConfig(t *testing.T) {
 				{Spec: v1alpha1.UnderlaySpec{Nics: []string{"eth0"}, EVPN: &v1alpha1.EVPNConfig{VTEPCIDR: "10.0.0.0/24"}}},
 				{Spec: v1alpha1.UnderlaySpec{Nics: []string{"eth1"}, EVPN: &v1alpha1.EVPNConfig{VTEPCIDR: "10.0.1.0/24"}}},
 			},
-			vnis:            []v1alpha1.L3VNI{},
-			l2vnis:          []v1alpha1.L2VNI{},
-			l3Passthrough:   []v1alpha1.L3Passthrough{},
-			wantUnderlay:    hostnetwork.UnderlayParams{},
-			wantL3VNIParams: []hostnetwork.L3VNIParams{},
-			wantL2VNIParams: []hostnetwork.L2VNIParams{},
-			wantPassthrough: nil,
-			wantErr:         true,
+			wantErr: true,
 		},
 		{
 			name:      "ipv4 only",
@@ -72,7 +65,7 @@ func TestAPItoHostConfig(t *testing.T) {
 			wantUnderlay: hostnetwork.UnderlayParams{
 				UnderlayInterface: "eth0",
 				TargetNS:          "namespace",
-				EVPN: &hostnetwork.UnderlayEVPNParams{
+				EVPN: hostnetwork.UnderlayEVPNParams{
 					VtepIP: "10.0.0.0/32",
 				},
 			},
@@ -110,7 +103,7 @@ func TestAPItoHostConfig(t *testing.T) {
 			wantUnderlay: hostnetwork.UnderlayParams{
 				UnderlayInterface: "eth0",
 				TargetNS:          "namespace",
-				EVPN: &hostnetwork.UnderlayEVPNParams{
+				EVPN: hostnetwork.UnderlayEVPNParams{
 					VtepIP: "10.0.0.0/32",
 				},
 			},
@@ -148,7 +141,7 @@ func TestAPItoHostConfig(t *testing.T) {
 			wantUnderlay: hostnetwork.UnderlayParams{
 				UnderlayInterface: "eth0",
 				TargetNS:          "namespace",
-				EVPN: &hostnetwork.UnderlayEVPNParams{
+				EVPN: hostnetwork.UnderlayEVPNParams{
 					VtepIP: "10.0.0.0/32",
 				},
 			},
@@ -188,7 +181,7 @@ func TestAPItoHostConfig(t *testing.T) {
 			wantUnderlay: hostnetwork.UnderlayParams{
 				UnderlayInterface: "eth0",
 				TargetNS:          "namespace",
-				EVPN: &hostnetwork.UnderlayEVPNParams{
+				EVPN: hostnetwork.UnderlayEVPNParams{
 					VtepIP: "10.0.0.0/32",
 				},
 			},
@@ -223,7 +216,7 @@ func TestAPItoHostConfig(t *testing.T) {
 			wantUnderlay: hostnetwork.UnderlayParams{
 				UnderlayInterface: "eth0",
 				TargetNS:          "namespace",
-				EVPN: &hostnetwork.UnderlayEVPNParams{
+				EVPN: hostnetwork.UnderlayEVPNParams{
 					VtepIP: "10.0.0.0/32",
 				},
 			},
@@ -258,7 +251,7 @@ func TestAPItoHostConfig(t *testing.T) {
 			wantUnderlay: hostnetwork.UnderlayParams{
 				UnderlayInterface: "eth0",
 				TargetNS:          "namespace",
-				EVPN: &hostnetwork.UnderlayEVPNParams{
+				EVPN: hostnetwork.UnderlayEVPNParams{
 					VtepIP: "10.0.0.0/32",
 				},
 			},
@@ -350,7 +343,7 @@ func TestAPItoHostConfig(t *testing.T) {
 			wantUnderlay: hostnetwork.UnderlayParams{
 				UnderlayInterface: "",
 				TargetNS:          "namespace",
-				EVPN: &hostnetwork.UnderlayEVPNParams{
+				EVPN: hostnetwork.UnderlayEVPNParams{
 					VtepIP: "10.0.0.0/32",
 				},
 			},
@@ -358,6 +351,47 @@ func TestAPItoHostConfig(t *testing.T) {
 			wantL2VNIParams: []hostnetwork.L2VNIParams{},
 			wantPassthrough: nil,
 			wantErr:         false,
+		},
+		{
+			name:      "l2vnis without EVPN",
+			nodeIndex: 0,
+			targetNS:  "namespace",
+			underlays: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						Nics: []string{"eth0"},
+					},
+				},
+			},
+			l2vnis: []v1alpha1.L2VNI{
+				{Spec: v1alpha1.L2VNISpec{VNI: 200, VXLanPort: 4789}},
+			},
+			wantErr: true,
+		},
+		{
+			name:      "l3vnis without EVPN",
+			nodeIndex: 0,
+			targetNS:  "namespace",
+			underlays: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						Nics: []string{"eth0"},
+					},
+				},
+			},
+			vnis: []v1alpha1.L3VNI{
+				{Spec: v1alpha1.L3VNISpec{
+					VRF: "red",
+					HostSession: &v1alpha1.HostSession{
+						LocalCIDR: v1alpha1.LocalCIDRConfig{
+							IPv4: "10.1.0.0/24"},
+					},
+					VNI:       100,
+					VXLanPort: 4789,
+				},
+				},
+			},
+			wantErr: true,
 		},
 	}
 

--- a/internal/hostnetwork/underlay.go
+++ b/internal/hostnetwork/underlay.go
@@ -22,9 +22,9 @@ const (
 const underlayInterfaceSpecialAddr = "172.16.1.1/32"
 
 type UnderlayParams struct {
-	UnderlayInterface string              `json:"underlay_interface"`
-	TargetNS          string              `json:"target_ns"`
-	EVPN              *UnderlayEVPNParams `json:"evpn"`
+	UnderlayInterface string             `json:"underlay_interface"`
+	TargetNS          string             `json:"target_ns"`
+	EVPN              UnderlayEVPNParams `json:"evpn"`
 }
 
 type UnderlayEVPNParams struct {
@@ -50,17 +50,11 @@ func SetupUnderlay(ctx context.Context, params UnderlayParams) error {
 		}
 	}
 
-	if params.EVPN == nil {
+	if params.EVPN.VtepIP == "" {
 		return nil
 	}
 
-	if params.EVPN.VtepIP != "" {
-		if err := ensureLoopback(ctx, ns, params.EVPN.VtepIP); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return ensureLoopback(ctx, ns, params.EVPN.VtepIP)
 }
 
 type UnderlayExistsError string

--- a/internal/hostnetwork/underlay_test.go
+++ b/internal/hostnetwork/underlay_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Underlay configuration should work when", func() {
 	It("should work with a single underlay", func() {
 		params := UnderlayParams{
 			UnderlayInterface: underlayTestInterface,
-			EVPN: &UnderlayEVPNParams{
+			EVPN: UnderlayEVPNParams{
 				VtepIP: "192.168.1.1/32",
 			},
 			TargetNS: underlayTestNSPath(),
@@ -84,7 +84,7 @@ var _ = Describe("Underlay configuration should work when", func() {
 	It("creating the same underlay twice should be idempotent", func() {
 		params := UnderlayParams{
 			UnderlayInterface: underlayTestInterface,
-			EVPN: &UnderlayEVPNParams{
+			EVPN: UnderlayEVPNParams{
 				VtepIP: "192.168.1.1/32",
 			},
 			TargetNS: underlayTestNSPath(),
@@ -102,7 +102,7 @@ var _ = Describe("Underlay configuration should work when", func() {
 	It("changing the underlay interface should error", func() {
 		params := UnderlayParams{
 			UnderlayInterface: underlayTestInterface,
-			EVPN: &UnderlayEVPNParams{
+			EVPN: UnderlayEVPNParams{
 				VtepIP: "192.168.1.1/32",
 			},
 			TargetNS: underlayTestNSPath(),
@@ -123,7 +123,7 @@ var _ = Describe("Underlay configuration should work when", func() {
 	It("changing the vtepip should work", func() {
 		params := UnderlayParams{
 			UnderlayInterface: underlayTestInterface,
-			EVPN: &UnderlayEVPNParams{
+			EVPN: UnderlayEVPNParams{
 				VtepIP: "192.168.1.1/32",
 			},
 			TargetNS: underlayTestNSPath(),
@@ -187,7 +187,7 @@ func validateUnderlay(g Gomega, params UnderlayParams, interfaceIPs ...string) {
 	for _, l := range links {
 		if l.Attrs().Name == UnderlayLoopback {
 			loopbackFound = true
-			if params.EVPN != nil && params.EVPN.VtepIP != "" {
+			if params.EVPN.VtepIP != "" {
 				validateIP(g, l, params.EVPN.VtepIP)
 			}
 		}
@@ -200,11 +200,12 @@ func validateUnderlay(g Gomega, params UnderlayParams, interfaceIPs ...string) {
 		}
 
 	}
-	if params.EVPN != nil && params.EVPN.VtepIP == "" {
+	if params.EVPN.VtepIP == "" {
 		g.Expect(loopbackFound).To(BeFalse(), fmt.Sprintf("loopback should not exist when vtepInterface is set, links %v", links))
-	} else if params.EVPN != nil {
+	} else {
 		g.Expect(loopbackFound).To(BeTrue(), fmt.Sprintf("failed to find loopback in ns, links %v", links))
 	}
+
 	if params.UnderlayInterface != "" && !mainNicFound {
 		g.Expect(mainNicFound).To(BeTrue(), fmt.Sprintf("failed to find underlay interface in ns, links %v", links))
 	}


### PR DESCRIPTION
Reduce complexity of APItoFRR by moving logic into dedicated convert*
functions.

**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:

While APItoFRR's complexity is currently still manageable, we
will have to extend it for the upcoming ISIS / SRv6 work and its
complexity will therefore grow a bit in the future.

**Special notes for your reviewer**:

N/A

**Release note**:

```release-note
Reduce cognitive complexity of APItoFRR
```
