### PR TITLE
Add unit tests for webhook validation logic

### DIFF
--- a/internal/webhooks/common.go
+++ b/internal/webhooks/common.go
@@ -3,12 +3,42 @@
 package webhooks
 
 import (
+	"fmt"
 	"log/slog"
 
+	"github.com/openperouter/openperouter/api/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var (
 	Logger        *slog.Logger
 	WebhookClient client.Reader
 )
+
+// setupFakeWebhookClient creates a new fake client from the provided slice of client.Object.
+func setupFakeWebhookClient(initObjects []client.Object) (client.Reader, error) {
+	scheme := runtime.NewScheme()
+	if err := v1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to add scheme: %w", err)
+	}
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to add scheme: %w", err)
+	}
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(initObjects...).
+		Build(), nil
+}
+
+// objectsFromResources converts the provided slice of CRs to a slice of client.Object.
+func objectsFromResources[T client.Object](objs []T) []client.Object {
+	output := make([]client.Object, 0, len(objs))
+	for _, obj := range objs {
+		output = append(output, obj)
+	}
+	return output
+}

--- a/internal/webhooks/l2vni_webhook_test.go
+++ b/internal/webhooks/l2vni_webhook_test.go
@@ -1,0 +1,393 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package webhooks
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openperouter/openperouter/api/v1alpha1"
+	"github.com/openperouter/openperouter/internal/logging"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestValidateL2VNICreate tests the create logic of the L2VNI webhook. The goal
+// is not to test each called function (functions themselves should have unit tests for that),
+// but to make sure that the webhook's logic overall is sound.
+func TestValidateL2VNICreate(t *testing.T) {
+	tcs := []struct {
+		name        string
+		l2vnis      []*v1alpha1.L2VNI
+		l3vnis      []*v1alpha1.L3VNI
+		nodes       []*v1.Node
+		newL2VNI    *v1alpha1.L2VNI
+		errorString string
+	}{
+		{
+			name: "webhook passes",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			l3vnis: []*v1alpha1.L3VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "existingL3VNI",
+					},
+					Spec: v1alpha1.L3VNISpec{
+						VRF: "vrfa",
+						VNI: 200,
+						NodeSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"nodeName": "node1",
+							},
+						},
+						HostSession: &v1alpha1.HostSession{
+							LocalCIDR: v1alpha1.LocalCIDRConfig{
+								IPv4: new("192.0.2.0/24"),
+							},
+						},
+					},
+				},
+			},
+			newL2VNI: &v1alpha1.L2VNI{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newL2VNI",
+				},
+				Spec: v1alpha1.L2VNISpec{
+					VNI: 100,
+					VRF: new("vrfb"),
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+					L2GatewayIPs: []string{"192.0.2.0/24"},
+				},
+			},
+		},
+		{
+			name: "webhook passes",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			newL2VNI: &v1alpha1.L2VNI{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newL2VNI",
+				},
+				Spec: v1alpha1.L2VNISpec{
+					VNI: 100,
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "testing conversion.ValidateL2VNIsForNodes is hit - duplicate VNI",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			l2vnis: []*v1alpha1.L2VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "existingL2VNI",
+					},
+					Spec: v1alpha1.L2VNISpec{
+						VNI: 100,
+						NodeSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"nodeName": "node1",
+							},
+						},
+					},
+				},
+			},
+			newL2VNI: &v1alpha1.L2VNI{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newL2VNI",
+				},
+				Spec: v1alpha1.L2VNISpec{
+					VNI: 100,
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			errorString: "duplicate vni",
+		},
+		{
+			name: "testing conversion.ValidateVRFsForNodes is hit - subnet overlap in VRF",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			l3vnis: []*v1alpha1.L3VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "existingL3VNI",
+					},
+					Spec: v1alpha1.L3VNISpec{
+						VRF: "vrfa",
+						VNI: 200,
+						NodeSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"nodeName": "node1",
+							},
+						},
+						HostSession: &v1alpha1.HostSession{
+							LocalCIDR: v1alpha1.LocalCIDRConfig{
+								IPv4: new("192.0.2.0/24"),
+							},
+						},
+					},
+				},
+			},
+			newL2VNI: &v1alpha1.L2VNI{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newL2VNI",
+				},
+				Spec: v1alpha1.L2VNISpec{
+					VNI: 100,
+					VRF: new("vrfa"),
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+					L2GatewayIPs: []string{"192.0.2.0/24"},
+				},
+			},
+			errorString: "subnet overlap in VRF \"vrfa\": " +
+				"IPNet 192.0.2.0/24 (L3VNI default/existingL3VNI) overlaps with IPNet " +
+				"192.0.2.0/24 (L2VNI default/newL2VNI)",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			l2vnis := objectsFromResources(tc.l2vnis)
+			l3vnis := objectsFromResources(tc.l3vnis)
+			nodes := objectsFromResources(tc.nodes)
+			objects := append(l2vnis, l3vnis...)
+			objects = append(objects, nodes...)
+			client, err := setupFakeWebhookClient(objects)
+			if err != nil {
+				t.Fatal(err)
+			}
+			origWebhookClient := WebhookClient
+			origLogger := Logger
+			defer func() {
+				WebhookClient = origWebhookClient
+				Logger = origLogger
+			}()
+			WebhookClient = client
+			Logger, _ = logging.New("debug")
+
+			err = validateL2VNICreate(tc.newL2VNI)
+			if tc.errorString == "" {
+				if err != nil {
+					t.Fatalf("expected no error, but got %q", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error to contain %q but got no error", tc.errorString)
+			}
+			if !strings.Contains(err.Error(), tc.errorString) {
+				t.Fatalf("expected error message %q to contain substring %q", err.Error(), tc.errorString)
+			}
+		})
+	}
+}
+
+// TestValidateL2VNIUpdate tests the update logic of the L2VNI webhook. The goal
+// is not to test each called function (functions themselves should have unit tests for that),
+// but to make sure that the webhook's logic overall is sound. The Update webhook has a lot
+// in common with the Create webhook, so only test validation that's different, here.
+func TestValidateL2VNIUpdate(t *testing.T) {
+	tcs := []struct {
+		name        string
+		l2vnis      []*v1alpha1.L2VNI
+		nodes       []*v1.Node
+		oldL2VNI    *v1alpha1.L2VNI
+		newL2VNI    *v1alpha1.L2VNI
+		errorString string
+	}{
+		{
+			name: "objects are the same",
+			newL2VNI: &v1alpha1.L2VNI{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newL2VNI",
+				},
+				Spec: v1alpha1.L2VNISpec{
+					VNI:          100,
+					L2GatewayIPs: []string{"192.0.2.1/24"},
+				},
+			},
+			oldL2VNI: &v1alpha1.L2VNI{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newL2VNI",
+				},
+				Spec: v1alpha1.L2VNISpec{
+					VNI:          100,
+					L2GatewayIPs: []string{"192.0.2.1/24"},
+				},
+			},
+		},
+		{
+			name: "L2GatewayIPs changed",
+			newL2VNI: &v1alpha1.L2VNI{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newL2VNI",
+				},
+				Spec: v1alpha1.L2VNISpec{
+					VNI:          100,
+					L2GatewayIPs: []string{"192.0.3.1/24"},
+				},
+			},
+			oldL2VNI: &v1alpha1.L2VNI{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newL2VNI",
+				},
+				Spec: v1alpha1.L2VNISpec{
+					VNI:          100,
+					L2GatewayIPs: []string{"192.0.2.1/24"},
+				},
+			},
+			errorString: "L2GatewayIPs cannot be changed",
+		},
+		{
+			name: "testing validateL2VNI is hit - duplicate VNI",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			l2vnis: []*v1alpha1.L2VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "existingL2VNI",
+					},
+					Spec: v1alpha1.L2VNISpec{
+						VNI: 100,
+						NodeSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"nodeName": "node1",
+							},
+						},
+					},
+				},
+			},
+			oldL2VNI: &v1alpha1.L2VNI{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "updatedL2VNI",
+				},
+				Spec: v1alpha1.L2VNISpec{
+					VNI: 100,
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			newL2VNI: &v1alpha1.L2VNI{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "updatedL2VNI",
+				},
+				Spec: v1alpha1.L2VNISpec{
+					VNI: 100,
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			errorString: "duplicate vni",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			l2vnis := objectsFromResources(tc.l2vnis)
+			nodes := objectsFromResources(tc.nodes)
+			objects := append(l2vnis, nodes...)
+			client, err := setupFakeWebhookClient(objects)
+			if err != nil {
+				t.Fatal(err)
+			}
+			origWebhookClient := WebhookClient
+			origLogger := Logger
+			defer func() {
+				WebhookClient = origWebhookClient
+				Logger = origLogger
+			}()
+			WebhookClient = client
+			Logger, _ = logging.New("debug")
+
+			err = validateL2VNIUpdate(tc.oldL2VNI, tc.newL2VNI)
+			if tc.errorString == "" {
+				if err != nil {
+					t.Fatalf("expected no error, but got %q", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error to contain %q but got no error", tc.errorString)
+			}
+			if !strings.Contains(err.Error(), tc.errorString) {
+				t.Fatalf("expected error message %q to contain substring %q", err.Error(), tc.errorString)
+			}
+		})
+	}
+}

