### PR TITLE
Optimize linter time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,11 +393,11 @@ kind-node-image-push: ## Push custom kind node image to quay.io
 
 .PHONY: golangci-lint
 golangci-lint:
-	hack/golangci-lint.sh build
+	CONTAINER_ENGINE=$(CONTAINER_ENGINE) hack/golangci-lint.sh build
 
 .PHONY: lint
 lint: golangci-lint
-	hack/golangci-lint.sh run
+	CONTAINER_ENGINE=$(CONTAINER_ENGINE) hack/golangci-lint.sh run
 
 .PHONY: bumplicense
 bumplicense:

--- a/Makefile
+++ b/Makefile
@@ -391,13 +391,19 @@ kind-node-image-build: ## Build custom kind node image with OVS
 kind-node-image-push: ## Push custom kind node image to quay.io
 	cd hack/kind-node-image && ./push.sh
 
+GOLANGCI_LINT_CACHE ?= $(HOME)/.cache/golangci-lint
+
 .PHONY: golangci-lint
 golangci-lint:
-	CONTAINER_ENGINE=$(CONTAINER_ENGINE) hack/golangci-lint.sh build
+	CONTAINER_ENGINE=$(CONTAINER_ENGINE) \
+	GOLANGCI_LINT_CACHE=$(GOLANGCI_LINT_CACHE) \
+	hack/golangci-lint.sh build
 
 .PHONY: lint
 lint: golangci-lint
-	CONTAINER_ENGINE=$(CONTAINER_ENGINE) hack/golangci-lint.sh run
+	CONTAINER_ENGINE=$(CONTAINER_ENGINE) \
+	GOLANGCI_LINT_CACHE=$(GOLANGCI_LINT_CACHE) \
+	hack/golangci-lint.sh run
 
 .PHONY: bumplicense
 bumplicense:

--- a/Makefile
+++ b/Makefile
@@ -391,17 +391,20 @@ kind-node-image-build: ## Build custom kind node image with OVS
 kind-node-image-push: ## Push custom kind node image to quay.io
 	cd hack/kind-node-image && ./push.sh
 
+GOLANGCI_LINT_VERSION ?= 2.9.0
 GOLANGCI_LINT_CACHE ?= $(HOME)/.cache/golangci-lint
 
 .PHONY: golangci-lint
 golangci-lint:
 	CONTAINER_ENGINE=$(CONTAINER_ENGINE) \
+	GOLANGCI_LINT_VERSION=$(GOLANGCI_LINT_VERSION) \
 	GOLANGCI_LINT_CACHE=$(GOLANGCI_LINT_CACHE) \
 	hack/golangci-lint.sh build
 
 .PHONY: lint
 lint: golangci-lint
 	CONTAINER_ENGINE=$(CONTAINER_ENGINE) \
