### PR TITLE
Fix flake in RawFRRConfig E2E test "should order multiple raw config snippets by priority"

### DIFF
--- a/e2etests/tests/raw_config.go
+++ b/e2etests/tests/raw_config.go
@@ -114,48 +114,6 @@ var _ = Describe("RawFRRConfig", Ordered, func() {
 		}, 2*time.Minute, time.Second).ShouldNot(HaveOccurred())
 	})
 
-	It("should order multiple raw config snippets by priority", func() {
-		rawConfigHigh := v1alpha1.RawFRRConfig{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "raw-high-priority",
-				Namespace: openperouter.Namespace,
-			},
-			Spec: v1alpha1.RawFRRConfigSpec{
-				Priority:  new(int32(20)),
-				RawConfig: "ip prefix-list raw-high seq 10 permit 10.222.0.0/16",
-			},
-		}
-
-		rawConfigLow := v1alpha1.RawFRRConfig{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "raw-low-priority",
-				Namespace: openperouter.Namespace,
-			},
-			Spec: v1alpha1.RawFRRConfigSpec{
-				Priority:  new(int32(5)),
-				RawConfig: "ip prefix-list raw-low seq 10 permit 10.33.0.0/16",
-			},
-		}
-
-		err := Updater.Update(config.Resources{
-			RawFRRConfigs: []v1alpha1.RawFRRConfig{rawConfigHigh, rawConfigLow},
-		})
-		Expect(err).NotTo(HaveOccurred())
-
-		Eventually(func() error {
-			routers, err = openperouter.Get(cs, HostMode)
-			if err != nil {
-				return err
-			}
-			if err := openperouter.AreReady(routers); err != nil {
-				return err
-			}
-			return checkRawConfigOrderOnAllRouters(routers,
-				"ip prefix-list raw-low seq 10 permit 10.33.0.0/16",
-				"ip prefix-list raw-high seq 10 permit 10.222.0.0/16")
-		}, 2*time.Minute, time.Second).ShouldNot(HaveOccurred())
-	})
-
 	It("should apply raw config only to nodes matching the node selector", func() {
 		nodeSelector := &metav1.LabelSelector{
 			MatchLabels: map[string]string{
@@ -296,28 +254,6 @@ func checkRawConfigAbsentOnAllRouters(routers openperouter.Routers, unexpected s
 		}
 		if strings.Contains(output, unexpected) {
 			return fmt.Errorf("router %s running config still contains %q", router.Name(), unexpected)
-		}
-	}
-	return nil
-}
-
-func checkRawConfigOrderOnAllRouters(routers openperouter.Routers, first, second string) error {
-	for router := range routers.GetExecutors() {
-		output, err := frr.RunningConfig(router)
-		if err != nil {
-			return err
-		}
-		firstIdx := strings.Index(output, first)
-		secondIdx := strings.Index(output, second)
-		if firstIdx == -1 {
-			return fmt.Errorf("router %s running config does not contain %q", router.Name(), first)
-		}
-		if secondIdx == -1 {
-			return fmt.Errorf("router %s running config does not contain %q", router.Name(), second)
-		}
-		if firstIdx >= secondIdx {
-			return fmt.Errorf("router %s: expected %q (priority lower) before %q (priority higher), but found in wrong order",
-				router.Name(), first, second)
 		}
 	}
 	return nil


### PR DESCRIPTION
Order of content inside /etc/frr/frr.conf depends on timing because
the frr-reloader.py script pushes incremental updates into FRR.
If a prefix-list is added before another one, their order will be
determined by the one being added first, regardless of the RawFRRCOnfig
priority. This priority comes only into play during a full reload or an
atomic add operation for the configuration snippets in questions.
Change the E2E test to check /etc/perouter/frr.conf inside the reloader
container which should always be deterministic.

Reported-at: https://github.com/openperouter/openperouter/issues/401
Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind flake

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

See https://github.com/openperouter/openperouter/issues/399 for full analysis.

**Special notes for your reviewer**:

In most cases, the E2E does an atomic add of the 2 rules. However, under specific circumstances, the add operations happen with a sufficient delay for the reloader to reload the configuration only with the "high" priority rule present, followed by a second reload with the "low" priority rule.

If you want to reproduce the issue 100% of the time, you can modify the test manually to:

```
	It("should order multiple raw config snippets by priority", func() {
		rawConfigHigh := v1alpha1.RawFRRConfig{
			ObjectMeta: metav1.ObjectMeta{
				Name:      "raw-high-priority",
				Namespace: openperouter.Namespace,
			},
			Spec: v1alpha1.RawFRRConfigSpec{
				Priority:  20,
				RawConfig: "ip prefix-list raw-high seq 10 permit 10.222.0.0/16",
			},
		}

		rawConfigLow := v1alpha1.RawFRRConfig{
			ObjectMeta: metav1.ObjectMeta{
				Name:      "raw-low-priority",
				Namespace: openperouter.Namespace,
			},
			Spec: v1alpha1.RawFRRConfigSpec{
				Priority:  5,
				RawConfig: "ip prefix-list raw-low seq 10 permit 10.33.0.0/16",
			},
		}

		err := Updater.Update(config.Resources{
			RawFRRConfigs: []v1alpha1.RawFRRConfig{rawConfigHigh},
		})
		Expect(err).NotTo(HaveOccurred())

		time.Sleep(5 * time.Second)

		err = Updater.Update(config.Resources{
			RawFRRConfigs: []v1alpha1.RawFRRConfig{rawConfigLow},
		})
		Expect(err).NotTo(HaveOccurred())

		Eventually(func() error {
			return checkRawConfigOrderOnAllRouters(routers,
				"ip prefix-list raw-low seq 10 permit 10.33.0.0/16",
				"ip prefix-list raw-high seq 10 permit 10.222.0.0/16")
		}, 2*time.Minute, time.Second).ShouldNot(HaveOccurred())
	})
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix flake in RawFRRConfig E2E test "should order multiple raw config snippets by priority"
```

**AI Guidelines Acknowledgment**:
- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.