### PR TITLE
fix: move underlay interface back to default netns on deletion

### DIFF
--- a/e2etests/pkg/openperouter/interface.go
+++ b/e2etests/pkg/openperouter/interface.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package openperouter
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/openperouter/openperouter/e2etests/pkg/executor"
+)
+
+// IsInterfaceInNS checks whether the interface exists in the given
+// network namespace on nodeName. Pass NamedNetns for the perouter netns,
+// or an empty string for the default netns.
+func IsInterfaceInNS(nodeName, intf string, ns string) bool {
+	exec := executor.ForContainer(nodeName)
+	if ns == "" {
+		_, err := exec.Exec("ip", "link", "show", intf)
+		return err == nil
+	}
+	_, err := exec.Exec("ip", "netns", "exec", ns, "ip", "link", "show", intf)
+	return err == nil
+}
+
+// IsInterfaceInDefaultNetns checks whether the interface exists
+// in the default network namespace on nodeName.
+func IsInterfaceInDefaultNetns(nodeName, intf string) bool {
+	return IsInterfaceInNS(nodeName, intf, "")
+}
+
+var addrRegexp = regexp.MustCompile(`\s(inet6?\s+\S+)`)
+
+// InterfaceIPAddresses returns the non-link-local IP addresses assigned to the
+// interface in the default netns on nodeName, sorted and newline-joined.
+func InterfaceIPAddresses(nodeName, intf string) (string, error) {
+	exec := executor.ForContainer(nodeName)
+	out, err := exec.Exec("ip", "-o", "a", "ls", "dev", intf, "scope", "global")
+	if err != nil {
+		return "", err
+	}
+	var addrs []string
+	for _, line := range strings.Split(out, "\n") {
+		m := addrRegexp.FindStringSubmatch(line)
+		if len(m) < 2 {
+			continue
+		}
+		addr := m[1]
+		addrs = append(addrs, addr)
+	}
+	sort.Strings(addrs)
+	return strings.Join(addrs, "\n"), nil
+}
+
+// InterfaceIsUp checks whether the interface in the default netns
+// on nodeName has state UP.
+func InterfaceIsUp(nodeName, intf string) bool {
+	exec := executor.ForContainer(nodeName)
+	out, err := exec.Exec("ip", "link", "show", intf, "up")
+	if err != nil {
+		return false
+	}
+	return out != ""
+}

--- a/e2etests/pkg/openperouter/netns.go
+++ b/e2etests/pkg/openperouter/netns.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openperouter/openperouter/e2etests/pkg/executor"
 )
 
