### PR TITLE
make,lint: Build linter binary only when needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -392,17 +392,17 @@ kind-node-image-push: ## Push custom kind node image to quay.io
 	cd hack/kind-node-image && ./push.sh
 
 GOLANGCI_LINT_VERSION ?= 2.9.0
+GOLANGCI_LINT_CUSTOM_BIN ?= $(LOCALBIN)/golangci-lint-custom
 GOLANGCI_LINT_CACHE ?= $(HOME)/.cache/golangci-lint
 
-.PHONY: golangci-lint
-golangci-lint:
+$(GOLANGCI_LINT_CUSTOM_BIN): .custom-gcl.yml
 	CONTAINER_ENGINE=$(CONTAINER_ENGINE) \
 	GOLANGCI_LINT_VERSION=$(GOLANGCI_LINT_VERSION) \
 	GOLANGCI_LINT_CACHE=$(GOLANGCI_LINT_CACHE) \
 	hack/golangci-lint.sh build
 
 .PHONY: lint
-lint: golangci-lint
+lint: $(GOLANGCI_LINT_CUSTOM_BIN)
 	CONTAINER_ENGINE=$(CONTAINER_ENGINE) \
 	GOLANGCI_LINT_VERSION=$(GOLANGCI_LINT_VERSION) \
 	GOLANGCI_LINT_CACHE=$(GOLANGCI_LINT_CACHE) \


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
The project use custom golnagci-lint, containing the kube-api-linter plugin, controlled by .custom-gcl.yml file.

Currently 'lint' make target builds the binary on every run, making run time longer (~12 seconds).

Introduce new make target for tracking the linter binary. Change 'lint' target to depend on the new binary target.

With change the custom linter binray is built only when needed; not exist or require update due to .custom-gcl.yaml change (e.g.: kube-api-linter version bump).
And the 'lint' target  run time time drops to **~2 seconds.**

**Special notes for your reviewer**:
Assisted by Claude sonnet 4.6

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
