### PR TITLE
refactor: use functional options for bridge setup

### DIFF
--- a/internal/hostnetwork/bridge.go
+++ b/internal/hostnetwork/bridge.go
@@ -13,18 +13,32 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-// setup bridge creates the bridge if not exists, and it enslaves it to the provided
-// vrf.
-func setupBridge(params VNIParams, vrf *netlink.Vrf) (*netlink.Bridge, error) {
+// BridgeOption is a function applied to a bridge after creation but before link-up.
+type BridgeOption func(*netlink.Bridge) error
+
+// WithAddrGenModeNone returns a BridgeOption that sets addr_gen_mode=1 (none)
+// on the bridge, suppressing automatic IPv6 link-local address generation.
+// L3VNI bridges need this; L2VNI bridges must NOT use it because the kernel's
+// NDP state machine requires a link-local address for unicast NS probes.
+func WithAddrGenModeNone() BridgeOption {
+	return func(bridge *netlink.Bridge) error {
+		return setAddrGenModeNone(bridge)
+	}
+}
+
+// setupBridge creates the bridge if not exists, enslaves it to the provided
+// vrf, and applies any bridge options before bringing the link up.
+func setupBridge(params VNIParams, vrf *netlink.Vrf, opts ...BridgeOption) (*netlink.Bridge, error) {
 	name := BridgeName(params.VNI)
 	bridge, err := createBridge(name, vrf.Index)
 	if err != nil {
 		return nil, err
 	}
 
-	err = setAddrGenModeNone(bridge)
-	if err != nil {
-		return nil, fmt.Errorf("failed to set addr_gen_mode to 1 for %s: %w", bridge.Name, err)
+	for _, opt := range opts {
+		if err := opt(bridge); err != nil {
+			return nil, fmt.Errorf("failed to apply bridge option for %s: %w", bridge.Name, err)
+		}
 	}
 
 	err = linkSetUp(bridge)

--- a/internal/hostnetwork/bridge.go
+++ b/internal/hostnetwork/bridge.go
@@ -13,22 +13,9 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-// BridgeOption is a function applied to a bridge after creation but before link-up.
-type BridgeOption func(*netlink.Bridge) error
-
-// WithAddrGenModeNone returns a BridgeOption that sets addr_gen_mode=1 (none)
-// on the bridge, suppressing automatic IPv6 link-local address generation.
-// L3VNI bridges need this; L2VNI bridges must NOT use it because the kernel's
-// NDP state machine requires a link-local address for unicast NS probes.
-func WithAddrGenModeNone() BridgeOption {
-	return func(bridge *netlink.Bridge) error {
-		return setAddrGenModeNone(bridge)
-	}
-}
-
 // setupBridge creates the bridge if not exists, enslaves it to the provided
 // vrf, and applies any bridge options before bringing the link up.
-func setupBridge(params VNIParams, vrf *netlink.Vrf, opts ...BridgeOption) (*netlink.Bridge, error) {
+func setupBridge(params VNIParams, vrf *netlink.Vrf, opts ...NetlinkOption) (*netlink.Bridge, error) {
 	name := BridgeName(params.VNI)
 	bridge, err := createBridge(name, vrf.Index)
 	if err != nil {

--- a/internal/hostnetwork/netlink.go
+++ b/internal/hostnetwork/netlink.go
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package hostnetwork
+
+import "github.com/vishvananda/netlink"
+
+// NetlinkOption is a function applied to a Link after creation but before link-up.
+type NetlinkOption func(link netlink.Link) error

--- a/internal/hostnetwork/vni.go
+++ b/internal/hostnetwork/vni.go
@@ -76,7 +76,7 @@ func (e NotRouterInterfaceError) Error() string {
 // VXLan interface, and moves the veth to the VRF corresponding
 // to the L3 routing domain, exposing it to the default host namespace.
 func SetupL3VNI(ctx context.Context, params L3VNIParams) error {
-	if err := setupVNI(ctx, params.VNIParams); err != nil {
+	if err := setupVNI(ctx, params.VNIParams, WithAddrGenModeNone()); err != nil {
 		return fmt.Errorf("SetupL3VNI: failed to setup VNI: %w", err)
 	}
 	slog.DebugContext(ctx, "setting up l3 VNI", "params", params)
@@ -246,7 +246,7 @@ func setupHostMaster(ctx context.Context, params L2VNIParams, hostVeth netlink.L
 //
 // Additionally, it creates a veth pair and moves one leg in the target
 // namespace.
-func setupVNI(ctx context.Context, params VNIParams) error {
+func setupVNI(ctx context.Context, params VNIParams, bridgeOpts ...BridgeOption) error {
 	slog.DebugContext(ctx, "setting up VNI", "params", params)
 	defer slog.DebugContext(ctx, "end setting up VNI", "params", params)
 	ns, err := netns.GetFromPath(params.TargetNS)
@@ -268,7 +268,7 @@ func setupVNI(ctx context.Context, params VNIParams) error {
 		}
 
 		slog.DebugContext(ctx, "setting up bridge")
-		bridge, err := setupBridge(params, vrf)
+		bridge, err := setupBridge(params, vrf, bridgeOpts...)
 		if err != nil {
 			return err
 		}

--- a/internal/hostnetwork/vni.go
+++ b/internal/hostnetwork/vni.go
@@ -76,7 +76,7 @@ func (e NotRouterInterfaceError) Error() string {
 // VXLan interface, and moves the veth to the VRF corresponding
 // to the L3 routing domain, exposing it to the default host namespace.
 func SetupL3VNI(ctx context.Context, params L3VNIParams) error {
-	if err := setupVNI(ctx, params.VNIParams, WithAddrGenModeNone()); err != nil {
+	if err := setupVNI(ctx, params.VNIParams, setAddrGenModeNone); err != nil {
 		return fmt.Errorf("SetupL3VNI: failed to setup VNI: %w", err)
 	}
 	slog.DebugContext(ctx, "setting up l3 VNI", "params", params)
@@ -246,7 +246,7 @@ func setupHostMaster(ctx context.Context, params L2VNIParams, hostVeth netlink.L
 //
 // Additionally, it creates a veth pair and moves one leg in the target
 // namespace.
-func setupVNI(ctx context.Context, params VNIParams, bridgeOpts ...BridgeOption) error {
+func setupVNI(ctx context.Context, params VNIParams, options ...NetlinkOption) error {
 	slog.DebugContext(ctx, "setting up VNI", "params", params)
 	defer slog.DebugContext(ctx, "end setting up VNI", "params", params)
 	ns, err := netns.GetFromPath(params.TargetNS)
@@ -268,7 +268,7 @@ func setupVNI(ctx context.Context, params VNIParams, bridgeOpts ...BridgeOption)
 		}
 
 		slog.DebugContext(ctx, "setting up bridge")
-		bridge, err := setupBridge(params, vrf, bridgeOpts...)
+		bridge, err := setupBridge(params, vrf, options...)
 		if err != nil {
 			return err
 		}

--- a/internal/hostnetwork/vni_test.go
+++ b/internal/hostnetwork/vni_test.go
@@ -509,6 +509,10 @@ func validateL3VNI(g Gomega, params L3VNIParams) {
 	}
 	validateVethForVNI(g, params.VNIParams)
 
+	bridgeLink, err := netlink.LinkByName(BridgeName(params.VNI))
+	g.Expect(err).NotTo(HaveOccurred(), "bridge not found for addr_gen_mode check", BridgeName(params.VNI))
+	g.Expect(checkAddrGenModeNone(bridgeLink)).To(BeTrue(), "L3VNI bridge must have addr_gen_mode=1")
+
 	vethNames := vethNamesFromVNI(params.VNI)
 	peLegLink, err := netlink.LinkByName(vethNames.NamespaceSide)
 	g.Expect(err).NotTo(HaveOccurred(), "veth pe side not found", vethNames.NamespaceSide)
@@ -536,6 +540,10 @@ func validateL3VNI(g Gomega, params L3VNIParams) {
 func validateL2VNI(g Gomega, params L2VNIParams) {
 	validateVNI(g, params.VNIParams)
 	validateVethForVNI(g, params.VNIParams)
+
+	bridgeLinkForMode, err := netlink.LinkByName(BridgeName(params.VNI))
+	g.Expect(err).NotTo(HaveOccurred(), "bridge not found for addr_gen_mode check", BridgeName(params.VNI))
+	g.Expect(checkAddrGenModeNone(bridgeLinkForMode)).To(BeFalse(), "L2VNI bridge must NOT have addr_gen_mode=1")
 
 	vethNames := vethNamesFromVNI(params.VNI)
 	peLegLink, err := netlink.LinkByName(vethNames.NamespaceSide)
@@ -595,9 +603,6 @@ func validateVNI(g Gomega, params VNIParams) {
 	g.Expect(bridge.OperState).To(BeEquivalentTo(netlink.OperUp))
 
 	g.Expect(bridge.MasterIndex).To(Equal(vrf.Index))
-
-	addrGenModeNone = checkAddrGenModeNone(bridge)
-	g.Expect(addrGenModeNone).To(BeTrue())
 
 	err = checkVXLanConfigured(vxlan, bridge.Index, vtepDev.Attrs().Index, params)
 	g.Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design

/kind flake

> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
Make `setupBridge` accept variadic `BridgeOption` functions instead of hardcoding `setAddrGenModeNone`. `L3VNI` passes `WithAddrGenModeNone()` to suppress IPv6 link-local generation; L2VNI passes no options, allowing the kernel to generate a link-local address naturally. 

This fixes the dual-stack NDP flake (#342) where the kernel's `ndisc_send_ns()` silently dropped unicast NS probes on L2VNI bridges that had no link-local.

**Special notes for your reviewer**:
Fixes: #342 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Do not set AddrGenModeNone on L2 VNI bridges.
```