+	GOLANGCI_LINT_VERSION=$(GOLANGCI_LINT_VERSION) \
 	GOLANGCI_LINT_CACHE=$(GOLANGCI_LINT_CACHE) \
 	hack/golangci-lint.sh run
 

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -8,12 +8,15 @@ ENV="${ENV:-container}"
 
 function _run() {
 	if [ "$ENV" == "container" ]; then
-	     docker run --rm -v $(git rev-parse --show-toplevel):/app -w /app golangci/golangci-lint:v$GOLANGCI_LINT_VERSION $@
+		docker run --rm \
+			-v "$(git rev-parse --show-toplevel)":/app \
+			-w /app \
+			golangci/golangci-lint:v"$GOLANGCI_LINT_VERSION" \
+			"$@"
 	else
-	   curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v"$GOLANGCI_LINT_VERSION"
-	   $@
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v"$GOLANGCI_LINT_VERSION"
+		$@
 	fi
-
 }
 
 function build() {

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -11,7 +11,7 @@ ENV="${ENV:-container}"
 function _run() {
 	if [ "$ENV" == "container" ]; then
 	     $CONTAINER_ENGINE run --rm \
-			-v "$(git rev-parse --show-toplevel)":/app \
+			-v "$(git rev-parse --show-toplevel)":/app:Z \
 			-w /app \
 			docker.io/golangci/golangci-lint:v"$GOLANGCI_LINT_VERSION" \
 			"$@"

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -3,14 +3,25 @@ set -o errexit
 set -x
 
 CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}
-
+GOLANGCI_LINT_CACHE=${GOLANGCI_LINT_CACHE:-$HOME/.cache/golangci-lint}
 GOLANGCI_LINT_VERSION="${GOLANGCI_LINT_VERSION:-2.9.0}"
+
 TIMEOUT="10m0s"
 ENV="${ENV:-container}"
 
 function _run() {
 	if [ "$ENV" == "container" ]; then
+	     local -r local_build_cache_dir="/.cache/go-build"
+	     local -r local_mod_cache_dir="/.cache/mod"
+	     local -r local_lint_cache_dir="/.cache/golangci-lint"
 	     $CONTAINER_ENGINE run --rm \
+			-u "$(id -u)":"$(id -g)" \
+			-e GOCACHE="$local_build_cache_dir" \
+			-e GOMODCACHE="$local_mod_cache_dir" \
+			-e GOLANGCI_LINT_CACHE="$local_lint_cache_dir" \
+			-v "$(go env GOCACHE)":"$local_build_cache_dir":Z \
+			-v "$(go env GOMODCACHE)":"$local_mod_cache_dir":Z \
+			-v "$GOLANGCI_LINT_CACHE":"$local_lint_cache_dir":Z \
 			-v "$(git rev-parse --show-toplevel)":/app:Z \
 			-w /app \
 			docker.io/golangci/golangci-lint:v"$GOLANGCI_LINT_VERSION" \

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -2,13 +2,15 @@
 set -o errexit
 set -x
 
+CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}
+
 GOLANGCI_LINT_VERSION="${GOLANGCI_LINT_VERSION:-2.9.0}"
 TIMEOUT="10m0s"
 ENV="${ENV:-container}"
 
 function _run() {
 	if [ "$ENV" == "container" ]; then
-		docker run --rm \
+		$CONTAINER_ENGINE run --rm \
 			-v "$(git rev-parse --show-toplevel)":/app \
 			-w /app \
 			golangci/golangci-lint:v"$GOLANGCI_LINT_VERSION" \

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -10,10 +10,10 @@ ENV="${ENV:-container}"
 
 function _run() {
 	if [ "$ENV" == "container" ]; then
-		$CONTAINER_ENGINE run --rm \
+	     $CONTAINER_ENGINE run --rm \
 			-v "$(git rev-parse --show-toplevel)":/app \
 			-w /app \
-			golangci/golangci-lint:v"$GOLANGCI_LINT_VERSION" \
+			docker.io/golangci/golangci-lint:v"$GOLANGCI_LINT_VERSION" \
 			"$@"
 	else
 		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v"$GOLANGCI_LINT_VERSION"


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

Workflow improvement.

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
/kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
The `linter` make target result with building the kubeapilinter plugin and running all linters.

Since the golangci-linter and Go caches are not mounted, their caches are built from scratch 
and disposed on every time the linter runs in a container.
As a result `lint` make target takes long time - about ~3 minutes (on a clean branch)

This PR optimize linter run time by mounting golnagci-lint and Go caches to the linter container.

With mounted cache lint make target time is dropped to ~10 seconds*.

**Special notes for your reviewer**:
In addition this PR fixes the `lint` make target to work with podman.

*The optimized linter run time distribute as follows (clean branch):
1. Build kubeapibuilder plugin - takes ~ 8 seconds
2. Run linters - ~2 seconds

(1) The `kubeapibuilder` plugin is built every time 'lint' make target runs, regardless of its state.
This can be optimized in follow-up PR to build the plugin conditionally upon existence or smarter strategy.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
