### PR TITLE
Enforce go fmt in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,6 +74,7 @@ jobs:
         run: |
           make generate-all-ci
           make fix
+          make fmt
           make checkuncommitted
 
       - name: Helm doc generate

--- a/website/content/docs/contributing/_index.md
+++ b/website/content/docs/contributing/_index.md
@@ -151,6 +151,12 @@ Or omit the version to automatically fetch and use the latest:
 make bump-go-version
 ```
 
+## Code Style and Formatting
+
+All Go code must be formatted with `go fmt`. CI enforces this automatically.
+
+**Style preference**: Use multi-line format for slices/structs with multiple elements for better readability in code review.
+
 ## Commit Messages
 
 The following are our commit message guidelines:


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

We are not enforcing go fmt in CI. However, this won't help in multiline literal initializations as both styles are acceptable, so we enhance the contribution guidelines with that information.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
