### PR TITLE
Fix gofmt issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,6 +74,7 @@ jobs:
         run: |
           make generate-all-ci
           make fix
+          make fmt
           make checkuncommitted
 
       - name: Helm doc generate

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ fix: ## Run go fix against code.
 .PHONY: fmt
 fmt: ## Run go fmt against code.
 	go fmt ./...
+	cd e2etests && go fmt ./...
 
 .PHONY: vet
 vet: ## Run go vet against code.

--- a/e2etests/pkg/metrics/metrics.go
+++ b/e2etests/pkg/metrics/metrics.go
@@ -114,8 +114,8 @@ type podMetricsList struct {
 }
 
 type podMetricsItem struct {
-	Metadata   podMetricsMetadata   `json:"metadata"`
-	Containers []containerMetrics   `json:"containers"`
+	Metadata   podMetricsMetadata `json:"metadata"`
+	Containers []containerMetrics `json:"containers"`
 }
 
 type podMetricsMetadata struct {

--- a/e2etests/pkg/metrics/metrics_test.go
+++ b/e2etests/pkg/metrics/metrics_test.go
@@ -76,8 +76,8 @@ func TestParseMetricsAPIResponse(t *testing.T) {
 			wantMemMB: []float64{0},
 		},
 		{
-			name: "empty items",
-			input: `{"items": []}`,
+			name:     "empty items",
+			input:    `{"items": []}`,
 			wantPods: 0,
 		},
 		{

--- a/e2etests/pkg/openperouter/netns.go
+++ b/e2etests/pkg/openperouter/netns.go
@@ -67,4 +67,3 @@ func UnderlayVethExists(nodeName string) bool {
 	}
 	return false
 }
-

--- a/e2etests/tests/hostconfiguration.go
+++ b/e2etests/tests/hostconfiguration.go
@@ -1410,7 +1410,6 @@ func validateConfig[T any](config T, test string, pod *corev1.Pod) {
 		ShouldNot(HaveOccurred())
 }
 
-
 func ensureValidator(cs clientset.Interface, pod *corev1.Pod) {
 	if pod.Annotations != nil && pod.Annotations["validator"] == "true" {
 		return

--- a/internal/controller/routerconfiguration/host_config.go
+++ b/internal/controller/routerconfiguration/host_config.go
@@ -122,4 +122,3 @@ func nonRecoverableHostError(e error) bool {
 	underlayExistsError := hostnetwork.UnderlayExistsError("")
 	return errors.As(e, &underlayExistsError)
 }
-

--- a/internal/conversion/validate_passthrough_test.go
+++ b/internal/conversion/validate_passthrough_test.go
@@ -14,14 +14,14 @@ import (
 
 func TestValidatePassthroughsForNodes(t *testing.T) {
 	tests := []struct {
-		name        string
-		nodes       []corev1.Node
+		name           string
+		nodes          []corev1.Node
 		l3Passthroughs []v1alpha1.L3Passthrough
-		expectedErr error
+		expectedErr    error
 	}{
 		{
-			name:      "no nodes no passthroughs",
-			nodes:     nil,
+			name:           "no nodes no passthroughs",
+			nodes:          nil,
 			l3Passthroughs: nil,
 		},
 		{
@@ -162,16 +162,16 @@ func TestValidatePassthroughsForNodes(t *testing.T) {
 
 func TestValidatePassthroughs(t *testing.T) {
 	tests := []struct {
-		name          string
+		name           string
 		l3Passthroughs []v1alpha1.L3Passthrough
-		expectedErr   error
+		expectedErr    error
 	}{
 		{
-			name:          "no passthroughs",
+			name:           "no passthroughs",
 			l3Passthroughs: nil,
 		},
 		{
-			name:          "empty slice",
+			name:           "empty slice",
 			l3Passthroughs: []v1alpha1.L3Passthrough{},
 		},
 		{


### PR DESCRIPTION
Run go fmt in github CI

Some files had indentation issues. Run make fmt to fix them.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
Some of the files are not formatted correctly, at least according to go
fmt version 1.26. Fix this with:

  find . -name *.go | xargs gofmt -w

**Special notes for your reviewer**:
Some of the files are not formatted correctly, at least according to go
fmt version 1.26. Fix this with:

  find . -name *.go | xargs gofmt -w

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Run go fmt in github CI
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
