### PR TITLE
configuration resilience with per-resource error reporting

### DIFF
--- a/e2etests/pkg/openperouter/status.go
+++ b/e2etests/pkg/openperouter/status.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package openperouter
+
+import (
+	"context"
+
+	"github.com/openperouter/openperouter/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetNodeStatus(cli client.Client, nodeName string) (*v1alpha1.RouterNodeConfigurationStatus, error) {
+	status := &v1alpha1.RouterNodeConfigurationStatus{}
+	err := cli.Get(context.Background(), client.ObjectKey{
+		Name:      nodeName,
+		Namespace: Namespace,
+	}, status)
+	if err != nil {
+		return nil, err
+	}
+	return status, nil
+}

--- a/e2etests/pkg/openperouter/webhooks.go
+++ b/e2etests/pkg/openperouter/webhooks.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package openperouter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+const skipWebhookLabel = "openperouter.io/skip-webhook"
+
+func DisableWebhooksForNamespace(cs clientset.Interface, namespace string) error {
+	_, err := cs.CoreV1().Namespaces().Patch(
+		context.Background(),
+		namespace,
+		types.MergePatchType,
+		[]byte(`{"metadata":{"labels":{"`+skipWebhookLabel+`":""}}}`),
+		metav1.PatchOptions{},
+	)
+	if err != nil {
+		return err
+	}
+
+	names, err := findWebhookConfigurations(cs)
+	if err != nil {
+		return err
+	}
+	for _, name := range names {
+		vwc, err := cs.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(
+			context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		for i := range vwc.Webhooks {
+			vwc.Webhooks[i].NamespaceSelector = &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      skipWebhookLabel,
+						Operator: metav1.LabelSelectorOpDoesNotExist,
+					},
+				},
+			}
+		}
+
+		_, err = cs.AdmissionregistrationV1().ValidatingWebhookConfigurations().Update(
+			context.Background(), vwc, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func RestoreWebhooks(cs clientset.Interface, namespace string) error {
+	labelPatch, _ := json.Marshal([]map[string]interface{}{
+		{
+			"op":   "remove",
+			"path": "/metadata/labels/" + jsonPatchEscape(skipWebhookLabel),
+		},
+	})
+	_, err := cs.CoreV1().Namespaces().Patch(
+		context.Background(),
+		namespace,
+		types.JSONPatchType,
+		labelPatch,
+		metav1.PatchOptions{},
+	)
+	if err != nil {
+		return err
+	}
+
+	names, err := findWebhookConfigurations(cs)
+	if err != nil {
+		return err
+	}
+	for _, name := range names {
+		vwc, err := cs.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(
+			context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		for i := range vwc.Webhooks {
+			vwc.Webhooks[i].NamespaceSelector = nil
+		}
+
+		_, err = cs.AdmissionregistrationV1().ValidatingWebhookConfigurations().Update(
+			context.Background(), vwc, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func findWebhookConfigurations(cs clientset.Interface) ([]string, error) {
+	vwcList, err := cs.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(
+		context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var names []string
+	for _, vwc := range vwcList.Items {
+		for _, wh := range vwc.Webhooks {
+			if strings.Contains(wh.Name, "openperouter") {
+				names = append(names, vwc.Name)
+				break
+			}
+		}
+	}
+	if len(names) == 0 {
+		return nil, fmt.Errorf("no ValidatingWebhookConfiguration found with openperouter webhooks")
+	}
+	return names, nil
+}
+
+func jsonPatchEscape(s string) string {
+	replacer := strings.NewReplacer("~", "~0", "/", "~1")
+	return replacer.Replace(s)
+}

--- a/e2etests/tests/hostconfiguration.go
+++ b/e2etests/tests/hostconfiguration.go
@@ -736,9 +736,7 @@ var _ = ginkgo.Describe("Router Host configuration", func() {
 				Namespace: openperouter.Namespace,
 			},
 			Spec: v1alpha1.L2VNISpec{
-				VNI:          400,
-				VRF:          new("second"),
-				L2GatewayIPs: []string{"192.168.1.4/24"},
+				VNI: 400,
 			},
 		}
 
@@ -799,11 +797,10 @@ var _ = ginkgo.Describe("Router Host configuration", func() {
 				}, l2VNIConfiguredTestSelector, p)
 
 				validateConfig(l2vniParams{
-					VRF:          *l2vni400.Spec.VRF,
-					VNI:          400,
-					VXLanPort:    4789,
-					VTEPIP:       vtepIP,
-					L2GatewayIPs: l2vni400.Spec.L2GatewayIPs,
+					VRF:       "",
+					VNI:       400,
+					VXLanPort: 4789,
+					VTEPIP:    vtepIP,
 				}, l2VNIConfiguredTestSelector, p)
 			}
 
@@ -816,11 +813,10 @@ var _ = ginkgo.Describe("Router Host configuration", func() {
 
 				vtepIP := vtepIPv4ForPod(cs, underlay.Spec.TunnelEndpoint, p)
 				validateConfig(l2vniParams{
-					VRF:          *l2vni400.Spec.VRF,
-					VNI:          400,
-					VXLanPort:    4789,
-					VTEPIP:       vtepIP,
-					L2GatewayIPs: l2vni400.Spec.L2GatewayIPs,
+					VRF:       "",
+					VNI:       400,
+					VXLanPort: 4789,
+					VTEPIP:    vtepIP,
 				}, l2VNIConfiguredTestSelector, p)
 
 				ginkgo.By(fmt.Sprintf("validating VNI is deleted for pod %s", p.Name))
@@ -956,10 +952,9 @@ var _ = ginkgo.Describe("Router Host configuration", func() {
 				VXLanPort: 4789,
 			}
 			l2VNI400Params := l2vniParams{
-				VRF:          *l2vni400.Spec.VRF,
-				VNI:          400,
-				VXLanPort:    4789,
-				L2GatewayIPs: l2vni400.Spec.L2GatewayIPs,
+				VRF:       "",
+				VNI:       400,
+				VXLanPort: 4789,
 			}
 
 			validate := func(p *corev1.Pod, params l2vniParams, test string) {

--- a/e2etests/tests/resiliency.go
+++ b/e2etests/tests/resiliency.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openperouter/openperouter/e2etests/pkg/url"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 )
@@ -763,3 +764,252 @@ func dumpPreTrafficState(cs clientset.Interface, nodeName string) {
 		}
 	}
 }
+
+var _ = Describe("Configuration Resiliency", Ordered, func() {
+	var cs clientset.Interface
+
+	goodL3VNI := v1alpha1.L3VNI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "good-l3",
+			Namespace: openperouter.Namespace,
+		},
+		Spec: v1alpha1.L3VNISpec{
+			VRF: "good",
+			VNI: 100,
+		},
+	}
+
+	goodL2VNI := v1alpha1.L2VNI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "good-l2",
+			Namespace: openperouter.Namespace,
+		},
+		Spec: v1alpha1.L2VNISpec{
+			VNI: 200,
+		},
+	}
+
+	conflictL3VNI := v1alpha1.L3VNI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "l3-conflict",
+			Namespace: openperouter.Namespace,
+		},
+		Spec: v1alpha1.L3VNISpec{
+			VRF: "conflict",
+			VNI: 300,
+		},
+	}
+
+	conflictL2VNI := v1alpha1.L2VNI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "l2-conflict",
+			Namespace: openperouter.Namespace,
+		},
+		Spec: v1alpha1.L2VNISpec{
+			VNI: 300,
+		},
+	}
+
+	BeforeAll(func() {
+		Expect(Updater.CleanAll()).To(Succeed())
+
+		cs = k8sclient.New()
+
+		Expect(openperouter.DisableWebhooksForNamespace(cs, openperouter.Namespace)).To(Succeed())
+
+		Expect(Updater.Update(config.Resources{
+			Underlays: []v1alpha1.Underlay{infra.Underlay},
+		})).To(Succeed())
+	})
+
+	AfterAll(func() {
+		Expect(openperouter.RestoreWebhooks(cs, openperouter.Namespace)).To(Succeed())
+
+		Expect(Updater.CleanAll()).To(Succeed())
+
+		Eventually(func() error {
+			newRouters, err := openperouter.Get(cs, HostMode)
+			if err != nil {
+				return err
+			}
+			return openperouter.AreReady(newRouters)
+		}, 2*time.Minute, time.Second).ShouldNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		dumpIfFails(cs)
+		Expect(Updater.CleanButUnderlay()).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			status, err := openperouter.GetNodeStatus(Updater.Client(), infra.KindControlPlane)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			readyCond := apimeta.FindStatusCondition(status.Status.Conditions, "Ready")
+			g.Expect(readyCond).NotTo(BeNil())
+			g.Expect(readyCond.Status).To(Equal(metav1.ConditionTrue))
+
+			degradedCond := apimeta.FindStatusCondition(status.Status.Conditions, "Degraded")
+			g.Expect(degradedCond).NotTo(BeNil())
+			g.Expect(degradedCond.Status).To(Equal(metav1.ConditionFalse))
+		}, time.Minute, time.Second).Should(Succeed())
+	})
+
+	Context("when L3VNI and L2VNI have the same VNI number", func() {
+		It("should skip the conflicting L2VNI and configure the good resources", func() {
+			Expect(Updater.Update(config.Resources{
+				L3VNIs: []v1alpha1.L3VNI{goodL3VNI, conflictL3VNI},
+				L2VNIs: []v1alpha1.L2VNI{goodL2VNI, conflictL2VNI},
+			})).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				status, err := openperouter.GetNodeStatus(Updater.Client(), infra.KindControlPlane)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(status.Status.FailedResources).To(HaveLen(1))
+				failed := status.Status.FailedResources[0]
+				g.Expect(failed.Kind).To(Equal(v1alpha1.FailedResourceKind("L2VNI")))
+				g.Expect(failed.Name).To(Equal("l2-conflict"))
+				g.Expect(failed.Reason).To(Equal(v1alpha1.FailedResourceReasonValidationFailed))
+				g.Expect(failed.Message).To(ContainSubstring("duplicate vni"))
+
+				readyCond := apimeta.FindStatusCondition(status.Status.Conditions, "Ready")
+				g.Expect(readyCond).NotTo(BeNil())
+				g.Expect(readyCond.Status).To(Equal(metav1.ConditionFalse))
+
+				degradedCond := apimeta.FindStatusCondition(status.Status.Conditions, "Degraded")
+				g.Expect(degradedCond).NotTo(BeNil())
+				g.Expect(degradedCond.Status).To(Equal(metav1.ConditionTrue))
+			}, time.Minute, time.Second).Should(Succeed())
+		})
+	})
+
+	Context("when an L3VNI has an invalid route target", func() {
+		It("should skip the L3VNI and cascade DependencyFailed to its L2VNIs", func() {
+			badRTL3VNI := v1alpha1.L3VNI{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bad-rt-l3",
+					Namespace: openperouter.Namespace,
+				},
+				Spec: v1alpha1.L3VNISpec{
+					VRF:       "cascade",
+					VNI:       400,
+					ExportRTs: []string{"invalid-rt"},
+				},
+			}
+
+			cascadeL2VNI := v1alpha1.L2VNI{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cascade-l2",
+					Namespace: openperouter.Namespace,
+				},
+				Spec: v1alpha1.L2VNISpec{
+					VRF: new("cascade"),
+					VNI: 401,
+				},
+			}
+
+			Expect(Updater.Update(config.Resources{
+				L3VNIs: []v1alpha1.L3VNI{goodL3VNI, badRTL3VNI},
+				L2VNIs: []v1alpha1.L2VNI{goodL2VNI, cascadeL2VNI},
+			})).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				status, err := openperouter.GetNodeStatus(Updater.Client(), infra.KindControlPlane)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(status.Status.FailedResources).To(HaveLen(2))
+
+				failedByName := map[string]v1alpha1.FailedResource{}
+				for _, f := range status.Status.FailedResources {
+					failedByName[f.Name] = f
+				}
+
+				g.Expect(failedByName).To(HaveKey("bad-rt-l3"))
+				g.Expect(failedByName["bad-rt-l3"].Kind).To(Equal(v1alpha1.FailedResourceKind("L3VNI")))
+				g.Expect(failedByName["bad-rt-l3"].Reason).To(Equal(v1alpha1.FailedResourceReasonValidationFailed))
+
+				g.Expect(failedByName).To(HaveKey("cascade-l2"))
+				g.Expect(failedByName["cascade-l2"].Kind).To(Equal(v1alpha1.FailedResourceKind("L2VNI")))
+				g.Expect(failedByName["cascade-l2"].Reason).To(Equal(v1alpha1.FailedResourceReasonDependencyFailed))
+				g.Expect(failedByName["cascade-l2"].Message).To(ContainSubstring("no valid L3VNI for L3 domain"))
+
+				readyCond := apimeta.FindStatusCondition(status.Status.Conditions, "Ready")
+				g.Expect(readyCond).NotTo(BeNil())
+				g.Expect(readyCond.Status).To(Equal(metav1.ConditionFalse))
+			}, time.Minute, time.Second).Should(Succeed())
+		})
+	})
+
+	Context("when an L2VNI references a VRF with no matching L3VNI", func() {
+		It("should report DependencyFailed for the orphan L2VNI", func() {
+			orphanL2VNI := v1alpha1.L2VNI{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "orphan-l2",
+					Namespace: openperouter.Namespace,
+				},
+				Spec: v1alpha1.L2VNISpec{
+					VRF: new("nonexistent"),
+					VNI: 500,
+				},
+			}
+
+			Expect(Updater.Update(config.Resources{
+				L3VNIs: []v1alpha1.L3VNI{goodL3VNI},
+				L2VNIs: []v1alpha1.L2VNI{goodL2VNI, orphanL2VNI},
+			})).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				status, err := openperouter.GetNodeStatus(Updater.Client(), infra.KindControlPlane)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(status.Status.FailedResources).To(HaveLen(1))
+				failed := status.Status.FailedResources[0]
+				g.Expect(failed.Kind).To(Equal(v1alpha1.FailedResourceKind("L2VNI")))
+				g.Expect(failed.Name).To(Equal("orphan-l2"))
+				g.Expect(failed.Reason).To(Equal(v1alpha1.FailedResourceReasonDependencyFailed))
+				g.Expect(failed.Message).To(ContainSubstring("no valid L3VNI for L3 domain"))
+
+				readyCond := apimeta.FindStatusCondition(status.Status.Conditions, "Ready")
+				g.Expect(readyCond).NotTo(BeNil())
+				g.Expect(readyCond.Status).To(Equal(metav1.ConditionFalse))
+			}, time.Minute, time.Second).Should(Succeed())
+		})
+	})
+
+	Context("when a cross-type VNI conflict is resolved", func() {
+		It("should recover and clear the status", func() {
+			By("creating a cross-type VNI conflict")
+			Expect(Updater.Update(config.Resources{
+				L3VNIs: []v1alpha1.L3VNI{conflictL3VNI},
+				L2VNIs: []v1alpha1.L2VNI{conflictL2VNI},
+			})).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				status, err := openperouter.GetNodeStatus(Updater.Client(), infra.KindControlPlane)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(status.Status.FailedResources).To(HaveLen(1))
+				g.Expect(status.Status.FailedResources[0].Name).To(Equal("l2-conflict"))
+			}, time.Minute, time.Second).Should(Succeed())
+
+			By("fixing the L2VNI to use a non-conflicting VNI number")
+			fixedL2VNI := conflictL2VNI.DeepCopy()
+			fixedL2VNI.Spec.VNI = 301
+
+			Expect(Updater.Update(config.Resources{
+				L3VNIs: []v1alpha1.L3VNI{conflictL3VNI},
+				L2VNIs: []v1alpha1.L2VNI{*fixedL2VNI},
+			})).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				status, err := openperouter.GetNodeStatus(Updater.Client(), infra.KindControlPlane)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(status.Status.FailedResources).To(BeEmpty())
+
+				readyCond := apimeta.FindStatusCondition(status.Status.Conditions, "Ready")
+				g.Expect(readyCond).NotTo(BeNil())
+				g.Expect(readyCond.Status).To(Equal(metav1.ConditionTrue))
+
+				degradedCond := apimeta.FindStatusCondition(status.Status.Conditions, "Degraded")
+				g.Expect(degradedCond).NotTo(BeNil())
+				g.Expect(degradedCond.Status).To(Equal(metav1.ConditionFalse))
+			}, time.Minute, time.Second).Should(Succeed())
+		})
+	})
+})

