### PR TITLE
Fix linter issues on main

### DIFF
--- a/internal/conversion/validate_passthrough_test.go
+++ b/internal/conversion/validate_passthrough_test.go
@@ -14,14 +14,14 @@ import (
 
 func TestValidatePassthroughsForNodes(t *testing.T) {
 	tests := []struct {
-		name        string
-		nodes       []corev1.Node
+		name           string
+		nodes          []corev1.Node
 		l3Passthroughs []v1alpha1.L3Passthrough
-		expectedErr error
+		expectedErr    error
 	}{
 		{
-			name:      "no nodes no passthroughs",
-			nodes:     nil,
+			name:           "no nodes no passthroughs",
+			nodes:          nil,
 			l3Passthroughs: nil,
 		},
 		{
@@ -162,16 +162,16 @@ func TestValidatePassthroughsForNodes(t *testing.T) {
 
 func TestValidatePassthroughs(t *testing.T) {
 	tests := []struct {
-		name          string
+		name           string
 		l3Passthroughs []v1alpha1.L3Passthrough
-		expectedErr   error
+		expectedErr    error
 	}{
 		{
-			name:          "no passthroughs",
+			name:           "no passthroughs",
 			l3Passthroughs: nil,
 		},
 		{
-			name:          "empty slice",
+			name:           "empty slice",
 			l3Passthroughs: []v1alpha1.L3Passthrough{},
 		},
 		{


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
/kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

Running 'make lint' on local environment fail on main branch.

This PR resolve the linter issues.

**Special notes for your reviewer**:
Its not clear how the these un-formatted changes slipped in.

One gap I see is CI using golnagci-lint Github Action while for local development we have 'make lint'.
Although using  linter GH Action continent the local development workflow may diverge, as in this case.
We should consider have CI run `make lint` as well.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
