### PR TITLE
e2e: remove unused blue VNI from iBGP test

### DIFF
--- a/e2etests/tests/evpn_routes.go
+++ b/e2etests/tests/evpn_routes.go
@@ -5,10 +5,11 @@ package tests
 import (
 	"context"
 	"fmt"
-	"k8s.io/utils/ptr"
 	"net"
 	"strings"
 	"time"
+
+	"k8s.io/utils/ptr"
 
 	frrk8sapi "github.com/metallb/frr-k8s/api/v1beta1"
 	"github.com/onsi/ginkgo/v2"
@@ -400,7 +401,7 @@ var _ = Describe("Routes between bgp and the fabric", Ordered, func() {
 	})
 })
 
-var _ = Describe("Routes between bgp and the fabric with iBGP testing e2e integration between a pod and the blue / red hosts", func() {
+var _ = Describe("Routes between bgp and the fabric with iBGP testing e2e integration between a pod and the red hosts", func() {
 	var cs clientset.Interface
 	var routers openperouter.Routers
 	var nodes []corev1.Node
@@ -441,25 +442,6 @@ var _ = Describe("Routes between bgp and the fabric with iBGP testing e2e integr
 				},
 			},
 			VNI: 100,
-		},
-	}
-
-	vniBlue := v1alpha1.L3VNI{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "blue",
-			Namespace: openperouter.Namespace,
-		},
-		Spec: v1alpha1.L3VNISpec{
-			VRF: "blue",
-			HostSession: &v1alpha1.HostSession{
-				ASN:     64514,
-				HostASN: ptr.To(int64(64515)),
-				LocalCIDR: v1alpha1.LocalCIDRConfig{
-					IPv4: ptr.To("192.169.11.0/24"),
-					IPv6: ptr.To("2001:db8:2::/64"),
-				},
-			},
-			VNI: 200,
 		},
 	}
 
@@ -508,21 +490,18 @@ var _ = Describe("Routes between bgp and the fabric with iBGP testing e2e integr
 
 		By("Creating the frr-k8s configuration for the node where the test pod runs and advertising all pod ips")
 		frrK8sConfigRedForPod := advertisePodToVNI(testPod, vniRed, nodeSelector)
-		frrK8sConfigBlueForPod := advertisePodToVNI(testPod, vniBlue, nodeSelector)
 
 		err = Updater.Update(config.Resources{
 			L3VNIs: []v1alpha1.L3VNI{
 				vniRed,
-				vniBlue,
 			},
-			FRRConfigurations: append(frrK8sConfigRedForPod, frrK8sConfigBlueForPod...),
+			FRRConfigurations: frrK8sConfigRedForPod,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		frrK8sPodOnNode, err := frrk8s.PodForNode(cs, testPod.Spec.NodeName)
 		Expect(err).NotTo(HaveOccurred())
 		validateFRRK8sSessionForHostSession(vniRed.Name, *vniRed.Spec.HostSession, Established, frrK8sPodOnNode)
-		validateFRRK8sSessionForHostSession(vniBlue.Name, *vniBlue.Spec.HostSession, Established, frrK8sPodOnNode)
 	})
 
 	AfterEach(func() {
@@ -556,12 +535,8 @@ var _ = Describe("Routes between bgp and the fabric with iBGP testing e2e integr
 		externalHostIP := infra.HostARedIPv4
 		ipFamily := ipfamily.IPv4
 
-		var localCIDR string
-		localCIDR = ptr.Deref(vni.Spec.HostSession.LocalCIDR.IPv4, "")
+		localCIDR := ptr.Deref(vni.Spec.HostSession.LocalCIDR.IPv4, "")
 
-		if ipFamily == ipfamily.IPv6 {
-			localCIDR = ptr.Deref(vni.Spec.HostSession.LocalCIDR.IPv6, "")
-		}
 		hostSide, err := openperouter.HostIPFromCIDRForNode(localCIDR, podNode)
 		Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Remove the "blue" L3VNI definition and all its references from the iBGP
E2E test, which only validates connectivity against the red host. This
also removes dead code for IPv6 local CIDR selection, since the test
hardcodes IPv4.


**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:
Remove the "blue" L3VNI definition and all its references from the iBGP
E2E test, which only validates connectivity against the red host. This
also removes dead code for IPv6 local CIDR selection, since the test
hardcodes IPv4.

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Cleanup of iBGP E2E test
```