--- a/internal/controller/routerconfiguration/host_config.go
+++ b/internal/controller/routerconfiguration/host_config.go
@@ -20,6 +20,10 @@ type interfacesConfiguration struct {
 	conversion.APIConfigData
 }
 
+// HostConfigurator applies host-level network configuration (interfaces, VNIs, sysctls).
+// Injected into Reconcile so tests can substitute a no-op implementation.
+type HostConfigurator func(ctx context.Context, config interfacesConfiguration) error
+
 func configureInterfaces(ctx context.Context, config interfacesConfiguration) error {
 	hasAlreadyUnderlay, err := hostnetwork.HasUnderlayInterface(config.targetNamespace)
 	if err != nil {

--- a/internal/controller/routerconfiguration/host_config.go
+++ b/internal/controller/routerconfiguration/host_config.go
@@ -8,7 +8,11 @@ import (
 	"fmt"
 	"log/slog"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/openperouter/openperouter/api/v1alpha1"
 	"github.com/openperouter/openperouter/internal/conversion"
+	openpeerrors "github.com/openperouter/openperouter/internal/errors"
 	"github.com/openperouter/openperouter/internal/hostnetwork"
 	"github.com/openperouter/openperouter/internal/hostnetwork/bridgerefresh"
 	"github.com/openperouter/openperouter/internal/sysctl"
@@ -75,49 +79,87 @@ func configureInterfaces(ctx context.Context, config interfacesConfiguration) er
 	if err := hostnetwork.SetupUnderlay(ctx, hostConfig.Underlay); err != nil {
 		return fmt.Errorf("failed to setup underlay: %w", err)
 	}
+
+	var resourceErrors []error
+	failedL3Domains := sets.New[string]()
+	reason := v1alpha1.FailedResourceReasonOverlayAttachmentFailed
+
+	var configuredL3VNIs []hostnetwork.L3VNIParams
 	for _, vni := range hostConfig.L3VNIs {
 		slog.InfoContext(ctx, "setting up VNI", "vni", vni.VRF)
 		if err := hostnetwork.SetupL3VNI(ctx, vni); err != nil {
-			return fmt.Errorf("failed to setup vni: %w", err)
+			resourceErrors = append(resourceErrors, &openpeerrors.ResourceError{
+				Obj: v1alpha1.FailedResource{
+					Kind: openpeerrors.KindL3VNI, Name: vni.Name, Reason: reason, Message: err.Error(),
+				},
+			})
+			failedL3Domains.Insert(vni.VRF)
+			continue
 		}
+		configuredL3VNIs = append(configuredL3VNIs, vni)
 	}
 
+	var configuredL2VNIs []hostnetwork.L2VNIParams
 	for _, vni := range hostConfig.L2VNIs {
+		if failedL3Domains.Has(vni.VRF) {
+			resourceErrors = append(resourceErrors, &openpeerrors.ResourceError{
+				Obj: v1alpha1.FailedResource{
+					Kind: openpeerrors.KindL2VNI, Name: vni.Name, Reason: reason,
+					Message: fmt.Sprintf("L3 domain %q failed netlink provisioning", vni.VRF),
+				},
+			})
+			continue
+		}
 		slog.InfoContext(ctx, "setting up L2VNI", "vni", vni.VNI)
 		if err := hostnetwork.SetupL2VNI(ctx, vni); err != nil {
-			return fmt.Errorf("failed to setup vni: %w", err)
+			resourceErrors = append(resourceErrors, &openpeerrors.ResourceError{
+				Obj: v1alpha1.FailedResource{
+					Kind: openpeerrors.KindL2VNI, Name: vni.Name, Reason: reason, Message: err.Error(),
+				},
+			})
+			continue
 		}
 		if err := bridgerefresh.StartForVNI(ctx, vni); err != nil {
-			return fmt.Errorf("failed to start bridge refresher for vni %d: %w", vni.VNI, err)
+			resourceErrors = append(resourceErrors, &openpeerrors.ResourceError{
+				Obj: v1alpha1.FailedResource{
+					Kind: openpeerrors.KindL2VNI, Name: vni.Name, Reason: reason, Message: err.Error(),
+				},
+			})
+			continue
 		}
+		configuredL2VNIs = append(configuredL2VNIs, vni)
 	}
 
 	slog.InfoContext(ctx, "setting up passthrough")
 	if hostConfig.L3Passthrough != nil {
 		if err := hostnetwork.SetupPassthrough(ctx, *hostConfig.L3Passthrough); err != nil {
-			return fmt.Errorf("failed to setup passthrough: %w", err)
+			resourceErrors = append(resourceErrors, &openpeerrors.ResourceError{
+				Obj: v1alpha1.FailedResource{
+					Kind: openpeerrors.KindL3Passthrough, Name: config.L3Passthrough[0].Name, Reason: reason, Message: err.Error(),
+				},
+			})
 		}
 	}
 
 	slog.InfoContext(ctx, "removing deleted vnis")
-	toCheck := make([]hostnetwork.VNIParams, 0, len(hostConfig.L3VNIs)+len(hostConfig.L2VNIs))
-	for _, vni := range hostConfig.L3VNIs {
+	toCheck := make([]hostnetwork.VNIParams, 0, len(configuredL3VNIs)+len(configuredL2VNIs))
+	for _, vni := range configuredL3VNIs {
 		toCheck = append(toCheck, vni.VNIParams)
 	}
-	for _, l2vni := range hostConfig.L2VNIs {
+	for _, l2vni := range configuredL2VNIs {
 		toCheck = append(toCheck, l2vni.VNIParams)
 	}
 	if err := hostnetwork.RemoveNonConfiguredVNIs(config.targetNamespace, toCheck); err != nil {
 		return fmt.Errorf("failed to remove deleted vnis: %w", err)
 	}
-	bridgerefresh.StopForRemovedVNIs(hostConfig.L2VNIs)
+	bridgerefresh.StopForRemovedVNIs(configuredL2VNIs)
 
-	if len(apiConfig.L3Passthrough) == 0 {
+	if len(config.L3Passthrough) == 0 {
 		if err := hostnetwork.RemovePassthrough(config.targetNamespace); err != nil {
 			return fmt.Errorf("failed to remove passthrough: %w", err)
 		}
 	}
-	return nil
+	return errors.Join(resourceErrors...)
 }
 
 // nonRecoverableHostError tells whether the router pod

--- a/internal/controller/routerconfiguration/node_status.go
+++ b/internal/controller/routerconfiguration/node_status.go
@@ -11,7 +11,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -21,7 +20,7 @@ import (
 
 // reconcileNodeStatus creates or updates the node status resource.
 // It sets the owner reference to the hosting node.
-func (r *PERouterReconciler) reconcileNodeStatus(ctx context.Context) error {
+func (r *PERouterReconciler) reconcileNodeStatus(ctx context.Context, reconcileErr error) error {
 	node := &corev1.Node{}
 	if err := r.Get(ctx, client.ObjectKey{Name: r.MyNode}, node); err != nil {
 		if k8serr.IsNotFound(err) {
@@ -40,14 +39,14 @@ func (r *PERouterReconciler) reconcileNodeStatus(ctx context.Context) error {
 		return fmt.Errorf("failed to create or update node status: %w", err)
 	}
 
-	newStatus := updateStatus(nodeStatus.Status)
+	newStatus := buildStatus(reconcileErr)
 
-	if equality.Semantic.DeepEqual(nodeStatus.Status, newStatus) {
+	if equality.Semantic.DeepEqual(nodeStatus.Status, &newStatus) {
 		return nil
 	}
 
 	newNodeStatus := nodeStatus.DeepCopy()
-	newNodeStatus.Status = newStatus
+	newNodeStatus.Status = &newStatus
 
 	if err := r.Status().Patch(ctx, newNodeStatus, client.MergeFrom(nodeStatus)); err != nil {
 		return fmt.Errorf("failed to patch status: %w", err)
@@ -57,39 +56,4 @@ func (r *PERouterReconciler) reconcileNodeStatus(ctx context.Context) error {
 		"node", r.MyNode, "namespace", r.MyNamespace, "status", newNodeStatus.Status)
 
 	return nil
-}
-
-func updateStatus(status *v1alpha1.RouterNodeConfigurationStatusStatus) *v1alpha1.RouterNodeConfigurationStatusStatus {
-	updated := status.DeepCopy()
-	if updated == nil {
-		updated = &v1alpha1.RouterNodeConfigurationStatusStatus{}
-	}
-
-	desiredConditions := newConditions()
-	for _, desiredCondition := range desiredConditions {
-		// SetStatusCondition update lastTransitionTime if unset or differs from desired condition.
-		meta.SetStatusCondition(&updated.Conditions, desiredCondition)
-	}
-
-	return updated
-}
-
-// newConditions return default conditions.
-// The conditions lastTransitionTime is unset.
-// TODO: create conditions according to status.FailedResources.
-func newConditions() []metav1.Condition {
-	ready := metav1.Condition{
-		Type:    v1alpha1.ConditionTypeReady,
-		Status:  metav1.ConditionUnknown,
-		Reason:  "Unknown",
-		Message: "Unknown status",
-	}
-	degraded := metav1.Condition{
-		Type:    v1alpha1.ConditionTypeDegraded,
-		Status:  metav1.ConditionUnknown,
-		Reason:  "Unknown",
-		Message: "Unknown status",
-	}
-
-	return []metav1.Condition{ready, degraded}
 }

--- a/internal/controller/routerconfiguration/reconcile.go
+++ b/internal/controller/routerconfiguration/reconcile.go
@@ -3,55 +3,129 @@
 package routerconfiguration
 
 import (
+	"cmp"
 	"context"
+	"errors"
 	"fmt"
+	"slices"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openperouter/openperouter/api/v1alpha1"
 	"github.com/openperouter/openperouter/internal/conversion"
+	openpeerrors "github.com/openperouter/openperouter/internal/errors"
 	"github.com/openperouter/openperouter/internal/frr"
 )
 
-func Reconcile(ctx context.Context, apiConfig conversion.APIConfigData, nodeIndex int, logLevel, frrConfigPath, targetNamespace string, updater frr.ConfigUpdater) error {
+func Reconcile(ctx context.Context, apiConfig conversion.APIConfigData, nodeIndex int, logLevel, frrConfigPath, targetNamespace string, updater frr.ConfigUpdater, hostConfigurator HostConfigurator) error {
+	normalizeConfig(&apiConfig)
 	if err := conversion.ValidateUnderlays(apiConfig.Underlays); err != nil {
-		return fmt.Errorf("failed to validate underlays: %w", err)
+		return err
 	}
 
-	if err := conversion.ValidateL3VNIs(apiConfig.L3VNIs); err != nil {
-		return fmt.Errorf("failed to validate l3vnis: %w", err)
-	}
+	var resourceErrors []error
+	var err error
 
-	if err := conversion.ValidateL2VNIs(apiConfig.L2VNIs); err != nil {
-		return fmt.Errorf("failed to validate l2vnis: %w", err)
-	}
+	var validL3VNIs []v1alpha1.L3VNI
+	validL3VNIs, err = conversion.FilterValidL3VNIs(apiConfig.L3VNIs)
+	resourceErrors = append(resourceErrors, err)
 
-	if err := conversion.ValidateVRFs(apiConfig.L2VNIs, apiConfig.L3VNIs); err != nil {
-		return fmt.Errorf("failed to validate VRFs: %w", err)
-	}
+	var validL2VNIs []v1alpha1.L2VNI
+	validL2VNIs, err = conversion.FilterValidL2VNIs(apiConfig.L2VNIs)
+	resourceErrors = append(resourceErrors, err)
 
-	if err := conversion.ValidatePassthroughs(apiConfig.L3Passthrough); err != nil {
-		return fmt.Errorf("failed to validate l3passthrough: %w", err)
-	}
+	validL3VNIs, validL2VNIs, err = conversion.FilterUniqueVNIs(validL3VNIs, validL2VNIs)
+	resourceErrors = append(resourceErrors, err)
 
-	if err := conversion.ValidateHostSessions(apiConfig.L3VNIs, apiConfig.L3Passthrough); err != nil {
+	validL3VNIs, err = conversion.FilterUniqueVRFs(validL3VNIs)
+	resourceErrors = append(resourceErrors, err)
+
+	validL3VNIs, validL2VNIs, err = conversion.FilterValidVRFSubnets(validL3VNIs, validL2VNIs)
+	resourceErrors = append(resourceErrors, err)
+
+	validL2VNIs, err = filterL2VNIsWithoutL3VNI(validL2VNIs, validL3VNIs)
+	resourceErrors = append(resourceErrors, err)
+
+	var validPassthrough []v1alpha1.L3Passthrough
+	validPassthrough, err = conversion.FilterValidPassthroughs(apiConfig.L3Passthrough)
+	resourceErrors = append(resourceErrors, err)
+
+	if err := conversion.ValidateHostSessions(validL3VNIs, validPassthrough); err != nil {
 		return fmt.Errorf("failed to validate host sessions: %w", err)
 	}
 
-	if err := configureInterfaces(ctx, interfacesConfiguration{
-		targetNamespace: targetNamespace,
-		APIConfigData:   apiConfig,
-		nodeIndex:       nodeIndex,
-	}); err != nil {
-		return fmt.Errorf("failed to configure the host: %w", err)
+	config := conversion.APIConfigData{
+		Underlays:     apiConfig.Underlays,
+		L3VNIs:        validL3VNIs,
+		L2VNIs:        validL2VNIs,
+		L3Passthrough: validPassthrough,
+		RawFRRConfigs: apiConfig.RawFRRConfigs,
 	}
 
-	if err := configureFRR(ctx, frrConfigData{
+	err = hostConfigurator(ctx, interfacesConfiguration{
+		targetNamespace: targetNamespace,
+		APIConfigData:   config,
+		nodeIndex:       nodeIndex,
+	})
+	if openpeerrors.IsNonResourceError(err) {
+		return err
+	}
+	resourceErrors = append(resourceErrors, err)
+
+	if err = configureFRR(ctx, frrConfigData{
 		configFile:    frrConfigPath,
 		updater:       updater,
-		APIConfigData: apiConfig,
+		APIConfigData: config,
 		nodeIndex:     nodeIndex,
 		logLevel:      logLevel,
 	}); err != nil {
-		return fmt.Errorf("failed to reload frr config: %w", err)
+		return err
 	}
 
-	return nil
+	return errors.Join(resourceErrors...)
+}
+
+// filterL2VNIsWithoutL3VNI must be called after all L3VNI filtering is complete.
+func filterL2VNIsWithoutL3VNI(l2Vnis []v1alpha1.L2VNI, l3Vnis []v1alpha1.L3VNI) ([]v1alpha1.L2VNI, error) {
+	vrfs := sets.New[string]()
+	for _, l3 := range l3Vnis {
+		vrfs.Insert(l3.Spec.VRF)
+	}
+	var valid []v1alpha1.L2VNI
+	var resourceErrors []error
+	for _, l2 := range l2Vnis {
+		if l2.Spec.VRF != nil && *l2.Spec.VRF != "" && !vrfs.Has(*l2.Spec.VRF) {
+			resourceErrors = append(resourceErrors, &openpeerrors.ResourceError{
+				Obj: v1alpha1.FailedResource{
+					Kind:    openpeerrors.KindL2VNI,
+					Name:    l2.Name,
+					Reason:  v1alpha1.FailedResourceReasonDependencyFailed,
+					Message: fmt.Sprintf("no valid L3VNI for L3 domain %q", *l2.Spec.VRF),
+				},
+			})
+			continue
+		}
+		valid = append(valid, l2)
+	}
+	return valid, errors.Join(resourceErrors...)
+}
+
+// normalizeConfig sorts resources by namespace/name so validation order is deterministic.
+func normalizeConfig(config *conversion.APIConfigData) {
+	slices.SortFunc(config.L3VNIs, func(a, b v1alpha1.L3VNI) int {
+		return cmp.Compare(objectKey(&a), objectKey(&b))
+	})
+
+	slices.SortFunc(config.L2VNIs, func(a, b v1alpha1.L2VNI) int {
+		return cmp.Compare(objectKey(&a), objectKey(&b))
+	})
+
+	slices.SortFunc(config.L3Passthrough, func(a, b v1alpha1.L3Passthrough) int {
+		return cmp.Compare(objectKey(&a), objectKey(&b))
+	})
+}
+
+func objectKey(o client.Object) string {
+	return client.ObjectKeyFromObject(o).String()
 }

--- a/internal/controller/routerconfiguration/reconcile_test.go
+++ b/internal/controller/routerconfiguration/reconcile_test.go
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package routerconfiguration
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openperouter/openperouter/api/v1alpha1"
+	"github.com/openperouter/openperouter/internal/conversion"
+	openpeerrors "github.com/openperouter/openperouter/internal/errors"
+	"github.com/openperouter/openperouter/internal/frr"
+)
+
+var noopUpdater = frr.ConfigUpdater(func(_ context.Context, _ string) error {
+	return nil
+})
+
+var failingUpdater = frr.ConfigUpdater(func(_ context.Context, _ string) error {
+	return fmt.Errorf("frr-reload failed")
+})
+
+var noopHostConfigurator = HostConfigurator(func(_ context.Context, _ interfacesConfiguration) error {
+	return nil
+})
+
+func TestReconcilePerResourceErrors(t *testing.T) {
+	tests := []struct {
+		name             string
+		l3VNIs           []v1alpha1.L3VNI
+		l2VNIs           []v1alpha1.L2VNI
+		l3Passthroughs   []v1alpha1.L3Passthrough
+		expectedFailures []v1alpha1.FailedResource
+	}{
+		{
+			name: "all valid L3VNIs pass through",
+			l3VNIs: []v1alpha1.L3VNI{
+				l3VNI("vni-a", "vrfA", 100),
+				l3VNI("vni-b", "vrfB", 200),
+			},
+		},
+		{
+			name: "duplicate vni within L3VNIs skips second",
+			l3VNIs: []v1alpha1.L3VNI{
+				l3VNI("first", "vrfA", 100),
+				l3VNI("second", "vrfB", 100),
+			},
+			expectedFailures: []v1alpha1.FailedResource{
+				{Kind: openpeerrors.KindL3VNI, Name: "second", Reason: v1alpha1.FailedResourceReasonValidationFailed,
+					Message: "duplicate vni 100:L3VNI/first"},
+			},
+		},
+		{
+			name: "invalid VRF name skips L3VNI",
+			l3VNIs: []v1alpha1.L3VNI{
+				l3VNI("bad-name", "this-is-way-too-long-for-interface", 100),
+				l3VNI("good", "vrfA", 200),
+			},
+			expectedFailures: []v1alpha1.FailedResource{
+				{Kind: openpeerrors.KindL3VNI, Name: "bad-name", Reason: v1alpha1.FailedResourceReasonValidationFailed,
+					Message: "invalid vrf name for vni \"bad-name\", vrf \"this-is-way-too-long-for-interface\": interface name this-is-way-too-long-for-interface can't be longer than 15 characters"},
+			},
+		},
+		{
+			name: "valid connected and disconnected L2VNIs",
+			l3VNIs: []v1alpha1.L3VNI{
+				l3VNI("l3-a", "vrfA", 100),
+			},
+			l2VNIs: []v1alpha1.L2VNI{
+				l2VNI("connected", new("vrfA"), 200),
+				l2VNI("disconnected", nil, 201),
+			},
+		},
+		{
+			name: "duplicate vni within L2VNIs skips second",
+			l2VNIs: []v1alpha1.L2VNI{
+				l2VNI("first", nil, 200),
+				l2VNI("second", nil, 200),
+			},
+			expectedFailures: []v1alpha1.FailedResource{
+				{Kind: openpeerrors.KindL2VNI, Name: "second", Reason: v1alpha1.FailedResourceReasonValidationFailed,
+					Message: "duplicate vni 200:L2VNI/first"},
+			},
+		},
+		{
+			name: "cross-type VNI conflict skips L2VNI",
+			l3VNIs: []v1alpha1.L3VNI{
+				l3VNI("good-l3", "vrfA", 100),
+				l3VNI("conflict-l3", "vrfB", 300),
+			},
+			l2VNIs: []v1alpha1.L2VNI{
+				l2VNI("good-l2", nil, 200),
+				l2VNI("conflict-l2", nil, 300),
+			},
+			expectedFailures: []v1alpha1.FailedResource{
+				{Kind: openpeerrors.KindL2VNI, Name: "conflict-l2", Reason: v1alpha1.FailedResourceReasonValidationFailed,
+					Message: "duplicate vni 300:L3VNI/conflict-l3"},
+			},
+		},
+		{
+			name: "more than one passthrough skips all",
+			l3Passthroughs: []v1alpha1.L3Passthrough{
+				{ObjectMeta: metav1.ObjectMeta{Name: "pt-a"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "pt-b"}},
+			},
+			expectedFailures: []v1alpha1.FailedResource{
+				{Kind: openpeerrors.KindL3Passthrough, Name: "pt-a", Reason: v1alpha1.FailedResourceReasonValidationFailed,
+					Message: "can't have more than one l3passthrough per node"},
+				{Kind: openpeerrors.KindL3Passthrough, Name: "pt-b", Reason: v1alpha1.FailedResourceReasonValidationFailed,
+					Message: "can't have more than one l3passthrough per node"},
+			},
+		},
+		{
+			name: "duplicate VRF skips second L3VNI",
+			l3VNIs: []v1alpha1.L3VNI{
+				l3VNI("first", "same-vrf", 100),
+				l3VNI("second", "same-vrf", 200),
+			},
+			expectedFailures: []v1alpha1.FailedResource{
+				{Kind: openpeerrors.KindL3VNI, Name: "second", Reason: v1alpha1.FailedResourceReasonValidationFailed,
+					Message: `more than one L3VNI detected in VRF "same-vrf": "/first" already exists`},
+			},
+		},
+		{
+			name: "L2VNI with no valid L3VNI reports DependencyFailed",
+			l3VNIs: []v1alpha1.L3VNI{
+				l3VNI("good-l3", "vrfA", 100),
+			},
+			l2VNIs: []v1alpha1.L2VNI{
+				l2VNI("good-l2", new("vrfA"), 200),
+				l2VNI("orphan-l2", new("vrfMissing"), 300),
+			},
+			expectedFailures: []v1alpha1.FailedResource{
+				{Kind: openpeerrors.KindL2VNI, Name: "orphan-l2", Reason: v1alpha1.FailedResourceReasonDependencyFailed,
+					Message: `no valid L3VNI for L3 domain "vrfMissing"`},
+			},
+		},
+		{
+			name: "VRF subnet overlap reports all resources in failed VRF",
+			l3VNIs: []v1alpha1.L3VNI{
+				l3VNI("good-l3", "vrfGood", 100),
+				l3VNI("bad-l3", "vrfBad", 200),
+			},
+			l2VNIs: []v1alpha1.L2VNI{
+				l2VNIWithGateway("good-l2", "vrfGood", 300, []string{"10.0.1.1/24"}),
+				l2VNIWithGateway("bad-l2-1", "vrfBad", 400, []string{"10.0.2.1/24"}),
+				l2VNIWithGateway("bad-l2-2", "vrfBad", 500, []string{"10.0.2.100/24"}),
+			},
+			expectedFailures: []v1alpha1.FailedResource{
+				{Kind: openpeerrors.KindL3VNI, Name: "bad-l3", Reason: v1alpha1.FailedResourceReasonValidationFailed,
+					Message: `subnet overlap in VRF "vrfBad": IPNet 10.0.2.0/24 (L2VNI /bad-l2-2) overlaps with IPNet 10.0.2.0/24 (L2VNI /bad-l2-1)`},
+				{Kind: openpeerrors.KindL2VNI, Name: "bad-l2-1", Reason: v1alpha1.FailedResourceReasonValidationFailed,
+					Message: `subnet overlap in VRF "vrfBad": IPNet 10.0.2.0/24 (L2VNI /bad-l2-2) overlaps with IPNet 10.0.2.0/24 (L2VNI /bad-l2-1)`},
+				{Kind: openpeerrors.KindL2VNI, Name: "bad-l2-2", Reason: v1alpha1.FailedResourceReasonValidationFailed,
+					Message: `subnet overlap in VRF "vrfBad": IPNet 10.0.2.0/24 (L2VNI /bad-l2-2) overlaps with IPNet 10.0.2.0/24 (L2VNI /bad-l2-1)`},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := conversion.APIConfigData{
+				L3VNIs:        tt.l3VNIs,
+				L2VNIs:        tt.l2VNIs,
+				L3Passthrough: tt.l3Passthroughs,
+			}
+			reconcileErr := Reconcile(context.Background(), config, 0, "",
+				"", "", noopUpdater, noopHostConfigurator)
+
+			failures := openpeerrors.CollectFailures(reconcileErr)
+
+			if !reflect.DeepEqual(failures, tt.expectedFailures) {
+				t.Errorf("FailedResources mismatch:\n  got:  %+v\n  want: %+v", failures, tt.expectedFailures)
+			}
+		})
+	}
+}
+
+func TestReconcileFrrReloadFailure(t *testing.T) {
+	reconcileErr := Reconcile(context.Background(), conversion.APIConfigData{}, 0, "",
+		"", "", failingUpdater, noopHostConfigurator)
+	if reconcileErr == nil {
+		t.Fatal("expected error from FRR reload failure")
+	}
+
+	if !strings.Contains(reconcileErr.Error(), "failed to update the frr configuration") {
+		t.Errorf("expected FRR error message, got: %s", reconcileErr.Error())
+	}
+
+	failures := openpeerrors.CollectFailures(reconcileErr)
+	if len(failures) != 0 {
+		t.Errorf("expected no resource failures for FRR error, got: %+v", failures)
+	}
+}
+
+func l3VNI(name, vrf string, vni int32) v1alpha1.L3VNI {
+	return v1alpha1.L3VNI{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       v1alpha1.L3VNISpec{VRF: vrf, VNI: vni},
+	}
+}
+
+func l2VNI(name string, vrf *string, vni int32) v1alpha1.L2VNI {
+	return v1alpha1.L2VNI{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       v1alpha1.L2VNISpec{VRF: vrf, VNI: vni},
+	}
+}
+
+func l2VNIWithGateway(name, vrf string, vni int32, gatewayIPs []string) v1alpha1.L2VNI {
+	return v1alpha1.L2VNI{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: v1alpha1.L2VNISpec{
+			VRF:          new(vrf),
+			VNI:          vni,
+			L2GatewayIPs: gatewayIPs,
+		},
+	}
+}

--- a/internal/controller/routerconfiguration/static_configuration_controller.go
+++ b/internal/controller/routerconfiguration/static_configuration_controller.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	openpeerrors "github.com/openperouter/openperouter/internal/errors"
 	"github.com/openperouter/openperouter/internal/frrconfig"
 )
 
@@ -74,7 +75,10 @@ func (r *StaticConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	updater := frrconfig.UpdaterForSocket(r.FRRReloadSocket, r.FRRConfigPath)
 
-	err = Reconcile(ctx, apiConfig, r.NodeIndex, r.LogLevel, r.FRRConfigPath, targetNS, updater)
+	err = Reconcile(ctx, apiConfig, r.NodeIndex, r.LogLevel, r.FRRConfigPath, targetNS, updater, configureInterfaces)
+	for _, f := range openpeerrors.CollectFailures(err) {
+		logger.Warn("resource skipped", "kind", f.Kind, "name", f.Name, "reason", f.Reason, "message", f.Message)
+	}
 	if nonRecoverableHostError(err) {
 		logger.Error("non recoverable error", "error", err)
 		if err := router.HandleNonRecoverableError(ctx); err != nil {

--- a/internal/controller/routerconfiguration/status.go
+++ b/internal/controller/routerconfiguration/status.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package routerconfiguration
+
+import (
+	openpeerrors "github.com/openperouter/openperouter/internal/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openperouter/openperouter/api/v1alpha1"
+)
+
+func buildStatus(err error) v1alpha1.RouterNodeConfigurationStatusStatus {
+	var s v1alpha1.RouterNodeConfigurationStatusStatus
+
+	if err == nil {
+		setReady(&s, v1alpha1.ConditionReasonConfigSuccessful, "All configuration applied successfully")
+		return s
+	}
+
+	s.FailedResources = openpeerrors.CollectFailures(err)
+	reason, msg := degradedReason(err, s.FailedResources)
+	setDegraded(&s, reason, msg)
+	return s
+}
+
+func degradedReason(err error, failures []v1alpha1.FailedResource) (string, string) {
+	if openpeerrors.HasUnderlayFailure(err) {
+		return v1alpha1.ConditionReasonUnderlayFailed, "Underlay failed validation, existing FRR configuration left as-is"
+	}
+	if len(failures) > 0 {
+		return v1alpha1.ConditionReasonConfigFailed, "Some resources failed validation, see status.failedResources for details"
+	}
+	return v1alpha1.ConditionReasonConfigFailed, err.Error()
+}
+
+func setDegraded(s *v1alpha1.RouterNodeConfigurationStatusStatus, reason, message string) {
+	apimeta.SetStatusCondition(&s.Conditions, metav1.Condition{
+		Type:    v1alpha1.ConditionTypeReady,
+		Status:  metav1.ConditionFalse,
+		Reason:  reason,
+		Message: message,
+	})
+	apimeta.SetStatusCondition(&s.Conditions, metav1.Condition{
+		Type:    v1alpha1.ConditionTypeDegraded,
+		Status:  metav1.ConditionTrue,
+		Reason:  reason,
+		Message: message,
+	})
+}
+
+func setReady(s *v1alpha1.RouterNodeConfigurationStatusStatus, reason, message string) {
+	apimeta.SetStatusCondition(&s.Conditions, metav1.Condition{
+		Type:    v1alpha1.ConditionTypeReady,
+		Status:  metav1.ConditionTrue,
+		Reason:  reason,
+		Message: message,
+	})
+	apimeta.SetStatusCondition(&s.Conditions, metav1.Condition{
+		Type:    v1alpha1.ConditionTypeDegraded,
+		Status:  metav1.ConditionFalse,
+		Reason:  reason,
+		Message: message,
+	})
+}

--- a/internal/controller/routerconfiguration/status_test.go
+++ b/internal/controller/routerconfiguration/status_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package routerconfiguration
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openperouter/openperouter/api/v1alpha1"
+	openpeerrors "github.com/openperouter/openperouter/internal/errors"
+)
+
+func TestBuildStatus(t *testing.T) {
+	underlayErr := &openpeerrors.ResourceError{
+		Obj: v1alpha1.FailedResource{
+			Kind: openpeerrors.KindUnderlay, Name: "my-underlay",
+			Reason: v1alpha1.FailedResourceReasonValidationFailed, Message: "bad ASN",
+		},
+	}
+
+	partialErr := errors.Join(
+		&openpeerrors.ResourceError{
+			Obj: v1alpha1.FailedResource{
+				Kind: openpeerrors.KindL3VNI, Name: "bad-vni",
+				Reason: v1alpha1.FailedResourceReasonValidationFailed, Message: "invalid vrf",
+			},
+		},
+		&openpeerrors.ResourceError{
+			Obj: v1alpha1.FailedResource{
+				Kind: openpeerrors.KindL2VNI, Name: "orphan",
+				Reason: v1alpha1.FailedResourceReasonDependencyFailed, Message: "no L3VNI",
+			},
+		},
+	)
+
+	tests := []struct {
+		name                    string
+		reconcileErr            error
+		expectedReady           metav1.ConditionStatus
+		expectedDegraded        metav1.ConditionStatus
+		expectedReadyReason     string
+		expectedReadyMessage    string
+		expectedFailedResources []v1alpha1.FailedResource
+	}{
+		{
+			name:                 "all resources valid",
+			reconcileErr:         nil,
+			expectedReady:        metav1.ConditionTrue,
+			expectedDegraded:     metav1.ConditionFalse,
+			expectedReadyReason:  v1alpha1.ConditionReasonConfigSuccessful,
+			expectedReadyMessage: "All configuration applied successfully",
+		},
+		{
+			name:                 "underlay failed",
+			reconcileErr:         underlayErr,
+			expectedReady:        metav1.ConditionFalse,
+			expectedDegraded:     metav1.ConditionTrue,
+			expectedReadyReason:  v1alpha1.ConditionReasonUnderlayFailed,
+			expectedReadyMessage: "Underlay failed validation, existing FRR configuration left as-is",
+			expectedFailedResources: []v1alpha1.FailedResource{
+				{Kind: openpeerrors.KindUnderlay, Name: "my-underlay", Reason: v1alpha1.FailedResourceReasonValidationFailed, Message: "bad ASN"},
+			},
+		},
+		{
+			name:                 "partial failure",
+			reconcileErr:         partialErr,
+			expectedReady:        metav1.ConditionFalse,
+			expectedDegraded:     metav1.ConditionTrue,
+			expectedReadyReason:  v1alpha1.ConditionReasonConfigFailed,
+			expectedReadyMessage: "Some resources failed validation, see status.failedResources for details",
+			expectedFailedResources: []v1alpha1.FailedResource{
+				{Kind: openpeerrors.KindL3VNI, Name: "bad-vni", Reason: v1alpha1.FailedResourceReasonValidationFailed, Message: "invalid vrf"},
+				{Kind: openpeerrors.KindL2VNI, Name: "orphan", Reason: v1alpha1.FailedResourceReasonDependencyFailed, Message: "no L3VNI"},
+			},
+		},
+		{
+			name:                 "reconcile hard error",
+			reconcileErr:         fmt.Errorf("failed to reload frr config: exit status 1"),
+			expectedReady:        metav1.ConditionFalse,
+			expectedDegraded:     metav1.ConditionTrue,
+			expectedReadyReason:  v1alpha1.ConditionReasonConfigFailed,
+			expectedReadyMessage: "failed to reload frr config: exit status 1",
+		},
+		{
+			name:                 "internal error",
+			reconcileErr:         fmt.Errorf("failed to get router pod instance: pod not found"),
+			expectedReady:        metav1.ConditionFalse,
+			expectedDegraded:     metav1.ConditionTrue,
+			expectedReadyReason:  v1alpha1.ConditionReasonConfigFailed,
+			expectedReadyMessage: "failed to get router pod instance: pod not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := buildStatus(tt.reconcileErr)
+
+			ready := apimeta.FindStatusCondition(s.Conditions, v1alpha1.ConditionTypeReady)
+			if ready == nil {
+				t.Fatal("Ready condition not set")
+			}
+			if ready.Status != tt.expectedReady {
+				t.Errorf("Ready status = %s, want %s", ready.Status, tt.expectedReady)
+			}
+			if ready.Reason != tt.expectedReadyReason {
+				t.Errorf("Ready reason = %s, want %s", ready.Reason, tt.expectedReadyReason)
+			}
+			if ready.Message != tt.expectedReadyMessage {
+				t.Errorf("Ready message = %q, want %q", ready.Message, tt.expectedReadyMessage)
+			}
+
+			degraded := apimeta.FindStatusCondition(s.Conditions, v1alpha1.ConditionTypeDegraded)
+			if degraded == nil {
+				t.Fatal("Degraded condition not set")
+			}
+			if degraded.Status != tt.expectedDegraded {
+				t.Errorf("Degraded status = %s, want %s", degraded.Status, tt.expectedDegraded)
+			}
+
+			if !reflect.DeepEqual(s.FailedResources, tt.expectedFailedResources) {
+				t.Errorf("FailedResources mismatch:\n  got:  %+v\n  want: %+v", s.FailedResources, tt.expectedFailedResources)
+			}
+		})
+	}
+}

--- a/internal/controller/routerconfiguration/underlay_vni_controller.go
+++ b/internal/controller/routerconfiguration/underlay_vni_controller.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/openperouter/openperouter/api/v1alpha1"
 	"github.com/openperouter/openperouter/internal/conversion"
+	openpeerrors "github.com/openperouter/openperouter/internal/errors"
 	"github.com/openperouter/openperouter/internal/filter"
 	"github.com/openperouter/openperouter/internal/frrconfig"
 	"github.com/openperouter/openperouter/internal/staticconfiguration"
@@ -85,6 +86,31 @@ func (r *PERouterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	ctx = context.WithValue(ctx, requestKey("request"), req.String())
 
+	result, err := r.reconcile(ctx, logger)
+
+	// Best-effort status write: non-recoverable errors must never requeue,
+	// so we ignore any status update failure here.
+	if nonRecoverableHostError(err) {
+		_ = r.reconcileNodeStatus(ctx, err)
+		return ctrl.Result{}, nil
+	}
+
+	if statusErr := r.reconcileNodeStatus(ctx, err); statusErr != nil {
+		return ctrl.Result{}, errors.Join(err, statusErr)
+	}
+
+	if err == nil {
+		return result, nil
+	}
+
+	if openpeerrors.HasUnderlayFailure(err) {
+		return ctrl.Result{}, nil
+	}
+
+	return ctrl.Result{}, err
+}
+
+func (r *PERouterReconciler) reconcile(ctx context.Context, logger *slog.Logger) (ctrl.Result, error) {
 	config, err := r.getConfigFromAPI(ctx, logger)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -123,27 +149,18 @@ func (r *PERouterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, err
 	}
 
-	err = Reconcile(ctx, config, nodeIndex, r.LogLevel, r.FRRConfigPath, targetNS, updater)
+	err = Reconcile(ctx, config, nodeIndex, r.LogLevel, r.FRRConfigPath, targetNS, updater, configureInterfaces)
 	if nonRecoverableHostError(err) {
 		logger.Error("non recoverable error", "error", err)
 		if err := router.HandleNonRecoverableError(ctx); err != nil {
 			slog.Error("failed to handle non recoverable error", "error", err)
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, err
 	}
-	var errs []error
+
 	if err != nil {
-		errs = append(errs, err)
-	}
-
-	if err := r.reconcileNodeStatus(ctx); err != nil {
-		errs = append(errs, err)
-	}
-
-	if len(errs) > 0 {
-		err := errors.Join(errs...)
-		slog.Error("failed to configure the host", "error", err)
+		logger.Error("failed to reconcile host configuration", "error", err)
 		return ctrl.Result{}, err
 	}
 

--- a/internal/conversion/host_conversion.go
+++ b/internal/conversion/host_conversion.go
@@ -83,6 +83,7 @@ func APItoHostConfig(nodeIndex int, targetNS string, apiConfig APIConfigData) (H
 				VNI:       vni.Spec.VNI,
 				VXLanPort: vni.Spec.VXLanPort,
 			},
+			Name: vni.Name,
 		}
 		if vni.Spec.HostSession == nil {
 			res.L3VNIs = append(res.L3VNIs, v)
@@ -147,6 +148,7 @@ func tunnelEndpointToHost(underlay v1alpha1.Underlay, nodeIndex int) (hostnetwor
 
 func convertL2VNI(l2vni v1alpha1.L2VNI, targetNS string, vtepIP string) (hostnetwork.L2VNIParams, error) {
 	vni := hostnetwork.L2VNIParams{
+		Name: l2vni.Name,
 		VNIParams: hostnetwork.VNIParams{
 			TargetNS:  targetNS,
 			VTEPIP:    vtepIP,

--- a/internal/conversion/host_conversion_test.go
+++ b/internal/conversion/host_conversion_test.go
@@ -289,6 +289,7 @@ func TestAPItoHostConfig(t *testing.T) {
 			wantL3VNIParams: []hostnetwork.L3VNIParams{},
 			wantL2VNIParams: []hostnetwork.L2VNIParams{
 				{
+					Name: "my-l2vni",
 					VNIParams: hostnetwork.VNIParams{
 						VRF:       "",
 						TargetNS:  "namespace",

--- a/internal/conversion/validate_passthrough.go
+++ b/internal/conversion/validate_passthrough.go
@@ -3,11 +3,13 @@
 package conversion
 
 import (
+	"errors"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openperouter/openperouter/api/v1alpha1"
+	openpeerrors "github.com/openperouter/openperouter/internal/errors"
 	"github.com/openperouter/openperouter/internal/filter"
 )
 
@@ -17,17 +19,27 @@ func ValidatePassthroughsForNodes(nodes []corev1.Node, underlays []v1alpha1.L3Pa
 		if err != nil {
 			return fmt.Errorf("failed to filter underlays for node %q: %w", node.Name, err)
 		}
-		if err := ValidatePassthroughs(filteredPassThroughs); err != nil {
+		if _, err := FilterValidPassthroughs(filteredPassThroughs); err != nil {
 			return fmt.Errorf("failed to validate underlays for node %q: %w", node.Name, err)
 		}
 	}
 	return nil
 }
 
-func ValidatePassthroughs(l3Passthrough []v1alpha1.L3Passthrough) error {
+func FilterValidPassthroughs(l3Passthrough []v1alpha1.L3Passthrough) ([]v1alpha1.L3Passthrough, error) {
 	if len(l3Passthrough) > 1 {
-		return fmt.Errorf("can't have more than one l3passthrough per node")
+		allErrors := make([]error, 0, len(l3Passthrough))
+		for _, pt := range l3Passthrough {
+			allErrors = append(allErrors, &openpeerrors.ResourceError{
+				Obj: v1alpha1.FailedResource{
+					Kind:    v1alpha1.FailedResourceKind("L3Passthrough"),
+					Name:    pt.Name,
+					Reason:  v1alpha1.FailedResourceReasonValidationFailed,
+					Message: "can't have more than one l3passthrough per node",
+				},
+			})
+		}
+		return nil, errors.Join(allErrors...)
 	}
-	// host sessions are validated in ValidateHostSessions
-	return nil
+	return l3Passthrough, nil
 }

--- a/internal/conversion/validate_passthrough_test.go
+++ b/internal/conversion/validate_passthrough_test.go
@@ -4,6 +4,7 @@ package conversion
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -55,7 +56,7 @@ func TestValidatePassthroughsForNodes(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: fmt.Errorf("failed to validate underlays for node \"node-1\": can't have more than one l3passthrough per node"),
+			expectedErr: fmt.Errorf("can't have more than one l3passthrough per node"),
 		},
 		{
 			name: "two nodes each with one matching passthrough",
@@ -118,7 +119,7 @@ func TestValidatePassthroughsForNodes(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: fmt.Errorf("failed to validate underlays for node \"node-1\": can't have more than one l3passthrough per node"),
+			expectedErr: fmt.Errorf("can't have more than one l3passthrough per node"),
 		},
 		{
 			name: "invalid node selector expression",
@@ -148,8 +149,8 @@ func TestValidatePassthroughsForNodes(t *testing.T) {
 				if err == nil {
 					t.Fatalf("expected error %q but got none", tt.expectedErr)
 				}
-				if err.Error() != tt.expectedErr.Error() {
-					t.Fatalf("expected error %q, got: %q", tt.expectedErr, err)
+				if !strings.Contains(err.Error(), tt.expectedErr.Error()) {
+					t.Fatalf("expected error containing %q, got: %q", tt.expectedErr, err)
 				}
 				return
 			}
@@ -160,7 +161,7 @@ func TestValidatePassthroughsForNodes(t *testing.T) {
 	}
 }
 
-func TestValidatePassthroughs(t *testing.T) {
+func TestFilterValidPassthroughs(t *testing.T) {
 	tests := []struct {
 		name           string
 		l3Passthroughs []v1alpha1.L3Passthrough
@@ -192,13 +193,13 @@ func TestValidatePassthroughs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidatePassthroughs(tt.l3Passthroughs)
+			_, err := FilterValidPassthroughs(tt.l3Passthroughs)
 			if tt.expectedErr != nil {
 				if err == nil {
 					t.Fatalf("expected error %q but got none", tt.expectedErr)
 				}
-				if err.Error() != tt.expectedErr.Error() {
-					t.Fatalf("expected error %q, got: %q", tt.expectedErr, err)
+				if !strings.Contains(err.Error(), tt.expectedErr.Error()) {
+					t.Fatalf("expected error containing %q, got: %q", tt.expectedErr, err)
 				}
 				return
 			}

--- a/internal/conversion/validate_underlay.go
+++ b/internal/conversion/validate_underlay.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openperouter/openperouter/api/v1alpha1"
+	openpeerrors "github.com/openperouter/openperouter/internal/errors"
 	"github.com/openperouter/openperouter/internal/filter"
 	"github.com/openperouter/openperouter/internal/ipfamily"
 )
@@ -30,9 +31,26 @@ func ValidateUnderlays(underlays []v1alpha1.Underlay) error {
 		return nil
 	}
 	if len(underlays) > 1 {
-		return fmt.Errorf("can't have more than one underlay per node")
+		return &openpeerrors.ResourceError{
+			Obj: v1alpha1.FailedResource{
+				Kind:    v1alpha1.FailedResourceKind("Underlay"),
+				Name:    underlays[0].Name,
+				Reason:  v1alpha1.FailedResourceReasonValidationFailed,
+				Message: "can't have more than one underlay per node",
+			},
+		}
 	}
-	return validateUnderlay(underlays[0])
+	if err := validateUnderlay(underlays[0]); err != nil {
+		return &openpeerrors.ResourceError{
+			Obj: v1alpha1.FailedResource{
+				Kind:    v1alpha1.FailedResourceKind("Underlay"),
+				Name:    underlays[0].Name,
+				Reason:  v1alpha1.FailedResourceReasonValidationFailed,
+				Message: err.Error(),
+			},
+		}
+	}
+	return nil
 }
 
 func validateUnderlay(underlay v1alpha1.Underlay) error {

--- a/internal/conversion/validate_vni.go
+++ b/internal/conversion/validate_vni.go
@@ -4,6 +4,7 @@ package conversion
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net"
 	"regexp"
@@ -16,6 +17,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/openperouter/openperouter/api/v1alpha1"
+	openpeerrors "github.com/openperouter/openperouter/internal/errors"
 	"github.com/openperouter/openperouter/internal/filter"
 	"github.com/openperouter/openperouter/internal/ipfamily"
 )
@@ -33,7 +35,10 @@ func ValidateL3VNIsForNodes(nodes []corev1.Node, underlays []v1alpha1.L3VNI) err
 		if err != nil {
 			return fmt.Errorf("failed to filter underlays for node %q: %w", node.Name, err)
 		}
-		if err := ValidateL3VNIs(filteredL3VNIs); err != nil {
+		if _, err := FilterValidL3VNIs(filteredL3VNIs); err != nil {
+			return fmt.Errorf("failed to validate underlays for node %q: %w", node.Name, err)
+		}
+		if _, _, err := FilterUniqueVNIs(filteredL3VNIs, nil); err != nil {
 			return fmt.Errorf("failed to validate underlays for node %q: %w", node.Name, err)
 		}
 	}
@@ -41,11 +46,34 @@ func ValidateL3VNIsForNodes(nodes []corev1.Node, underlays []v1alpha1.L3VNI) err
 	return nil
 }
 
-// ValidateL3VNIs runs L3VNI specific validation.
-func ValidateL3VNIs(l3Vnis []v1alpha1.L3VNI) error {
-	vnis := vnisFromL3VNIs(l3Vnis)
-	if err := validateVNIs(vnis); err != nil {
-		return err
+// FilterValidL3VNIs validates L3VNIs per-field and returns the valid resources
+// alongside per-resource errors.
+func FilterValidL3VNIs(l3Vnis []v1alpha1.L3VNI) ([]v1alpha1.L3VNI, error) {
+	var valid []v1alpha1.L3VNI
+	var allErrors []error
+	for _, l3 := range l3Vnis {
+		if err := validateL3VNI(l3); err != nil {
+			allErrors = append(allErrors, &openpeerrors.ResourceError{
+				Obj: v1alpha1.FailedResource{
+					Kind: "L3VNI", Name: l3.Name,
+					Reason: v1alpha1.FailedResourceReasonValidationFailed, Message: err.Error(),
+				},
+			})
+			continue
+		}
+		valid = append(valid, l3)
+	}
+	return valid, errors.Join(allErrors...)
+}
+
+// validateL3VNI validates a single L3VNI's fields (VRF name, route targets).
+func validateL3VNI(l3Vni v1alpha1.L3VNI) error {
+	vni := vniFromL3VNI(l3Vni)
+	if err := isValidInterfaceName(vni.vrfName); err != nil {
+		return fmt.Errorf("invalid vrf name for vni %q, vrf %q: %w", vni.name, vni.vrfName, err)
+	}
+	if err := ValidateRouteTargets(vni); err != nil {
+		return fmt.Errorf("invalid route targets for vni %q: %w", vni.name, err)
 	}
 	return nil
 }
@@ -57,41 +85,101 @@ func ValidateL2VNIsForNodes(nodes []corev1.Node, underlays []v1alpha1.L2VNI) err
 		if err != nil {
 			return fmt.Errorf("failed to filter underlays for node %q: %w", node.Name, err)
 		}
-		if err := ValidateL2VNIs(filteredL2VNIs); err != nil {
+		if _, err := FilterValidL2VNIs(filteredL2VNIs); err != nil {
+			return fmt.Errorf("failed to validate underlays for node %q: %w", node.Name, err)
+		}
+		if _, _, err := FilterUniqueVNIs(nil, filteredL2VNIs); err != nil {
 			return fmt.Errorf("failed to validate underlays for node %q: %w", node.Name, err)
 		}
 	}
 	return nil
 }
 
-// ValidateL2VNIs runs L2VNI specific validation.
-func ValidateL2VNIs(l2Vnis []v1alpha1.L2VNI) error {
-	// Convert L2VNIs to vni structs
-	vnis := vnisFromL2VNIs(l2Vnis)
+// FilterValidL2VNIs validates L2VNIs per-field and returns the valid resources
+// alongside per-resource errors.
+func FilterValidL2VNIs(l2Vnis []v1alpha1.L2VNI) ([]v1alpha1.L2VNI, error) {
+	var valid []v1alpha1.L2VNI
+	var allErrors []error
+	for _, l2 := range l2Vnis {
+		if err := validateL2VNI(l2); err != nil {
+			allErrors = append(allErrors, &openpeerrors.ResourceError{
+				Obj: v1alpha1.FailedResource{
+					Kind: "L2VNI", Name: l2.Name,
+					Reason: v1alpha1.FailedResourceReasonValidationFailed, Message: err.Error(),
+				},
+			})
+			continue
+		}
+		valid = append(valid, l2)
+	}
+	return valid, errors.Join(allErrors...)
+}
 
-	// Perform common validation
-	if err := validateVNIs(vnis); err != nil {
-		return err
+// FilterUniqueVNIs removes VNIs with duplicate VNI numbers. L3VNIs are
+// processed first and take priority; L2VNIs that collide with an L3VNI
+// are discarded.
+func FilterUniqueVNIs(l3Vnis []v1alpha1.L3VNI, l2Vnis []v1alpha1.L2VNI) ([]v1alpha1.L3VNI, []v1alpha1.L2VNI, error) {
+	existingVNIs := map[int32]string{}
+	reason := v1alpha1.FailedResourceReasonValidationFailed
+	var allErrors []error
+
+	var validL3 []v1alpha1.L3VNI
+	for _, l3 := range l3Vnis {
+		if existing, ok := existingVNIs[l3.Spec.VNI]; ok {
+			allErrors = append(allErrors, &openpeerrors.ResourceError{
+				Obj: v1alpha1.FailedResource{
+					Kind: "L3VNI", Name: l3.Name, Reason: reason,
+					Message: fmt.Sprintf("duplicate vni %d:%s", l3.Spec.VNI, existing),
+				},
+			})
+			continue
+		}
+		existingVNIs[l3.Spec.VNI] = "L3VNI/" + l3.Name
+		validL3 = append(validL3, l3)
 	}
 
-	// Perform L2-specific validation (HostMaster and L2GatewayIPs validation)
-	for _, vni := range l2Vnis {
-		if vni.Spec.HostMaster != nil {
-			if err := validateHostMaster(vni.Name, vni.Spec.HostMaster); err != nil {
-				return err
-			}
+	var validL2 []v1alpha1.L2VNI
+	for _, l2 := range l2Vnis {
+		if existing, ok := existingVNIs[l2.Spec.VNI]; ok {
+			allErrors = append(allErrors, &openpeerrors.ResourceError{
+				Obj: v1alpha1.FailedResource{
+					Kind: "L2VNI", Name: l2.Name, Reason: reason,
+					Message: fmt.Sprintf("duplicate vni %d:%s", l2.Spec.VNI, existing),
+				},
+			})
+			continue
 		}
-		if len(vni.Spec.L2GatewayIPs) > 0 && !hasVRF(vni) {
-			return fmt.Errorf("l2gatewayips cannot be set without spec.vrf for vni %q", vni.Name)
-		}
-		if len(vni.Spec.L2GatewayIPs) > 0 {
-			_, err := ipfamily.ForCIDRStrings(vni.Spec.L2GatewayIPs...)
-			if err != nil {
-				return fmt.Errorf("invalid l2gatewayips for vni %q = %v: %w", vni.Name, vni.Spec.L2GatewayIPs, err)
-			}
-		}
+		existingVNIs[l2.Spec.VNI] = "L2VNI/" + l2.Name
+		validL2 = append(validL2, l2)
 	}
 
+	return validL3, validL2, errors.Join(allErrors...)
+}
+
+// validateL2VNI validates a single L2VNI's fields (VRF name, route targets, HostMaster, L2GatewayIPs).
+func validateL2VNI(l2Vni v1alpha1.L2VNI) error {
+	vni := vniFromL2VNI(l2Vni)
+	if hasVRF(l2Vni) {
+		if err := isValidInterfaceName(vni.vrfName); err != nil {
+			return fmt.Errorf("invalid vrf name for vni %q, vrf %q: %w", vni.name, vni.vrfName, err)
+		}
+	}
+	if err := ValidateRouteTargets(vni); err != nil {
+		return fmt.Errorf("invalid route targets for vni %q: %w", vni.name, err)
+	}
+	if l2Vni.Spec.HostMaster != nil {
+		if err := validateHostMaster(l2Vni.Name, l2Vni.Spec.HostMaster); err != nil {
+			return err
+		}
+	}
+	if len(l2Vni.Spec.L2GatewayIPs) > 0 && !hasVRF(l2Vni) {
+		return fmt.Errorf("l2gatewayips cannot be set without spec.vrf for vni %q", l2Vni.Name)
+	}
+	if len(l2Vni.Spec.L2GatewayIPs) > 0 {
+		if _, err := ipfamily.ForCIDRStrings(l2Vni.Spec.L2GatewayIPs...); err != nil {
+			return fmt.Errorf("invalid l2gatewayips for vni %q = %v: %w", l2Vni.Name, l2Vni.Spec.L2GatewayIPs, err)
+		}
+	}
 	return nil
 }
 
@@ -106,29 +194,87 @@ func ValidateVRFsForNodes(nodes []corev1.Node, l2vnis []v1alpha1.L2VNI, l3vnis [
 		if err != nil {
 			return fmt.Errorf("failed to filter l3vnis for node %q: %w", node.Name, err)
 		}
-		if err := ValidateVRFs(filteredL2VNIs, filteredL3VNIs); err != nil {
+		if _, err := FilterUniqueVRFs(filteredL3VNIs); err != nil {
+			return fmt.Errorf("failed to validate VRFs for node %q: %w", node.Name, err)
+		}
+		if _, _, err := FilterValidVRFSubnets(filteredL3VNIs, filteredL2VNIs); err != nil {
 			return fmt.Errorf("failed to validate VRFs for node %q: %w", node.Name, err)
 		}
 	}
 	return nil
 }
 
-// ValidateVRFs validates that the information in each VRF as a whole is correct.
-// Note that when ValidateVRFs is called, L3VNIs and L2VNIs should already have been verified for correctness
-// by ValidateL2VNIs() and ValidateL3VNIs() (such as individual subnets parse correctly, no duplicate AF per VNI).
-func ValidateVRFs(l2Vnis []v1alpha1.L2VNI, l3Vnis []v1alpha1.L3VNI) error {
-	// Make sure that there's only a single l3Vni in a given VRF.
+// FilterUniqueVRFs checks VRF uniqueness among L3VNIs and returns the valid
+// L3VNIs alongside per-resource errors for duplicates.
+func FilterUniqueVRFs(l3Vnis []v1alpha1.L3VNI) ([]v1alpha1.L3VNI, error) {
+	reason := v1alpha1.FailedResourceReasonValidationFailed
+	var allErrors []error
+
 	vrfToVNI := map[string]types.NamespacedName{}
+	var valid []v1alpha1.L3VNI
 	for _, l3Vni := range l3Vnis {
 		namespaceName := types.NamespacedName{Namespace: l3Vni.Namespace, Name: l3Vni.Name}
-		l3vni, ok := vrfToVNI[l3Vni.Spec.VRF]
+		existing, ok := vrfToVNI[l3Vni.Spec.VRF]
 		if ok {
-			return fmt.Errorf("more than one L3VNI detected in VRF %q: %s - %s", l3Vni.Spec.VRF, l3vni, namespaceName)
+			allErrors = append(allErrors, &openpeerrors.ResourceError{
+				Obj: v1alpha1.FailedResource{
+					Kind: "L3VNI", Name: l3Vni.Name, Reason: reason,
+					Message: fmt.Sprintf("more than one L3VNI detected in VRF %q: %q already exists", l3Vni.Spec.VRF, existing),
+				},
+			})
+			continue
 		}
 		vrfToVNI[l3Vni.Spec.VRF] = namespaceName
+		valid = append(valid, l3Vni)
+	}
+	return valid, errors.Join(allErrors...)
+}
+
+// FilterValidVRFSubnets checks for subnet overlaps per VRF and returns valid
+// L3VNIs, valid L2VNIs, and per-resource errors. Resources in VRFs with
+// overlapping subnets are excluded.
+func FilterValidVRFSubnets(l3Vnis []v1alpha1.L3VNI, l2Vnis []v1alpha1.L2VNI) ([]v1alpha1.L3VNI, []v1alpha1.L2VNI, error) {
+	reason := v1alpha1.FailedResourceReasonValidationFailed
+	failedVRFs := ValidateVRFSubnets(l2Vnis, l3Vnis)
+	if len(failedVRFs) == 0 {
+		return l3Vnis, l2Vnis, nil
 	}
 
-	// Make sure that there are no subnet overlaps in the VRFs.
+	var allErrors []error
+	var resultL3 []v1alpha1.L3VNI
+	for _, l3 := range l3Vnis {
+		if err, failed := failedVRFs[l3.Spec.VRF]; failed {
+			allErrors = append(allErrors, &openpeerrors.ResourceError{
+				Obj: v1alpha1.FailedResource{
+					Kind: "L3VNI", Name: l3.Name, Reason: reason, Message: err.Error(),
+				},
+			})
+			continue
+		}
+		resultL3 = append(resultL3, l3)
+	}
+
+	var resultL2 []v1alpha1.L2VNI
+	for _, l2 := range l2Vnis {
+		if hasVRF(l2) {
+			if err, failed := failedVRFs[*l2.Spec.VRF]; failed {
+				allErrors = append(allErrors, &openpeerrors.ResourceError{
+					Obj: v1alpha1.FailedResource{
+						Kind: "L2VNI", Name: l2.Name, Reason: reason, Message: err.Error(),
+					},
+				})
+				continue
+			}
+		}
+		resultL2 = append(resultL2, l2)
+	}
+
+	return resultL3, resultL2, errors.Join(allErrors...)
+}
+
+// ValidateVRFSubnets checks for subnet overlaps per VRF and returns a map of
+// VRF name to error for each VRF that has overlapping subnets.
+func ValidateVRFSubnets(l2Vnis []v1alpha1.L2VNI, l3Vnis []v1alpha1.L3VNI) map[string]error {
 	v4SubnetsForVRF := map[string]subnets{}
 	v6SubnetsForVRF := map[string]subnets{}
 	for _, l2vni := range l2Vnis {
@@ -154,19 +300,21 @@ func ValidateVRFs(l2Vnis []v1alpha1.L2VNI, l3Vnis []v1alpha1.L3VNI) error {
 			v6SubnetsForVRF[vrfName] = append(v6SubnetsForVRF[vrfName], subnetWithSource{source, subnet})
 		}
 	}
+
+	failedVRFs := map[string]error{}
 	for vrf, subnetList := range v4SubnetsForVRF {
 		subnetList.sort()
 		if err := hasSubnetOverlap(subnetList); err != nil {
-			return fmt.Errorf("subnet overlap in VRF %q: %w", vrf, err)
+			failedVRFs[vrf] = fmt.Errorf("subnet overlap in VRF %q: %w", vrf, err)
 		}
 	}
 	for vrf, subnetList := range v6SubnetsForVRF {
 		subnetList.sort()
 		if err := hasSubnetOverlap(subnetList); err != nil {
-			return fmt.Errorf("subnet overlap in VRF %q: %w", vrf, err)
+			failedVRFs[vrf] = fmt.Errorf("subnet overlap in VRF %q: %w", vrf, err)
 		}
 	}
-	return nil
+	return failedVRFs
 }
 
 // vni holds VNI validation data
@@ -178,60 +326,25 @@ type VNI struct {
 	importRTs []string
 }
 
-// vnisFromL3VNIs converts L3VNIs to vni slice
-func vnisFromL3VNIs(l3vnis []v1alpha1.L3VNI) []VNI {
-	result := make([]VNI, len(l3vnis))
-	for i, l3vni := range l3vnis {
-		result[i] = VNI{
-			name:      l3vni.Name,
-			vni:       uint32(l3vni.Spec.VNI),
-			vrfName:   l3vni.Spec.VRF,
-			exportRTs: l3vni.Spec.ExportRTs,
-			importRTs: l3vni.Spec.ImportRTs,
-		}
+func vniFromL3VNI(l3vni v1alpha1.L3VNI) VNI {
+	return VNI{
+		name:      l3vni.Name,
+		vni:       uint32(l3vni.Spec.VNI),
+		vrfName:   l3vni.Spec.VRF,
+		exportRTs: l3vni.Spec.ExportRTs,
+		importRTs: l3vni.Spec.ImportRTs,
 	}
-	return result
 }
 
-// vnisFromL2VNIs converts L2VNIs to vni slice
-func vnisFromL2VNIs(l2vnis []v1alpha1.L2VNI) []VNI {
-	result := make([]VNI, len(l2vnis))
-	for i, l2vni := range l2vnis {
-		v := VNI{
-			name: l2vni.Name,
-			vni:  uint32(l2vni.Spec.VNI),
-		}
-		if hasVRF(l2vni) {
-			v.vrfName = *l2vni.Spec.VRF
-		}
-		result[i] = v
+func vniFromL2VNI(l2vni v1alpha1.L2VNI) VNI {
+	v := VNI{
+		name: l2vni.Name,
+		vni:  uint32(l2vni.Spec.VNI),
 	}
-	return result
-}
-
-// validateVNIs performs common validation logic for VNIs
-func validateVNIs(vnis []VNI) error {
-	existingVNIs := map[uint32]string{} // a map between the given VNI number and the VNI instance it's configured in
-
-	for _, vni := range vnis {
-		if vni.vrfName != "" {
-			if err := isValidInterfaceName(vni.vrfName); err != nil {
-				return fmt.Errorf("invalid vrf name for vni %s: %s - %w", vni.name, vni.vrfName, err)
-			}
-		}
-
-		existingVNI, ok := existingVNIs[vni.vni]
-		if ok {
-			return fmt.Errorf("duplicate vni %d:%s - %s", vni.vni, existingVNI, vni.name)
-		}
-		existingVNIs[vni.vni] = vni.name
-
-		if err := ValidateRouteTargets(vni); err != nil {
-			return fmt.Errorf("invalid route targets for vni %s: %w", vni.name, err)
-		}
+	if hasVRF(l2vni) {
+		v.vrfName = *l2vni.Spec.VRF
 	}
-
-	return nil
+	return v
 }
 
 func cidrsOverlap(cidr1, cidr2 string) (bool, error) {

--- a/internal/conversion/validate_vni_test.go
+++ b/internal/conversion/validate_vni_test.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestValidateVNIs(t *testing.T) {
+func TestFilterValidL3VNIs(t *testing.T) {
 	tests := []struct {
 		name    string
 		vnis    []v1alpha1.L3VNI
@@ -90,43 +90,19 @@ func TestValidateVNIs(t *testing.T) {
 			},
 			wantErr: false,
 		},
-		{
-			name: "duplicate VNI",
-			vnis: []v1alpha1.L3VNI{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "vni1"},
-					Spec: v1alpha1.L3VNISpec{
-						VNI:         1001,
-						VRF:         "vrf1",
-						HostSession: &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
-					},
-					Status: &v1alpha1.L3VNIStatus{},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "vni2"},
-					Spec: v1alpha1.L3VNISpec{
-						VNI:         1001,
-						VRF:         "vrf2",
-						HostSession: &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
-					},
-					Status: &v1alpha1.L3VNIStatus{},
-				},
-			},
-			wantErr: true,
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateL3VNIs(tt.vnis)
+			_, err := FilterValidL3VNIs(tt.vnis)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("validateL3VNIs() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("FilterValidL3VNIs() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
 }
 
-func TestValidateL2VNIs(t *testing.T) {
+func TestFilterValidL2VNIs(t *testing.T) {
 	tests := []struct {
 		name    string
 		vnis    []v1alpha1.L2VNI
@@ -173,26 +149,6 @@ func TestValidateL2VNIs(t *testing.T) {
 				},
 			},
 			wantErr: false,
-		},
-		{
-			name: "duplicate VNI",
-			vnis: []v1alpha1.L2VNI{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "vni1"},
-					Spec: v1alpha1.L2VNISpec{
-						VNI: 1001,
-					},
-					Status: &v1alpha1.L2VNIStatus{},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "vni2"},
-					Spec: v1alpha1.L2VNISpec{
-						VNI: 1001,
-					},
-					Status: &v1alpha1.L2VNIStatus{},
-				},
-			},
-			wantErr: true,
 		},
 		{
 			name: "invalid VRF name",
@@ -384,15 +340,15 @@ func TestValidateL2VNIs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateL2VNIs(tt.vnis)
+			_, err := FilterValidL2VNIs(tt.vnis)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ValidateL2VNIs() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("FilterValidL2VNIs() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
 }
 
-func TestValidateVRFs(t *testing.T) {
+func TestFilterValidVRFSubnets(t *testing.T) {
 	tests := []struct {
 		name       string
 		l2vnis     []v1alpha1.L2VNI
@@ -616,42 +572,57 @@ func TestValidateVRFs(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "more than one L3VNI in the same VRF",
-			l3vnis: []v1alpha1.L3VNI{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"},
-					Spec: v1alpha1.L3VNISpec{
-						VNI:         1001,
-						VRF:         "vni1",
-						HostSession: &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
-					},
-					Status: &v1alpha1.L3VNIStatus{},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "vni2", Namespace: "test"},
-					Spec: v1alpha1.L3VNISpec{
-						VNI:         1002,
-						HostSession: &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
-						VRF:         "vni1",
-					},
-					Status: &v1alpha1.L3VNIStatus{},
-				},
-			},
-			wantErrStr: "more than one L3VNI detected in VRF \"vni1\": test/vni1 - test/vni2",
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateVRFs(tt.l2vnis, tt.l3vnis)
+			_, _, err := FilterValidVRFSubnets(tt.l3vnis, tt.l2vnis)
 			if tt.wantErrStr == "" && err != nil {
-				t.Errorf("ValidateVRFs() no error expected but got error = %q", err)
+				t.Errorf("FilterValidVRFSubnets() no error expected but got errors = %v", err)
 			}
-			if tt.wantErrStr != "" && (err == nil || !strings.Contains(err.Error(), tt.wantErrStr)) {
-				t.Errorf("ValidateVRFs() error expected but got error = %q, wantErr %q", err, tt.wantErrStr)
+			if tt.wantErrStr != "" {
+				if err == nil {
+					t.Errorf("FilterValidVRFSubnets() error expected but got none, wantErr %q", tt.wantErrStr)
+				} else if !strings.Contains(err.Error(), tt.wantErrStr) {
+					t.Errorf("FilterValidVRFSubnets() error = %q, wantErr %q", err, tt.wantErrStr)
+				}
 			}
 		})
+	}
+}
+
+func TestFilterUniqueVRFs_DuplicateVRF(t *testing.T) {
+	l3vnis := []v1alpha1.L3VNI{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"},
+			Spec: v1alpha1.L3VNISpec{
+				VNI:         1001,
+				VRF:         "vni1",
+				HostSession: &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
+			},
+			Status: &v1alpha1.L3VNIStatus{},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "vni2", Namespace: "test"},
+			Spec: v1alpha1.L3VNISpec{
+				VNI:         1002,
+				HostSession: &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
+				VRF:         "vni1",
+			},
+			Status: &v1alpha1.L3VNIStatus{},
+		},
+	}
+
+	valid, err := FilterUniqueVRFs(l3vnis)
+	if err == nil {
+		t.Fatal("expected error for duplicate VRF")
+	}
+	wantErr := "more than one L3VNI detected in VRF \"vni1\": \"test/vni1\" already exists"
+	if !strings.Contains(err.Error(), wantErr) {
+		t.Errorf("error = %q, want %q", err, wantErr)
+	}
+	if len(valid) != 1 || valid[0].Name != "vni1" {
+		t.Errorf("expected first L3VNI to be valid, got %v", valid)
 	}
 }
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package openpeerrors
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/openperouter/openperouter/api/v1alpha1"
+)
+
+const (
+	KindUnderlay      = v1alpha1.FailedResourceKind("Underlay")
+	KindL3VNI         = v1alpha1.FailedResourceKind("L3VNI")
+	KindL2VNI         = v1alpha1.FailedResourceKind("L2VNI")
+	KindL3Passthrough = v1alpha1.FailedResourceKind("L3Passthrough")
+)
+
+// ResourceError represents a per-resource error (e.g., bad VRF name, duplicate VNI).
+// These are reported in status.failedResources via CollectFailures.
+type ResourceError struct {
+	Obj v1alpha1.FailedResource
+}
+
+// Error implements the error interface so ResourceError can be used with errors.Join.
+func (v *ResourceError) Error() string {
+	return fmt.Sprintf("%s/%s: %s", v.Obj.Kind, v.Obj.Name, v.Obj.Message)
+}
+
+func CollectFailures(err error) []v1alpha1.FailedResource {
+	var out []v1alpha1.FailedResource
+	for _, e := range unwrapAll(err) {
+		if ve, ok := e.(*ResourceError); ok {
+			out = append(out, ve.Obj)
+		}
+	}
+	return out
+}
+
+func IsNonResourceError(err error) bool {
+	var ve *ResourceError
+	return err != nil && !errors.As(err, &ve)
+}
+
+func HasUnderlayFailure(err error) bool {
+	for _, e := range unwrapAll(err) {
+		if ve, ok := e.(*ResourceError); ok && ve.Obj.Kind == KindUnderlay {
+			return true
+		}
+	}
+	return false
+}
+
+// unwrapAll flattens a (possibly nested) error tree into its leaf errors.
+// It handles both errors.Join trees (Unwrap() []error) and single-wrapped
+// errors (Unwrap() error), using an iterative stack to avoid recursion.
+func unwrapAll(err error) []error {
+	if err == nil {
+		return nil
+	}
+	var out []error
+	stack := []error{err}
+	for len(stack) > 0 {
+		n := len(stack) - 1
+		e := stack[n]
+		stack = stack[:n]
+		if e == nil {
+			continue
+		}
+		switch x := e.(type) {
+		case interface{ Unwrap() []error }:
+			subs := x.Unwrap()
+			slices.Reverse(subs)
+			stack = append(stack, subs...)
+		case interface{ Unwrap() error }:
+			stack = append(stack, x.Unwrap())
+		default:
+			out = append(out, e)
+		}
+	}
+	return out
+}

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package openpeerrors
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/openperouter/openperouter/api/v1alpha1"
+)
+
+func newVE(kind, name, message string) *ResourceError {
+	return &ResourceError{
+		Obj: v1alpha1.FailedResource{
+			Kind: v1alpha1.FailedResourceKind(kind), Name: name,
+			Reason: v1alpha1.FailedResourceReasonValidationFailed, Message: message,
+		},
+	}
+}
+
+func TestCollectFailures_nil(t *testing.T) {
+	if got := CollectFailures(nil); got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+func TestCollectFailures_validationErrors(t *testing.T) {
+	ve1 := newVE("L3VNI", "vni1", "bad vrf")
+	ve2 := newVE("L2VNI", "vni2", "duplicate")
+
+	got := CollectFailures(errors.Join(ve1, ve2))
+	want := []v1alpha1.FailedResource{ve1.Obj, ve2.Obj}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestCollectFailures_underlayError(t *testing.T) {
+	ue := newVE("Underlay", "my-underlay", "bad ASN")
+
+	got := CollectFailures(ue)
+	want := []v1alpha1.FailedResource{ue.Obj}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestCollectFailures_mixedErrors(t *testing.T) {
+	ve := newVE("L3VNI", "vni1", "bad vrf")
+	plain := fmt.Errorf("some other error")
+
+	got := CollectFailures(errors.Join(ve, plain))
+	want := []v1alpha1.FailedResource{ve.Obj}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestCollectFailures_nestedJoins(t *testing.T) {
+	ve1 := newVE("L3VNI", "a", "err1")
+	ve2 := newVE("L2VNI", "b", "err2")
+
+	inner := errors.Join(ve1, ve2)
+	outer := errors.Join(inner, fmt.Errorf("plain"))
+	got := CollectFailures(outer)
+	want := []v1alpha1.FailedResource{ve1.Obj, ve2.Obj}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestCollectFailures_noResourceErrors(t *testing.T) {
+	got := CollectFailures(fmt.Errorf("other"))
+	if got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}
+
+func TestHasUnderlayFailure_nil(t *testing.T) {
+	if HasUnderlayFailure(nil) {
+		t.Error("nil should return false")
+	}
+}
+
+func TestHasUnderlayFailure_true(t *testing.T) {
+	ue := newVE("Underlay", "u1", "bad ASN")
+	if !HasUnderlayFailure(ue) {
+		t.Error("single underlay error should return true")
+	}
+}
+
+func TestHasUnderlayFailure_mixed(t *testing.T) {
+	ue := newVE("Underlay", "u1", "bad")
+	ve := newVE("L3VNI", "vni1", "bad vrf")
+	if !HasUnderlayFailure(errors.Join(ue, ve)) {
+		t.Error("underlay + other validation should return true")
+	}
+}
+
+func TestHasUnderlayFailure_noUnderlay(t *testing.T) {
+	ve := newVE("L3VNI", "vni1", "bad vrf")
+	if HasUnderlayFailure(ve) {
+		t.Error("non-underlay error should return false")
+	}
+}
+
+func TestHasUnderlayFailure_plainError(t *testing.T) {
+	if HasUnderlayFailure(fmt.Errorf("something broke")) {
+		t.Error("plain error should return false")
+	}
+}
+
+func TestIsNonResourceError_nil(t *testing.T) {
+	if IsNonResourceError(nil) {
+		t.Error("nil should return false")
+	}
+}
+
+func TestIsNonResourceError_validationError(t *testing.T) {
+	ve := newVE("L3VNI", "vni1", "bad vrf")
+	if IsNonResourceError(ve) {
+		t.Error("ResourceError should return false")
+	}
+}
+
+func TestIsNonResourceError_plainError(t *testing.T) {
+	if !IsNonResourceError(fmt.Errorf("sysctl failed")) {
+		t.Error("plain error should return true")
+	}
+}
+
+func TestResourceError_errorString(t *testing.T) {
+	ve := newVE("L3VNI", "test", "bad config")
+	want := "L3VNI/test: bad config"
+	if got := ve.Error(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/internal/hostnetwork/vni.go
+++ b/internal/hostnetwork/vni.go
@@ -39,7 +39,8 @@ type VNIParams struct {
 
 type L3VNIParams struct {
 	VNIParams `json:",inline"`
-	HostVeth  *Veth `json:"veth"`
+	Name      string `json:"name"`
+	HostVeth  *Veth  `json:"veth"`
 }
 
 type L3PassthroughParams struct {
@@ -56,6 +57,7 @@ type Veth struct {
 
 type L2VNIParams struct {
 	VNIParams    `json:",inline"`
+	Name         string      `json:"name"`
 	L2GatewayIPs []string    `json:"l2gatewayips"`
 	HostMaster   *HostMaster `json:"hostmaster"`
 }

--- a/website/content/docs/configuration/node-status.md
+++ b/website/content/docs/configuration/node-status.md
@@ -57,8 +57,85 @@ status:
   - type: Degraded
     status: "False"
     reason: ConfigurationSuccessful
-    message: "All configuration are healthy"
+    message: "All configuration applied successfully"
     lastTransitionTime: "2026-05-19T10:30:00Z"
+```
+
+### Degraded State and Per-Resource Error Reporting
+
+When one or more configuration resources fail validation, the controller **skips** the
+invalid resources and continues applying the rest. The node enters a degraded state:
+`Ready=False`, `Degraded=True`, and `failedResources` lists each failed resource with
+its failure reason.
+
+Healthy resources are still applied. For example, if two L3VNIs are configured and one has an
+invalid VRF name, the valid L3VNI is applied normally while the invalid one is reported as failed.
+
+```shell
+$ kubectl -n openperouter-system get routernodeconfigurationstatus
+NAME                   READY   DEGRADED    AGE
+pe-kind-control-plane  False   True        19h
+pe-kind-worker         True    False       19h
+```
+
+```yaml
+apiVersion: openpe.openperouter.github.io/v1alpha1
+kind: RouterNodeConfigurationStatus
+metadata:
+  name: pe-kind-control-plane
+  namespace: openperouter-system
+status:
+  conditions:
+  - type: Ready
+    status: "False"
+    reason: ConfigurationFailed
+    message: "Some resources failed validation, see status.failedResources for details"
+  - type: Degraded
+    status: "True"
+    reason: ConfigurationFailed
+    message: "Some resources failed validation, see status.failedResources for details"
+  failedResources:
+  - kind: L3VNI
+    name: bad-vrf
+    reason: ValidationFailed
+    message: 'invalid vrf name for vni "bad-vrf", vrf "toolongvrfname": interface name too long'
+  - kind: L2VNI
+    name: orphan-l2
+    reason: DependencyFailed
+    message: 'no valid L3VNI for L3 domain "nonexistent"'
+```
+
+#### Failure Reasons
+
+| Reason | Meaning |
+|--------|---------|
+| `ValidationFailed` | The resource itself is invalid (e.g., VRF name too long, duplicate vni, subnet overlap) |
+| `DependencyFailed` | A resource this one depends on is missing or failed (e.g., L2VNI references an L3 domain with no valid L3VNI) |
+| `OverlayAttachmentFailed` | Provisioning failure at the network layer (e.g., failed to create VRF or move interface) |
+| `FrrConfigurationFailed` | Applying the FRR configuration failed |
+
+#### Underlay Failures
+
+Underlay validation failures are special: since all VNIs depend on the underlay, a bad underlay
+means no configuration can be applied. The status shows `UnderlayFailed` and no resources are
+provisioned. The existing FRR configuration is left as-is.
+
+```yaml
+status:
+  conditions:
+  - type: Ready
+    status: "False"
+    reason: UnderlayFailed
+    message: "Underlay failed validation, existing FRR configuration left as-is"
+  - type: Degraded
+    status: "True"
+    reason: UnderlayFailed
+    message: "Underlay failed validation, existing FRR configuration left as-is"
+  failedResources:
+  - kind: Underlay
+    name: underlay
+    reason: ValidationFailed
+    message: "failed to validate underlays: ..."
 ```
 
 ### Lifecycle


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

Implements configuration resilience with per-resource error reporting, as described in the enhancement proposal:
https://github.com/openperouter/openperouter/pull/225

Today, a single invalid resource causes the entire reconcile loop to fail and tears down all configuration, including valid resources. This PR changes the controller to validate and process resources independently:

- Invalid resources are skipped and reported via status
- Valid resources continue to be configured (FRR + host)

Behavior details:

- **L3VNI validation failure**: Entire VRF is skipped. Dependent L2VNIs are marked `DependencyFailed` and not configured.
- **L2VNI validation failure**: Isolated to the resource. Does not affect other L2VNIs.
- **VRF subnet overlap**: All L3VNIs and L2VNIs in the conflicting VRFs are skipped.
- **Additional controller-only validations**: Cross-type VNI uniqueness, VRF dependency tracking.
- **Overlay teardown**: Scoped per-VRF. Failures (e.g. netlink errors) do not affect other VRFs.
- **FRR reload failure**: Reported as `FrrConfigurationFailed` in node status. Error is still returned so controller-runtime requeues with backoff for retry.
- **Status reporting**: All failures are exposed via `RouterNodeConfigurationStatus` with Ready/Degraded conditions and per-resource failure details.

This improves robustness and prevents unrelated configuration from being disrupted by a single bad resource.

Enhancement:
- https://github.com/openperouter/openperouter/pull/225 (Configuration resilience design)

Related:
- https://github.com/openperouter/openperouter/pull/355 (Node Router Status CRD)
- https://github.com/openperouter/openperouter/pull/332 (L2VNI webhook validation)

**Special notes for your reviewer**:

This PR includes PR #355's commits as its base. Review only the commits starting from `feat(status): add ReconcileResult and status reporting helpers` onward.

The commits are structured incrementally:
1. `feat(status)` -- ReconcileResult type and `buildStatus` helper
2. `feat(reconcile)` -- Wire ReconcileResult into the reconcile loop and status reporting
3. `refactor(conversion)` -- Extract per-field validators (`validateL3VNI`, `validateL2VNI`)
4. `feat(reconcile)` -- Report underlay validation failures in node status
5. `refactor(reconcile)` -- Extract `HostConfigurator` for testability
6. `feat(reconcile)` -- Per-resource error reporting for L3/L2 validation
7. `feat(reconcile)` -- Per-resource error reporting for passthroughs
8. `feat(reconcile)` -- Per-resource error reporting for VRF checks
9. `feat(reconcile)` -- Report FRR reload failures in node status
10. `refactor(host)` -- Split host configuration into prereqs and overlays
11. `feat(host)` -- Per-VRF netlink isolation in overlay provisioning
12. `fix(e2e)` -- Remove VRF and gateway IPs from disconnected L2VNI tests
13. `test(e2e)` -- Add configuration resiliency tests
14. `docs(node-status)` -- Document degraded state and per-resource errors

Test plan:

- [x] E2E: cross-type VNI conflict -- L2VNI skipped with `ValidationFailed`
- [x] E2E: invalid RT on L3VNI -- VRF skipped, L2VNI gets `DependencyFailed`
- [x] E2E: orphan L2VNI -- `DependencyFailed`
- [x] E2E: recovery -- fix issue, status clears, node becomes Ready
- [x] Existing e2e suite passes (no regressions)

- [x] I've reviewed all changes in the PR, including any AI-generated content, and take full responsibility for it.

**Release note**:

```release-note
Introduce per-resource configuration resilience.

Invalid L3VNI resources cause their VRF to be skipped along with dependent L2VNIs.
Invalid L2VNIs are isolated and do not affect other resources.
VRF subnet overlaps are detected and all affected resources are skipped.
FRR reload failures are reported as FrrConfigurationFailed with automatic retry.

All failures are reported via RouterNodeConfigurationStatus with detailed conditions.
```