--- a/internal/webhooks/l3passthrough_webhook_test.go
+++ b/internal/webhooks/l3passthrough_webhook_test.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package webhooks
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openperouter/openperouter/api/v1alpha1"
+	"github.com/openperouter/openperouter/internal/logging"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestValidateL3Passthrough tests the create and update logic of the L3Passthrough webhook. The goal
+// is not to test each called function (functions themselves should have unit tests for that),
+// but to make sure that the webhook's logic overall is sound.
+func TestValidateL3Passthrough(t *testing.T) {
+	tcs := []struct {
+		name             string
+		l3passthroughs   []*v1alpha1.L3Passthrough
+		l3vnis           []*v1alpha1.L3VNI
+		nodes            []*v1.Node
+		newL3Passthrough *v1alpha1.L3Passthrough
+		errorString      string
+	}{
+		{
+			name: "webhook passes",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			newL3Passthrough: &v1alpha1.L3Passthrough{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newL3Passthrough",
+				},
+				Spec: v1alpha1.L3PassthroughSpec{
+					HostSession: v1alpha1.HostSession{
+						LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.0.2.0/24")},
+					},
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "testing conversion.ValidatePassthroughsForNodes is hit - more than one passthrough per node",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			l3passthroughs: []*v1alpha1.L3Passthrough{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "existingL3Passthrough",
+					},
+					Spec: v1alpha1.L3PassthroughSpec{
+						HostSession: v1alpha1.HostSession{
+							LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.0.2.0/24")},
+						},
+						NodeSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"nodeName": "node1",
+							},
+						},
+					},
+				},
+			},
+			newL3Passthrough: &v1alpha1.L3Passthrough{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newL3Passthrough",
+				},
+				Spec: v1alpha1.L3PassthroughSpec{
+					HostSession: v1alpha1.HostSession{
+						LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.0.3.0/24")},
+					},
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			errorString: "can't have more than one l3passthrough per node",
+		},
+		{
+			name: "testing conversion.ValidateHostSessionsForNodes is hit - missing local CIDR",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			newL3Passthrough: &v1alpha1.L3Passthrough{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newL3Passthrough",
+				},
+				Spec: v1alpha1.L3PassthroughSpec{
+					HostSession: v1alpha1.HostSession{
+						LocalCIDR: v1alpha1.LocalCIDRConfig{},
+					},
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			errorString: "at least one local CIDR (IPv4 or IPv6) must be provided",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			l3passthroughs := objectsFromResources(tc.l3passthroughs)
+			l3vnis := objectsFromResources(tc.l3vnis)
+			nodes := objectsFromResources(tc.nodes)
+			objects := append(l3passthroughs, l3vnis...)
+			objects = append(objects, nodes...)
+			client, err := setupFakeWebhookClient(objects)
+			if err != nil {
+				t.Fatal(err)
+			}
+			origWebhookClient := WebhookClient
+			origLogger := Logger
+			defer func() {
+				WebhookClient = origWebhookClient
+				Logger = origLogger
+			}()
+			WebhookClient = client
+			Logger, _ = logging.New("debug")
+
+			err = validateL3Passthrough(tc.newL3Passthrough)
+			if tc.errorString == "" {
+				if err != nil {
+					t.Fatalf("expected no error, but got %q", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error to contain %q but got no error", tc.errorString)
+			}
+			if !strings.Contains(err.Error(), tc.errorString) {
+				t.Fatalf("expected error message %q to contain substring %q", err.Error(), tc.errorString)
+			}
+		})
+	}
+}

