### PR TITLE
test: Fix hostnetwork unit skipping

### DIFF
--- a/hack/integration_tests.sh
+++ b/hack/integration_tests.sh
@@ -47,7 +47,6 @@ echo "OVS is ready"
 ovs-vsctl show
 
 umask 0
-shift # skip container image name
 for test_bin in "$@"; do
     echo "Running $test_bin..."
     if "$test_bin" -help 2>&1 | grep -q ginkgo; then


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
/kind cleanup

**What this PR does / why we need it**:
When calling "make test" the unit test under "hostnetwork" where not executed, this change fix that by removing the unneeded "shift" at the hack/integration_tests.sh script


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