-const namedNetns = "perouter"
+const NamedNetns = "perouter"
 
 // NamedNetnsExists checks whether /var/run/netns/perouter is present on nodeName.
 func NamedNetnsExists(nodeName string) (bool, error) {
@@ -23,7 +23,7 @@ func NamedNetnsExists(nodeName string) (bool, error) {
 	// Use exact name comparison to avoid "perouter" matching inside "openperouter".
 	for _, line := range strings.Split(out, "\n") {
 		fields := strings.Fields(line)
-		if len(fields) > 0 && fields[0] == namedNetns {
+		if len(fields) > 0 && fields[0] == NamedNetns {
 			return true, nil
 		}
 	}
@@ -34,7 +34,7 @@ func NamedNetnsExists(nodeName string) (bool, error) {
 // interface of the given link type (e.g. "vrf", "bridge", "vxlan").
 func NamedNetnsHasInterfaceType(nodeName, linkType string) (bool, error) {
 	exec := executor.ForContainer(nodeName)
-	out, err := exec.Exec("ip", "netns", "exec", namedNetns, "ip", "link", "show", "type", linkType)
+	out, err := exec.Exec("ip", "netns", "exec", NamedNetns, "ip", "link", "show", "type", linkType)
 	if err != nil {
 		return false, err
 	}
@@ -51,7 +51,7 @@ func DeleteNamedNetns(nodeName string) error {
 		log.Printf("pre-deletion of devices failed for %q, proceeding with netns delete: %v", nodeName, err)
 	}
 
-	_, err := e.Exec("ip", "netns", "delete", namedNetns)
+	_, err := e.Exec("ip", "netns", "delete", NamedNetns)
 	return err
 }
 
@@ -66,11 +66,11 @@ func UnderlayConfigured(nodeName string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if !strings.Contains(out, namedNetns) {
+	if !strings.Contains(out, NamedNetns) {
 		return false, nil
 	}
 
-	out, err = exec.Exec("ip", "netns", "exec", namedNetns, "ip", "-o", "link", "show", "dev", "lo")
+	out, err = exec.Exec("ip", "netns", "exec", NamedNetns, "ip", "-o", "link", "show", "dev", "lo")
 	if err != nil {
 		return false, err
 	}
@@ -78,7 +78,7 @@ func UnderlayConfigured(nodeName string) (bool, error) {
 		return false, nil
 	}
 
-	out, err = exec.Exec("ip", "netns", "exec", namedNetns, "ip", "address", "show", "dev", "lo", "scope", "global")
+	out, err = exec.Exec("ip", "netns", "exec", NamedNetns, "ip", "address", "show", "dev", "lo", "scope", "global")
 	if err != nil {
 		return false, err
 	}
@@ -97,7 +97,7 @@ func UnderlayVethsExists(nodeName string) bool {
 		if _, err := exec.Exec("ip", "link", "show", iface); err == nil {
 			return true
 		}
-		if _, err := exec.Exec("ip", "netns", "exec", namedNetns, "ip", "link", "show", iface); err == nil {
+		if _, err := exec.Exec("ip", "netns", "exec", NamedNetns, "ip", "link", "show", iface); err == nil {
 			return true
 		}
 	}
@@ -107,7 +107,7 @@ func UnderlayVethsExists(nodeName string) bool {
 // deleteNetnsDevices lists all devices inside the perouter netns and deletes
 // them one by one, skipping loopback.
 func deleteNetnsDevices(e executor.Executor) error {
-	out, err := e.Exec("ip", "netns", "exec", namedNetns, "ip", "-o", "link", "show")
+	out, err := e.Exec("ip", "netns", "exec", NamedNetns, "ip", "-o", "link", "show")
 	if err != nil {
 		return err
 	}
@@ -121,7 +121,7 @@ func deleteNetnsDevices(e executor.Executor) error {
 		if name == "lo" {
 			continue
 		}
-		if out, err := e.Exec("ip", "netns", "exec", namedNetns, "ip", "link", "delete", name); err != nil {
+		if out, err := e.Exec("ip", "netns", "exec", NamedNetns, "ip", "link", "delete", name); err != nil {
 			if strings.Contains(out, "Cannot find device") {
 				continue
 			}

--- a/e2etests/tests/hostconfiguration.go
+++ b/e2etests/tests/hostconfiguration.go
@@ -1184,6 +1184,75 @@ var _ = ginkgo.Describe("Router Host configuration", func() {
 				}, underlayConfiguredTestSelector, p)
 			}
 		})
+
+		ginkgo.It("moves the underlay interface back to the default netns on deletion", func() {
+			nodes, err := k8s.GetNodes(cs)
+			Expect(err).NotTo(HaveOccurred())
+
+			underlayNIC := "toswitch1"
+
+			ginkgo.By(fmt.Sprintf("verifying %s exists in the default netns before creating the underlay", underlayNIC))
+			for _, node := range nodes {
+				Eventually(func() bool {
+					return openperouter.IsInterfaceInDefaultNetns(node.Name, underlayNIC)
+				}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(
+					BeTrueBecause("%s should be in the default netns on %s before underlay creation", underlayNIC, node.Name))
+			}
+
+			ginkgo.By(fmt.Sprintf("recording the %s IP addresses before creating the underlay", underlayNIC))
+			addrsBefore := map[string]string{}
+			for _, node := range nodes {
+				addrs, err := openperouter.InterfaceIPAddresses(node.Name, underlayNIC)
+				Expect(err).NotTo(HaveOccurred(), "failed to get %s addresses on %s", underlayNIC, node.Name)
+				addrsBefore[node.Name] = addrs
+			}
+
+			ginkgo.By("creating the underlay")
+			err = Updater.Update(config.Resources{
+				Underlays: []v1alpha1.Underlay{underlay},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("verifying %s moved into the perouter netns", underlayNIC))
+			for _, node := range nodes {
+				Eventually(func() bool {
+					return openperouter.IsInterfaceInNS(node.Name, underlayNIC, openperouter.NamedNetns)
+				}).WithTimeout(2 * time.Minute).WithPolling(time.Second).Should(BeTrueBecause(
+					"%s should be inside the perouter netns on %s after underlay creation", underlayNIC, node.Name))
+			}
+
+			ginkgo.By("deleting the underlay")
+			Expect(Updater.CleanAll()).To(Succeed())
+
+			ginkgo.By("waiting for all router pods to be ready after underlay deletion")
+			Eventually(func(g Gomega) {
+				pods, err := openperouter.RouterPods(cs)
+				g.Expect(err).NotTo(HaveOccurred())
+				for _, p := range pods {
+					g.Expect(k8s.PodIsReady(p)).To(BeTrueBecause("pod %s must be ready", p.Name))
+				}
+			}).WithTimeout(2 * time.Minute).WithPolling(time.Second).Should(Succeed())
+
+			ginkgo.By(fmt.Sprintf("verifying %s is back in the default netns after underlay deletion", underlayNIC))
+			for _, node := range nodes {
+				Eventually(func() bool {
+					return openperouter.IsInterfaceInDefaultNetns(node.Name, underlayNIC)
+				}).WithTimeout(2 * time.Minute).WithPolling(time.Second).Should(BeTrueBecause(
+					"%s should be back in the default netns on %s after underlay deletion", underlayNIC, node.Name))
+			}
+
+			ginkgo.By(fmt.Sprintf("verifying %s is UP and has the same IP addresses as before", underlayNIC))
+			for _, node := range nodes {
+				Expect(openperouter.InterfaceIsUp(node.Name, underlayNIC)).To(BeTrueBecause(
+					"%s should be UP on %s after underlay deletion", underlayNIC, node.Name))
+
+				addrsAfter, err := openperouter.InterfaceIPAddresses(node.Name, underlayNIC)
+				Expect(err).NotTo(HaveOccurred(), "failed to get %s addresses on %s after deletion", underlayNIC, node.Name)
+				Expect(addrsAfter).To(Equal(addrsBefore[node.Name]),
+					"%s IP addresses on %s should be preserved after underlay deletion; was: %q, is: %q",
+					underlayNIC, node.Name, addrsBefore[node.Name], addrsAfter)
+			}
+		})
 	})
 
 	ginkgo.Context("L3Passthrough", func() {

--- a/internal/controller/routerconfiguration/host_config.go
+++ b/internal/controller/routerconfiguration/host_config.go
@@ -39,7 +39,7 @@ func configureInterfaces(ctx context.Context, config interfacesConfiguration) er
 			slog.Warn("failed to remove vnis after underlay removal", "err", err)
 		}
 		bridgerefresh.StopAllVNIs()
-		if err := hostnetwork.RemoveUnderlay(config.targetNamespace); err != nil {
+		if err := hostnetwork.RestoreUnderlay(ctx, config.targetNamespace); err != nil {
 			slog.Warn("failed to remove underlay interfaces after underlay removal", "err", err)
 		}
 		return nil

--- a/internal/hostnetwork/external_suite_test.go
+++ b/internal/hostnetwork/external_suite_test.go
@@ -42,7 +42,7 @@ var _ = Describe("EXTERNAL", func() {
 
 		It("should be configured", func() {
 			Eventually(func(g Gomega) {
-				validateUnderlay(g, params)
+				validateUnderlay(g, params, nil)
 			}, 30*time.Second, 1*time.Second).Should(Succeed())
 		})
 		It("should not be configured", func() {

--- a/internal/hostnetwork/link_properties.go
+++ b/internal/hostnetwork/link_properties.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/openperouter/openperouter/internal/netnamespace"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
 	"github.com/vishvananda/netns"
@@ -173,67 +172,70 @@ func setNeighSuppression(link netlink.Link) error {
 	return nil
 }
 
-// moveInterfaceToNamespace takes the given interface and moves it into the given namespace.
-func moveInterfaceToNamespace(ctx context.Context, intf string, ns netns.NsHandle) error {
-	slog.DebugContext(ctx, "move intf to namespace", "intf", intf, "namespace", ns.String())
-	defer slog.DebugContext(ctx, "move intf to namespace end", "intf", intf, "namespace", ns.String())
+// moveInterfaceToNamespace takes the given interface and moves it from the given to the given namespace.
+func moveInterfaceToNamespace(ctx context.Context, intf string, fromHandle, toHandle *netlink.Handle,
+	toNS netns.NsHandle, groupID uint32) error {
+	slog.DebugContext(ctx, "move intf to namespace", "intf", intf, "toNS", toNS.String())
+	defer slog.DebugContext(ctx, "move intf to namespace end", "intf", intf, "toNS", toNS.String())
 
-	err := netnamespace.In(ns, func() error {
-		_, err := netlink.LinkByName(intf)
-		if err != nil {
-			return fmt.Errorf("moveInterfaceToNamespace: Failed to find link %s: %w", intf, err)
-		}
-		return nil
-	})
-	if err == nil {
-		slog.DebugContext(ctx, "intf is already in namespace", "intf", intf, "namespace", ns.String())
+	// Nothing to do for us if the interface is already inside the target namespace.
+	if _, err := toHandle.LinkByName(intf); err == nil {
+		slog.DebugContext(ctx, "intf is already in namespace", "intf", intf, "namespace", toNS.String())
 		return nil
 	}
-	var nsError netnamespace.SetNamespaceError
-	if errors.As(err, &nsError) {
-		return fmt.Errorf("moveInterfaceToNamespace: Failed to execute in ns %s: %w", intf, err)
-	}
 
-	link, err := netlink.LinkByName(intf)
+	// Get the link, store its current addresses so that we can later restore them (addresses are lost upon moving),
+	// and move the link to the target netns.
+	link, err := fromHandle.LinkByName(intf)
 	if err != nil {
 		return fmt.Errorf("moveInterfaceToNamespace: Failed to find link %s: %w", intf, err)
 	}
 
-	addresses, err := netlink.AddrList(link, netlink.FAMILY_ALL)
+	addresses, err := fromHandle.AddrList(link, netlink.FAMILY_ALL)
 	if err != nil {
 		return fmt.Errorf("moveInterfaceToNamespace: Failed to get addresses for intf %s: %w", link.Attrs().Name, err)
 	}
-
 	slog.DebugContext(ctx, "addresses before moving", "addresses", addresses)
-	err = netlink.LinkSetNsFd(link, int(ns))
-	if err != nil {
-		return fmt.Errorf("moveInterfaceToNamespace: Failed to move %s to network namespace %s: %w", link.Attrs().Name, ns.String(), err)
-	}
-	if err := netnamespace.In(ns, func() error {
-		nsLink, err := netlink.LinkByName(intf)
-		if err != nil {
-			return fmt.Errorf("moveInterfaceToNamespace: Failed to get link by name %s up in network namespace %s: %w", intf, ns.String(), err)
-		}
-		err = netlink.LinkSetUp(nsLink)
-		if err != nil {
-			return fmt.Errorf("moveInterfaceToNamespace: Failed to set %s up in network namespace %s: %w", nsLink.Attrs().Name, ns.String(), err)
-		}
 
-		slog.DebugContext(ctx, "restoring addresses in namespace", "addresses", addresses)
-		for _, a := range addresses {
-			slog.DebugContext(ctx, "restoring address in namespace", "address", a, "flags", a.Flags)
-			IFA_F_NOPREFIXROUTE := 0x200 //nolint:revive // matches kernel define
-			a.Flags &= ^IFA_F_NOPREFIXROUTE
-			slog.DebugContext(ctx, "restoring address in namespace after no prefix", "address", a, "flags", a.Flags)
-			err := netlink.AddrAdd(nsLink, &a)
-			if err != nil && !os.IsExist(err) {
-				return fmt.Errorf("moveNicToNamespace: Failed to add address %s to %s: %w", a, nsLink.Attrs().Name, err)
-			}
-		}
-		return nil
-	}); err != nil {
-		return err
+	err = fromHandle.LinkSetNsFd(link, int(toNS))
+	if err != nil {
+		return fmt.Errorf("moveInterfaceToNamespace: Failed to move %s to network namespace %s: %w", link.Attrs().Name, toNS.String(), err)
 	}
+
+	// After the move, get the link inside the new namespace, set the link up, and add the addresses again.
+	nsLink, err := toHandle.LinkByName(intf)
+	if err != nil {
+		return fmt.Errorf("moveInterfaceToNamespace: Failed to get link by name %s up in network namespace %s: %w", intf, toNS.String(), err)
+	}
+
+	slog.DebugContext(ctx, "restoring addresses in namespace", "addresses", addresses)
+	var errs []error
+	for _, a := range addresses {
+		slog.DebugContext(ctx, "restoring address in namespace", "address", a, "flags", a.Flags)
+		a.Flags &= ^unix.IFA_F_NOPREFIXROUTE
+		slog.DebugContext(ctx, "restoring address in namespace after no prefix", "address", a, "flags", a.Flags)
+		err := toHandle.AddrAdd(nsLink, &a)
+		if err != nil && !os.IsExist(err) {
+			errs = append(errs, fmt.Errorf("moveInterfaceToNamespace: Failed to add address %s to %s: %w", a, nsLink.Attrs().Name, err))
+			continue
+		}
+	}
+	if len(errs) != 0 {
+		return errors.Join(errs...)
+	}
+
+	// Set group ID only if not already set (idempotent)
+	if nsLink.Attrs().Group != groupID {
+		if err := toHandle.LinkSetGroup(nsLink, int(groupID)); err != nil {
+			return fmt.Errorf("moveInterfaceToNamespace: Failed to set group ID %d on interface %s: %w", groupID, intf, err)
+		}
+	}
+
+	err = toHandle.LinkSetUp(nsLink)
+	if err != nil {
+		return fmt.Errorf("moveInterfaceToNamespace: Failed to set %s up in network namespace %s: %w", nsLink.Attrs().Name, toNS.String(), err)
+	}
+
 	return nil
 }
 

--- a/internal/hostnetwork/underlay.go
+++ b/internal/hostnetwork/underlay.go
@@ -37,20 +37,30 @@ type UnderlayTunnelEndpointParams struct {
 func SetupUnderlay(ctx context.Context, params UnderlayParams) error {
 	slog.DebugContext(ctx, "setup underlay", "params", params)
 	defer slog.DebugContext(ctx, "setup underlay done")
-	ns, err := netns.GetFromPath(params.TargetNS)
+
+	targetNetNS, err := netns.GetFromPath(params.TargetNS)
 	if err != nil {
 		return fmt.Errorf("setupUnderlay: Failed to find network namespace %s: %w", params.TargetNS, err)
 	}
 	defer func() {
-		if err := ns.Close(); err != nil {
+		if err := targetNetNS.Close(); err != nil {
 			slog.Error("failed to close namespace", "namespace", params.TargetNS, "error", err)
+		}
+	}()
+	defaultNetNS, err := netns.Get()
+	if err != nil {
+		return fmt.Errorf("SetupUnderlay: failed to get netns handle for default namespace: %w", err)
+	}
+	defer func() {
+		if err := defaultNetNS.Close(); err != nil {
+			slog.Error("failed to close default namespace", "error", err)
 		}
 	}()
 
 	// Check if there are existing underlay interfaces that aren't in the new list.
 	// This means the underlay configuration changed and requires rebuilding
 	// the network namespace.
-	existingIfaces, err := findInterfacesInGroup(ns, underlayGroupID)
+	existingIfaces, err := findInterfacesInGroup(targetNetNS, underlayGroupID)
 	if err != nil {
 		return fmt.Errorf("failed to check existing underlay interfaces: %w", err)
 	}
@@ -61,26 +71,20 @@ func SetupUnderlay(ctx context.Context, params UnderlayParams) error {
 		}
 	}
 
+	targetNetNSHandle, err := netlink.NewHandleAt(targetNetNS)
+	if err != nil {
+		return fmt.Errorf("SetupUnderlay: failed to get netlink handle for namespace %s: %w", targetNetNS.String(), err)
+	}
+	defer targetNetNSHandle.Close()
+	defaultNetNSHandle, err := netlink.NewHandleAt(defaultNetNS)
+	if err != nil {
+		return fmt.Errorf("SetupUnderlay: failed to get netlink handle for default namespace: %w", err)
+	}
+	defer defaultNetNSHandle.Close()
+
 	for _, underlayInterface := range params.UnderlayInterfaces {
-		if err := moveInterfaceToNamespace(ctx, underlayInterface, ns); err != nil {
-			return err
-		}
-		if err := netnamespace.In(ns, func() error {
-			underlay, err := netlink.LinkByName(underlayInterface)
-			if err != nil {
-				return fmt.Errorf("failed to get underlay nic by name %s: %w", underlayInterface, err)
-			}
-			// Set group ID only if not already set (idempotent)
-			if underlay.Attrs().Group != underlayGroupID {
-				if err := netlink.LinkSetGroup(underlay, int(underlayGroupID)); err != nil {
-					return fmt.Errorf("failed to set group ID on underlay interface %s: %w", underlayInterface, err)
-				}
-			}
-			if err := netlink.LinkSetUp(underlay); err != nil {
-				return fmt.Errorf("could not set link up for VRF %s: %v", underlay.Attrs().Name, err)
-			}
-			return nil
-		}); err != nil {
+		if err := moveInterfaceToNamespace(ctx, underlayInterface, defaultNetNSHandle, targetNetNSHandle, targetNetNS,
+			underlayGroupID); err != nil {
 			return err
 		}
 	}
@@ -96,7 +100,7 @@ func SetupUnderlay(ctx context.Context, params UnderlayParams) error {
 	if ip := params.TunnelEndpoint.IPv6CIDR; ip != "" {
 		vtepIPs = append(vtepIPs, ip)
 	}
-	if err := ensureLoopback(ctx, ns, vtepIPs...); err != nil {
+	if err := ensureLoopback(ctx, targetNetNS, vtepIPs...); err != nil {
 		return err
 	}
 
@@ -139,38 +143,78 @@ func ensureLoopback(ctx context.Context, ns netns.NsHandle, vtepIPs ...string) e
 	return nil
 }
 
-// RemoveUnderlay removes the underlay state from the named network namespace:
-// it resets the group ID on underlay NICs (so HasUnderlayInterface
-// returns false on the next reconcile) and clears all IP addresses from the VTEP loopback (lo).
-func RemoveUnderlay(targetNS string) error {
-	ns, err := netns.GetFromPath(targetNS)
-	if err != nil {
-		return fmt.Errorf("RemoveUnderlay: failed to find network namespace %s: %w", targetNS, err)
-	}
-	defer func() {
-		if err := ns.Close(); err != nil {
-			slog.Error("failed to close namespace", "namespace", targetNS, "error", err)
-		}
-	}()
-
-	return netnamespace.In(ns, func() error {
-		if err := clearNonDefaultLoopbackIPs(loopbackName); err != nil {
-			return err
+// RestoreUnderlay restores the underlay state:
+//   - it clears all non-default IP addresses from the loopback in the namespace identified by fromNetNSPath
+//     (`/var/run/netns/perouter`).
+//   - it moves the interfaces that are identified by the groupID marker from the aforementioned namespace back to the
+//     default network namespace.
+func RestoreUnderlay(ctx context.Context, fromNetNSPath string) error {
+	restoreUnderlay := func(ctx context.Context, fromNetNSHandle, defaultNetNSHandle *netlink.Handle,
+		defaultNetNS netns.NsHandle) error {
+		if err := clearNonDefaultLoopbackIPs(fromNetNSHandle, loopbackName); err != nil {
+			return fmt.Errorf("RestoreUnderlay: failed to clear non default loopback IPs from interface %s, err: %w",
+				loopbackName, err)
 		}
 
-		links, err := netlink.LinkList()
+		links, err := fromNetNSHandle.LinkList()
 		if err != nil {
 			return fmt.Errorf("failed to list links: %w", err)
 		}
+
+		var errs []error
 		for _, l := range links {
-			if l.Attrs().Group == underlayGroupID {
-				if err := netlink.LinkSetGroup(l, 0); err != nil {
-					return fmt.Errorf("failed to reset group ID on %s: %w", l.Attrs().Name, err)
-				}
+			if l.Attrs().Group != underlayGroupID {
+				continue
+			}
+			if err = moveInterfaceToNamespace(ctx, l.Attrs().Name, fromNetNSHandle, defaultNetNSHandle, defaultNetNS,
+				0); err != nil {
+				errs = append(errs, err)
+				continue
 			}
 		}
-		return nil
-	})
+		return errors.Join(errs...)
+	}
+
+	return restoreUnderlayWithHandles(ctx, fromNetNSPath, restoreUnderlay)
+}
+
+// restoreUnderlayWithHandles sets up the required netns and netlink handles for RestoreUnderlay and then calls
+// restoreFn with those handles.
+func restoreUnderlayWithHandles(ctx context.Context, fromNetNSPath string,
+	restoreFn func(context.Context, *netlink.Handle, *netlink.Handle, netns.NsHandle) error) error {
+	fromNetNS, err := netns.GetFromPath(fromNetNSPath)
+	if err != nil {
+		return fmt.Errorf("RestoreUnderlay: failed to find network namespace %s: %w", fromNetNSPath, err)
+	}
+	defer func() {
+		if err := fromNetNS.Close(); err != nil {
+			slog.Error("failed to close namespace", "namespace", fromNetNSPath, "error", err)
+		}
+	}()
+
+	defaultNetNS, err := netns.Get()
+	if err != nil {
+		return fmt.Errorf("RestoreUnderlay: failed to get netns for default namespace: %w", err)
+	}
+	defer func() {
+		if err := defaultNetNS.Close(); err != nil {
+			slog.Error("failed to close default namespace", "error", err)
+		}
+	}()
+
+	fromNetNSHandle, err := netlink.NewHandleAt(fromNetNS)
+	if err != nil {
+		return fmt.Errorf("RestoreUnderlay: failed to get netlink handle for namespace %s: %w", fromNetNSPath, err)
+	}
+	defer fromNetNSHandle.Close()
+
+	defaultNetNSHandle, err := netlink.NewHandleAt(defaultNetNS)
+	if err != nil {
+		return fmt.Errorf("RestoreUnderlay: failed to get netlink handle for default namespace: %w", err)
+	}
+	defer defaultNetNSHandle.Close()
+
+	return restoreFn(ctx, fromNetNSHandle, defaultNetNSHandle, defaultNetNS)
 }
 
 // HasUnderlayInterface returns true if the given network
@@ -240,13 +284,13 @@ func findUnderlayMTU(ns netns.NsHandle) (int, error) {
 	return minMTU, nil
 }
 
-func clearNonDefaultLoopbackIPs(intf string) error {
-	lo, err := netlink.LinkByName(intf)
+func clearNonDefaultLoopbackIPs(nsHandle *netlink.Handle, intf string) error {
+	lo, err := nsHandle.LinkByName(intf)
 	if err != nil {
 		return fmt.Errorf("failed to find %s: %w", intf, err)
 	}
 
-	addresses, err := netlink.AddrList(lo, netlink.FAMILY_ALL)
+	addresses, err := nsHandle.AddrList(lo, netlink.FAMILY_ALL)
 	if err != nil {
 		return fmt.Errorf("failed to list addresses on %s: %w", intf, err)
 	}
@@ -256,7 +300,7 @@ func clearNonDefaultLoopbackIPs(intf string) error {
 		if address.IP.IsLoopback() {
 			continue
 		}
-		if err := netlink.AddrDel(lo, &address); err != nil {
+		if err := nsHandle.AddrDel(lo, &address); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/internal/hostnetwork/underlay_test.go
+++ b/internal/hostnetwork/underlay_test.go
@@ -6,8 +6,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
+	"net"
 	"os"
 	"runtime"
+	"slices"
 
 	"strings"
 	"time"
@@ -40,29 +43,8 @@ var _ = Describe("Underlay configuration should work when", func() {
 
 	BeforeEach(func() {
 		cleanTest(underlayTestNS)
-
-		toMove := &netlink.Dummy{
-			LinkAttrs: netlink.LinkAttrs{
-				Name: underlayTestInterface,
-			},
-		}
-		err := netlink.LinkAdd(toMove)
-		Expect(err).NotTo(HaveOccurred())
-
-		err = assignIPToInterface(toMove, externalInterfaceIP)
-		Expect(err).NotTo(HaveOccurred())
-
-		toEdit := &netlink.Dummy{
-			LinkAttrs: netlink.LinkAttrs{
-				Name: underlayTestInterfaceEdit,
-			},
-		}
-		err = netlink.LinkAdd(toEdit)
-		Expect(err).NotTo(HaveOccurred())
-
-		err = assignIPToInterface(toEdit, externalInterfaceEditIP)
-		Expect(err).NotTo(HaveOccurred())
-
+		Expect(createInterface(underlayTestInterface, externalInterfaceIP)).To(Succeed())
+		Expect(createInterface(underlayTestInterfaceEdit, externalInterfaceEditIP)).To(Succeed())
 		testNs = createTestNS(underlayTestNS)
 	})
 
@@ -191,16 +173,76 @@ var _ = Describe("Underlay configuration should work when", func() {
 			validateUnderlayInNS(g, testNs, params)
 		}, 30*time.Second, 1*time.Second).Should(Succeed())
 	})
+	It("RemoveUnderlay should move the underlay interfaces back to the default namespace", func() {
+		underlayInterfaces := map[string]string{
+			underlayTestInterface:     externalInterfaceIP,
+			underlayTestInterfaceEdit: externalInterfaceEditIP,
+		}
+		params := UnderlayParams{
+			UnderlayInterfaces: slices.Collect(maps.Keys(underlayInterfaces)),
+			TunnelEndpoint: &UnderlayTunnelEndpointParams{
+				IPv4CIDR: "192.168.1.1/32",
+			},
+			TargetNS: underlayTestNSPath(),
+		}
+		Expect(SetupUnderlay(context.Background(), params)).To(Succeed())
+
+		By("verifying the interfaces have the original IP while in the target namespace and have the correct group ID")
+		Eventually(func(g Gomega) {
+			validateUnderlayInNS(g, testNs, params)
+		}, 30*time.Second, 1*time.Second).Should(Succeed())
+
+		Expect(RestoreUnderlay(context.Background(), underlayTestNSPath())).To(Succeed())
+
+		By("verifying the loopback IPs were deleted from the target namespace")
+		Eventually(func(g Gomega) {
+			_ = netnamespace.In(testNs, func() error {
+				checkInterfaceHasNoNonLoopbackIPs(g, loopbackName)
+				return nil
+			})
+		}, 30*time.Second, 1*time.Second).Should(Succeed())
+
+		By("verifying the interface was moved back, is up, still has the original IP and groupID was removed")
+		Eventually(func(g Gomega) {
+			for intf, ip := range underlayInterfaces {
+				link, err := netlink.LinkByName(intf)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(link).NotTo(BeNil())
+				g.Expect(link.Attrs().Flags&net.FlagUp).To(Equal(net.FlagUp), "interface should be administratively up")
+
+				hasIP, err := interfaceHasIP(link, ip)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(hasIP).To(BeTrue(), "interface should have %s after moving back to the default namespace",
+					ip)
+
+				g.Expect(link.Attrs().Group).To(
+					Equal(uint32(0)),
+					"interface should not be part of a group after moving back to default namespace, found group: %d",
+					link.Attrs().Group,
+				)
+			}
+		}, 30*time.Second, 1*time.Second).Should(Succeed())
+	})
 })
 
 func validateUnderlayInNS(g Gomega, ns netns.NsHandle, params UnderlayParams) {
 	_ = netnamespace.In(ns, func() error {
-		validateUnderlay(g, params, externalInterfaceIP)
+		validateUnderlay(
+			g,
+			params,
+			map[string]string{
+				underlayTestInterface:     externalInterfaceIP,
+				underlayTestInterfaceEdit: externalInterfaceEditIP,
+			},
+		)
 		return nil
 	})
 }
 
-func validateUnderlay(g Gomega, params UnderlayParams, interfaceIPs ...string) {
+// validateUnderlay checks that everything inside the underlay was configured as expected.
+// If the caller does not care about interface IP address validation, they can set interfaceIPs to empty and these
+// checks will be skipped.
+func validateUnderlay(g Gomega, params UnderlayParams, interfaceIPs map[string]string) {
 	links, err := netlink.LinkList()
 	g.Expect(err).NotTo(HaveOccurred())
 	foundInterfaces := map[string]bool{}
@@ -211,10 +253,14 @@ func validateUnderlay(g Gomega, params UnderlayParams, interfaceIPs ...string) {
 		for _, underlayIface := range params.UnderlayInterfaces {
 			if l.Attrs().Name == underlayIface {
 				foundInterfaces[underlayIface] = true
-				for _, ip := range interfaceIPs {
-					validateIP(g, l, ip)
-				}
 				validateGroupID(g, l, underlayGroupID)
+
+				if len(interfaceIPs) == 0 {
+					continue
+				}
+				ip := interfaceIPs[underlayIface]
+				g.Expect(ip).NotTo(BeEmpty())
+				validateIP(g, l, ip)
 			}
 		}
 	}
@@ -286,8 +332,33 @@ func cleanTest(namespace string) {
 	err = removeLinkByName(PassthroughNames.HostSide)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = clearNonDefaultLoopbackIPs(loopbackName)
+	curNS, err := netns.Get()
+	defer func() {
+		if err := curNS.Close(); err != nil {
+			GinkgoWriter.Printf("couldn't close curNS, err: %v", err)
+		}
+	}()
 	Expect(err).NotTo(HaveOccurred())
+
+	handle, err := netlink.NewHandleAt(curNS)
+	Expect(err).NotTo(HaveOccurred())
+	defer handle.Close()
+
+	err = clearNonDefaultLoopbackIPs(handle, loopbackName)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func createInterface(intf, ip string) error {
+	toMove := &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: intf,
+		},
+	}
+	if err := netlink.LinkAdd(toMove); err != nil {
+		return err
+	}
+
+	return assignIPToInterface(toMove, ip)
 }
 
 func createTestNS(testNs string) netns.NsHandle {


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Move underlay interface back to default netns on deletion

Fixes https://github.com/openperouter/openperouter/issues/441

**Special notes for your reviewer**:

N/A

**Release note**:

```release-note
Fix underlay interface not being moved back to the default network namespace on underlay deletion. The interface is now restored with its original IP addresses and link-up state.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.