--- a/internal/webhooks/l3vni_webhook_test.go
+++ b/internal/webhooks/l3vni_webhook_test.go
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package webhooks
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openperouter/openperouter/api/v1alpha1"
+	"github.com/openperouter/openperouter/internal/logging"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestValidateL3VNICreate tests the create logic of the L3VNI webhook. The goal
+// is not to test each called function (functions themselves should have unit tests for that),
+// but to make sure that the webhook's logic overall is sound.
+func TestValidateL3VNICreate(t *testing.T) {
+	tcs := []struct {
+		name        string
+		l3vnis      []*v1alpha1.L3VNI
+		nodes       []*v1.Node
+		newL3VNI    *v1alpha1.L3VNI
+		errorString string
+	}{
+		{
+			name: "webhook passes",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			newL3VNI: &v1alpha1.L3VNI{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newL3VNI",
+				},
+				Spec: v1alpha1.L3VNISpec{
+					VRF: "vrfa",
+					HostSession: &v1alpha1.HostSession{
+						LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.0.3.0/24")},
+					},
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "testing conversion.ValidateL3VNIsForNodes is hit - long VRF name",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			newL3VNI: &v1alpha1.L3VNI{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newL3VNI",
+				},
+				Spec: v1alpha1.L3VNISpec{
+					VRF: "0123456789abcdefghijkl",
+					HostSession: &v1alpha1.HostSession{
+						LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.0.3.0/24")},
+					},
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			errorString: "can't be longer than 15 characters",
+		},
+		{
+			name: "testing conversion.ValidateHostSessionsForNodes is hit",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			newL3VNI: &v1alpha1.L3VNI{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newL3VNI",
+				},
+				Spec: v1alpha1.L3VNISpec{
+					VRF: "vrfa",
+					HostSession: &v1alpha1.HostSession{
+						LocalCIDR: v1alpha1.LocalCIDRConfig{},
+					},
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			errorString: "at least one local CIDR (IPv4 or IPv6) must be provided for vni l3vni newL3VNI",
+		},
+		{
+			name: "testing conversion.ValidateVRFs is hit",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			l3vnis: []*v1alpha1.L3VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "existingL3VNI",
+					},
+					Spec: v1alpha1.L3VNISpec{
+						VRF: "vrfa",
+						VNI: 100,
+						NodeSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"nodeName": "node1",
+							},
+						},
+					},
+				},
+			},
+			newL3VNI: &v1alpha1.L3VNI{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newL3VNI",
+				},
+				Spec: v1alpha1.L3VNISpec{
+					VRF: "vrfa",
+					VNI: 101,
+					HostSession: &v1alpha1.HostSession{
+						LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.0.2.0/24")},
+					},
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			errorString: "more than one L3VNI detected in VRF",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			l3vnis := objectsFromResources(tc.l3vnis)
+			nodes := objectsFromResources(tc.nodes)
+			objects := append(l3vnis, nodes...)
+			client, err := setupFakeWebhookClient(objects)
+			if err != nil {
+				t.Fatal(err)
+			}
+			origWebhookClient := WebhookClient
+			origLogger := Logger
+			defer func() {
+				WebhookClient = origWebhookClient
+				Logger = origLogger
+			}()
+			WebhookClient = client
+			Logger, _ = logging.New("debug")
+
+			err = validateL3VNICreate(tc.newL3VNI)
+			if tc.errorString == "" {
+				if err != nil {
+					t.Fatalf("expected no error, but got %q", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error to contain %q but got no error", tc.errorString)
+			}
+			if !strings.Contains(err.Error(), tc.errorString) {
+				t.Fatalf("expected error message %q to contain substring %q", err.Error(), tc.errorString)
+			}
+		})
+	}
+}
+
+// TestValidateL3VNIUpdate tests the update logic of the L3VNI webhook. The goal
+// is not to test each called function (functions themselves should have unit tests for that),
+// but to make sure that the webhook's logic overall is sound. The Update webhook has a lot
+// in common with the Create webhook, so only test validation that's different, here.
+func TestValidateL3VNIUpdate(t *testing.T) {
+	tcs := []struct {
+		name        string
+		l3vnis      []*v1alpha1.L3VNI
+		nodes       []*v1.Node
+		newL3VNI    *v1alpha1.L3VNI
+		oldL3VNI    *v1alpha1.L3VNI
+		errorString string
+	}{
+		{
+			name: "objects are the same",
+			newL3VNI: &v1alpha1.L3VNI{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newL3VNI",
+				},
+				Spec: v1alpha1.L3VNISpec{
+					HostSession: &v1alpha1.HostSession{
+						LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.0.2.0/24")},
+					},
+				},
+			},
+			oldL3VNI: &v1alpha1.L3VNI{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newL3VNI",
+				},
+				Spec: v1alpha1.L3VNISpec{
+					HostSession: &v1alpha1.HostSession{
+						LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.0.2.0/24")},
+					},
+				},
+			},
+		},
+		{
+			name: "objects have different LocalCIDRs",
+			newL3VNI: &v1alpha1.L3VNI{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newL3VNI",
+				},
+				Spec: v1alpha1.L3VNISpec{
+					HostSession: &v1alpha1.HostSession{
+						LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.0.3.0/24")},
+					},
+				},
+			},
+			oldL3VNI: &v1alpha1.L3VNI{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newL3VNI",
+				},
+				Spec: v1alpha1.L3VNISpec{
+					HostSession: &v1alpha1.HostSession{
+						LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.0.2.0/24")},
+					},
+				},
+			},
+			errorString: "LocalCIDR cannot be changed",
+		},
+		{
+			name: "testing validateL3VNI is hit - long VRF name",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			newL3VNI: &v1alpha1.L3VNI{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newL3VNI",
+				},
+				Spec: v1alpha1.L3VNISpec{
+					VRF: "0123456789abcdefghijkl",
+					HostSession: &v1alpha1.HostSession{
+						LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.0.3.0/24")},
+					},
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			oldL3VNI: &v1alpha1.L3VNI{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newL3VNI",
+				},
+				Spec: v1alpha1.L3VNISpec{
+					VRF: "vrfa",
+					HostSession: &v1alpha1.HostSession{
+						LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.0.3.0/24")},
+					},
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			errorString: "can't be longer than 15 characters",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			l3vnis := objectsFromResources(tc.l3vnis)
+			nodes := objectsFromResources(tc.nodes)
+			objects := append(l3vnis, nodes...)
+			client, err := setupFakeWebhookClient(objects)
+			if err != nil {
+				t.Fatal(err)
+			}
+			origWebhookClient := WebhookClient
+			origLogger := Logger
+			defer func() {
+				WebhookClient = origWebhookClient
+				Logger = origLogger
+			}()
+			WebhookClient = client
+			Logger, _ = logging.New("debug")
+
+			err = validateL3VNIUpdate(tc.newL3VNI, tc.oldL3VNI)
+			if tc.errorString == "" {
+				if err != nil {
+					t.Fatalf("expected no error, but got %q", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error to contain %q but got no error", tc.errorString)
+			}
+			if !strings.Contains(err.Error(), tc.errorString) {
+				t.Fatalf("expected error message %q to contain substring %q", err.Error(), tc.errorString)
+			}
+		})
+	}
+}

--- a/internal/webhooks/rawfrrconfig_webhook_test.go
+++ b/internal/webhooks/rawfrrconfig_webhook_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package webhooks
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openperouter/openperouter/api/v1alpha1"
+	"github.com/openperouter/openperouter/internal/logging"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestValidateRawFRRConfig tests the validation logic of the RawFRRConfig webhook. The goal
+// is not to test each called function (functions themselves should have unit tests for that),
+// but to make sure that the webhook's logic overall is sound.
+func TestValidateRawFRRConfig(t *testing.T) {
+	tcs := []struct {
+		name         string
+		rawFRRConfig *v1alpha1.RawFRRConfig
+		errorString  string
+	}{
+		{
+			name: "webhook passes",
+			rawFRRConfig: &v1alpha1.RawFRRConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "rawfrrconfig",
+				},
+				Spec: v1alpha1.RawFRRConfigSpec{
+					RawConfig: "some config",
+				},
+			},
+		},
+		{
+			name: "empty rawConfig",
+			rawFRRConfig: &v1alpha1.RawFRRConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "rawfrrconfig",
+				},
+				Spec: v1alpha1.RawFRRConfigSpec{
+					RawConfig: "",
+				},
+			},
+			errorString: "rawConfig must not be empty",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			origLogger := Logger
+			defer func() {
+				Logger = origLogger
+			}()
+			Logger, _ = logging.New("debug")
+
+			err := validateRawFRRConfig(tc.rawFRRConfig)
+			if tc.errorString == "" {
+				if err != nil {
+					t.Fatalf("expected no error, but got %q", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error to contain %q but got no error", tc.errorString)
+			}
+			if !strings.Contains(err.Error(), tc.errorString) {
+				t.Fatalf("expected error message %q to contain substring %q", err.Error(), tc.errorString)
+			}
+		})
+	}
+}

--- a/internal/webhooks/underlay_webhook_test.go
+++ b/internal/webhooks/underlay_webhook_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package webhooks
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openperouter/openperouter/api/v1alpha1"
+	"github.com/openperouter/openperouter/internal/logging"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestValidateUnderlay tests the logic of the Underlay webhook. The goal
+// is not to test each called function (functions themselves should have unit tests for that),
+// but to make sure that the webhook's logic overall is sound.
+func TestValidateUnderlay(t *testing.T) {
+	tcs := []struct {
+		name        string
+		underlays   []*v1alpha1.Underlay
+		nodes       []*v1.Node
+		newUnderlay *v1alpha1.Underlay
+		errorString string
+	}{
+		{
+			name: "webhook passes",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			newUnderlay: &v1alpha1.Underlay{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newUnderlay",
+				},
+				Spec: v1alpha1.UnderlaySpec{
+					ASN: 65000,
+					EVPN: &v1alpha1.EVPNConfig{
+						VTEPCIDR: new("10.0.0.0/24"),
+					},
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+					Neighbors: []v1alpha1.Neighbor{{}},
+				},
+			},
+		},
+		{
+			name: "testing conversion.ValidateUnderlaysForNodes is hit - more than one underlay per node",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			underlays: []*v1alpha1.Underlay{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "existingUnderlay",
+					},
+					Spec: v1alpha1.UnderlaySpec{
+						ASN: 65000,
+						EVPN: &v1alpha1.EVPNConfig{
+							VTEPCIDR: new("10.0.0.0/24"),
+						},
+						NodeSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"nodeName": "node1",
+							},
+						},
+						Neighbors: []v1alpha1.Neighbor{{}},
+					},
+				},
+			},
+			newUnderlay: &v1alpha1.Underlay{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newUnderlay",
+				},
+				Spec: v1alpha1.UnderlaySpec{
+					ASN: 65001,
+					EVPN: &v1alpha1.EVPNConfig{
+						VTEPCIDR: new("10.0.1.0/24"),
+					},
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			errorString: "can't have more than one underlay per node",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			underlays := objectsFromResources(tc.underlays)
+			nodes := objectsFromResources(tc.nodes)
+			objects := append(underlays, nodes...)
+			client, err := setupFakeWebhookClient(objects)
+			if err != nil {
+				t.Fatal(err)
+			}
+			origWebhookClient := WebhookClient
+			origLogger := Logger
+			defer func() {
+				WebhookClient = origWebhookClient
+				Logger = origLogger
+			}()
+			WebhookClient = client
+			Logger, _ = logging.New("debug")
+
+			err = validateUnderlay(tc.newUnderlay)
+			if tc.errorString == "" {
+				if err != nil {
+					t.Fatalf("expected no error, but got %q", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error to contain %q but got no error", tc.errorString)
+			}
+			if !strings.Contains(err.Error(), tc.errorString) {
+				t.Fatalf("expected error message %q to contain substring %q", err.Error(), tc.errorString)
+			}
+		})
+	}
+}


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

Add unit tests for L2VNI, L3VNI, L3Passthrough, RawFRRConfig, and Underlay webhook validation. The goal is not to test each called function individually (functions themselves should have unit tests for that), but to verify that each webhook's overall validation logic is sound and that webhooks correctly fetch the API objects. Update webhooks are tested only if validation differs from the create path.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```


- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.