### PR TITLE
Run `go fix` against entire code base

### DIFF
--- a/e2etests/pkg/frr/bgp.go
+++ b/e2etests/pkg/frr/bgp.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/openperouter/openperouter/e2etests/pkg/executor"
 )
@@ -31,12 +32,7 @@ func (r BGPRoutes) HaveRoute(prefix, expectedNexthop string) bool {
 	if !ok {
 		return false
 	}
-	for _, n := range nextHops {
-		if n == expectedNexthop {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(nextHops, expectedNexthop)
 }
 
 func BGPRoutesFor(exec executor.Executor) (BGPRoutes, BGPRoutes, error) {

--- a/e2etests/pkg/frr/dump.go
+++ b/e2etests/pkg/frr/dump.go
@@ -11,7 +11,7 @@ import (
 )
 
 func RawDump(exec executor.Executor) (string, error) {
-	res := ""
+	var res strings.Builder
 	allerrs := errors.New("")
 
 	commands := []struct {
@@ -39,17 +39,17 @@ func RawDump(exec executor.Executor) (string, error) {
 	}
 
 	for _, c := range commands {
-		res += fmt.Sprintf("\n######## %s\n\n", c.desc)
+		res.WriteString(fmt.Sprintf("\n######## %s\n\n", c.desc))
 		out, err := exec.Exec(c.cmd[0], c.cmd[1:]...)
 		if err != nil {
 			allerrs = errors.Join(allerrs, fmt.Errorf("\nFailed exec %q: %v", strings.Join(c.cmd, " "), err))
 		}
-		res += out
+		res.WriteString(out)
 	}
 
 	if allerrs.Error() == "" {
 		allerrs = nil
 	}
 
-	return res, allerrs
+	return res.String(), allerrs
 }

--- a/e2etests/pkg/frr/evpn.go
+++ b/e2etests/pkg/frr/evpn.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -278,10 +279,5 @@ func vnisFromExtendedCommunity(extendedCommunity string) ([]int, error) {
 }
 
 func containsVNI(vnis []int, vni int) bool {
-	for _, v := range vnis {
-		if v == vni {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(vnis, vni)
 }

--- a/e2etests/pkg/k8s/reporter.go
+++ b/e2etests/pkg/k8s/reporter.go
@@ -5,6 +5,7 @@ package k8s
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"time"
 
 	frrk8sv1beta1 "github.com/metallb/frr-k8s/api/v1beta1"
@@ -30,12 +31,7 @@ func InitReporter(kubeconfig, path string, namespaces ...string) (*k8sreporter.K
 
 	// The namespaces we want to dump resources for (including pods and pod logs)
 	dumpNamespace := func(ns string) bool {
-		for _, n := range namespaces {
-			if n == ns {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(namespaces, ns)
 	}
 
 	// The list of CRDs we want to dump

--- a/e2etests/pkg/openperouter/dump_podman.go
+++ b/e2etests/pkg/openperouter/dump_podman.go
@@ -15,54 +15,54 @@ import (
 // For each node, it lists all containers in the router pod and dumps their logs.
 func DumpPodmanLogs(nodes []corev1.Node) (string, error) {
 	allerrs := errors.New("")
-	res := ""
+	var res strings.Builder
 
 	for _, node := range nodes {
-		res += fmt.Sprintf("####### Node: %s\n", node.Name)
+		res.WriteString(fmt.Sprintf("####### Node: %s\n", node.Name))
 
 		exec := executor.ForContainer(node.Name)
 
-		res += fmt.Sprintf("### Podman pods on %s:\n", node.Name)
+		res.WriteString(fmt.Sprintf("### Podman pods on %s:\n", node.Name))
 		podList, err := exec.Exec("podman", "pod", "ps", "--format", "{{.Name}}")
 		if err != nil {
 			allerrs = errors.Join(allerrs, fmt.Errorf("\nFailed to list pods on node %s: %v", node.Name, err))
-			res += fmt.Sprintf("Failed to list pods: %v\n", err)
+			res.WriteString(fmt.Sprintf("Failed to list pods: %v\n", err))
 			continue
 		}
-		res += podList + "\n"
+		res.WriteString(podList + "\n")
 
-		res += fmt.Sprintf("### Podman containers on %s:\n", node.Name)
+		res.WriteString(fmt.Sprintf("### Podman containers on %s:\n", node.Name))
 		containerList, err := exec.Exec("podman", "ps", "--format", "{{.Names}}")
 		if err != nil {
 			allerrs = errors.Join(allerrs, fmt.Errorf("\nFailed to list containers on node %s: %v", node.Name, err))
-			res += fmt.Sprintf("Failed to list containers: %v\n", err)
+			res.WriteString(fmt.Sprintf("Failed to list containers: %v\n", err))
 			continue
 		}
-		res += containerList + "\n"
+		res.WriteString(containerList + "\n")
 
-		containers := strings.Split(strings.TrimSpace(containerList), "\n")
-		for _, containerName := range containers {
+		containers := strings.SplitSeq(strings.TrimSpace(containerList), "\n")
+		for containerName := range containers {
 			containerName = strings.TrimSpace(containerName)
 			if containerName == "" {
 				continue
 			}
 
-			res += fmt.Sprintf("\n### %s container logs on %s:\n", containerName, node.Name)
+			res.WriteString(fmt.Sprintf("\n### %s container logs on %s:\n", containerName, node.Name))
 			logs, err := exec.Exec("podman", "logs", "--since", "10m", containerName)
 			if err != nil {
 				allerrs = errors.Join(allerrs, fmt.Errorf("\nFailed to get %s logs on node %s: %v", containerName, node.Name, err))
-				res += fmt.Sprintf("Failed to get %s logs: %v\n", containerName, err)
+				res.WriteString(fmt.Sprintf("Failed to get %s logs: %v\n", containerName, err))
 			} else {
-				res += logs + "\n"
+				res.WriteString(logs + "\n")
 			}
 		}
 
-		res += "\n"
+		res.WriteString("\n")
 	}
 
 	if allerrs.Error() == "" {
 		allerrs = nil
 	}
 
-	return res, allerrs
+	return res.String(), allerrs
 }

--- a/e2etests/pkg/openperouter/netns.go
+++ b/e2etests/pkg/openperouter/netns.go
@@ -19,7 +19,7 @@ func NamedNetnsExists(nodeName string) (bool, error) {
 	}
 	// Each line of "ip netns list" is "<name>" or "<name> (id: N)".
 	// Use exact name comparison to avoid "perouter" matching inside "openperouter".
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		fields := strings.Fields(line)
 		if len(fields) > 0 && fields[0] == namedNetns {
 			return true, nil

--- a/e2etests/scale_tests/scale.go
+++ b/e2etests/scale_tests/scale.go
@@ -226,7 +226,7 @@ func generateL2VNIs(count int, namespace, bridgeType string) []v1alpha1.L2VNI {
 	const baseVNI = 1000
 
 	vnis := make([]v1alpha1.L2VNI, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		vrfName := fmt.Sprintf("vrf%03d", i+1)
 		vnis[i] = v1alpha1.L2VNI{
 			ObjectMeta: metav1.ObjectMeta{
@@ -250,7 +250,7 @@ func generateL3VNIsWithL2VNIs(count int, namespace, bridgeType string) ([]v1alph
 	l3vnis := make([]v1alpha1.L3VNI, count)
 	l2vnis := make([]v1alpha1.L2VNI, count)
 
-	for i := 0; i < count; i++ {
+	for i := range count {
 		vrfName := fmt.Sprintf("vrf%03d", i+1)
 
 		l3vnis[i] = v1alpha1.L3VNI{

--- a/internal/ovsmodel/autoattach.go
+++ b/internal/ovsmodel/autoattach.go
@@ -5,6 +5,8 @@
 
 package ovsmodel
 
+import "maps"
+
 import "github.com/ovn-kubernetes/libovsdb/model"
 
 const AutoAttachTable = "AutoAttach"
@@ -30,9 +32,7 @@ func copyAutoAttachMappings(a map[int]int) map[int]int {
 		return nil
 	}
 	b := make(map[int]int, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 

--- a/internal/ovsmodel/bridge.go
+++ b/internal/ovsmodel/bridge.go
@@ -5,6 +5,8 @@
 
 package ovsmodel
 
+import "maps"
+
 import "github.com/ovn-kubernetes/libovsdb/model"
 
 const BridgeTable = "Bridge"
@@ -145,9 +147,7 @@ func copyBridgeExternalIDs(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -225,9 +225,7 @@ func copyBridgeFlowTables(a map[int]string) map[int]string {
 		return nil
 	}
 	b := make(map[int]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -335,9 +333,7 @@ func copyBridgeOtherConfig(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -425,9 +421,7 @@ func copyBridgeRSTPStatus(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -477,9 +471,7 @@ func copyBridgeStatus(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 

--- a/internal/ovsmodel/controller.go
+++ b/internal/ovsmodel/controller.go
@@ -5,6 +5,8 @@
 
 package ovsmodel
 
+import "maps"
+
 import "github.com/ovn-kubernetes/libovsdb/model"
 
 const ControllerTable = "Controller"
@@ -170,9 +172,7 @@ func copyControllerExternalIDs(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -314,9 +314,7 @@ func copyControllerOtherConfig(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -366,9 +364,7 @@ func copyControllerStatus(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 

--- a/internal/ovsmodel/ct_timeout_policy.go
+++ b/internal/ovsmodel/ct_timeout_policy.go
@@ -5,6 +5,8 @@
 
 package ovsmodel
 
+import "maps"
+
 import "github.com/ovn-kubernetes/libovsdb/model"
 
 const CTTimeoutPolicyTable = "CT_Timeout_Policy"
@@ -52,9 +54,7 @@ func copyCTTimeoutPolicyExternalIDs(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -82,9 +82,7 @@ func copyCTTimeoutPolicyTimeouts(a map[string]int) map[string]int {
 		return nil
 	}
 	b := make(map[string]int, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 

--- a/internal/ovsmodel/ct_zone.go
+++ b/internal/ovsmodel/ct_zone.go
@@ -5,6 +5,8 @@
 
 package ovsmodel
 
+import "maps"
+
 import "github.com/ovn-kubernetes/libovsdb/model"
 
 const CTZoneTable = "CT_Zone"
@@ -29,9 +31,7 @@ func copyCTZoneExternalIDs(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 

--- a/internal/ovsmodel/datapath.go
+++ b/internal/ovsmodel/datapath.go
@@ -5,6 +5,8 @@
 
 package ovsmodel
 
+import "maps"
+
 import "github.com/ovn-kubernetes/libovsdb/model"
 
 const DatapathTable = "Datapath"
@@ -31,9 +33,7 @@ func copyDatapathCapabilities(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -61,9 +61,7 @@ func copyDatapathCTZones(a map[int]string) map[int]string {
 		return nil
 	}
 	b := make(map[int]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -95,9 +93,7 @@ func copyDatapathExternalIDs(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 

--- a/internal/ovsmodel/flow_sample_collector_set.go
+++ b/internal/ovsmodel/flow_sample_collector_set.go
@@ -5,6 +5,8 @@
 
 package ovsmodel
 
+import "maps"
+
 import "github.com/ovn-kubernetes/libovsdb/model"
 
 const FlowSampleCollectorSetTable = "Flow_Sample_Collector_Set"
@@ -35,9 +37,7 @@ func copyFlowSampleCollectorSetExternalIDs(a map[string]string) map[string]strin
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 

--- a/internal/ovsmodel/flow_table.go
+++ b/internal/ovsmodel/flow_table.go
@@ -5,6 +5,8 @@
 
 package ovsmodel
 
+import "maps"
+
 import "github.com/ovn-kubernetes/libovsdb/model"
 
 const FlowTableTable = "Flow_Table"
@@ -42,9 +44,7 @@ func copyFlowTableExternalIDs(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 

--- a/internal/ovsmodel/interface.go
+++ b/internal/ovsmodel/interface.go
@@ -5,6 +5,8 @@
 
 package ovsmodel
 
+import "maps"
+
 import "github.com/ovn-kubernetes/libovsdb/model"
 
 const InterfaceTable = "Interface"
@@ -102,9 +104,7 @@ func copyInterfaceBFD(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -132,9 +132,7 @@ func copyInterfaceBFDStatus(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -372,9 +370,7 @@ func copyInterfaceExternalIDs(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -528,9 +524,7 @@ func copyInterfaceLLDP(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -694,9 +688,7 @@ func copyInterfaceOptions(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -724,9 +716,7 @@ func copyInterfaceOtherConfig(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -754,9 +744,7 @@ func copyInterfaceStatistics(a map[string]int) map[string]int {
 		return nil
 	}
 	b := make(map[string]int, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -784,9 +772,7 @@ func copyInterfaceStatus(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 

--- a/internal/ovsmodel/ipfix.go
+++ b/internal/ovsmodel/ipfix.go
@@ -5,6 +5,8 @@
 
 package ovsmodel
 
+import "maps"
+
 import "github.com/ovn-kubernetes/libovsdb/model"
 
 const IPFIXTable = "IPFIX"
@@ -79,9 +81,7 @@ func copyIPFIXExternalIDs(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -153,9 +153,7 @@ func copyIPFIXOtherConfig(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 

--- a/internal/ovsmodel/manager.go
+++ b/internal/ovsmodel/manager.go
@@ -5,6 +5,8 @@
 
 package ovsmodel
 
+import "maps"
+
 import "github.com/ovn-kubernetes/libovsdb/model"
 
 const ManagerTable = "Manager"
@@ -66,9 +68,7 @@ func copyManagerExternalIDs(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -144,9 +144,7 @@ func copyManagerOtherConfig(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -174,9 +172,7 @@ func copyManagerStatus(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 

--- a/internal/ovsmodel/mirror.go
+++ b/internal/ovsmodel/mirror.go
@@ -5,6 +5,8 @@
 
 package ovsmodel
 
+import "maps"
+
 import "github.com/ovn-kubernetes/libovsdb/model"
 
 const MirrorTable = "Mirror"
@@ -37,9 +39,7 @@ func copyMirrorExternalIDs(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -225,9 +225,7 @@ func copyMirrorStatistics(a map[string]int) map[string]int {
 		return nil
 	}
 	b := make(map[string]int, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 

--- a/internal/ovsmodel/netflow.go
+++ b/internal/ovsmodel/netflow.go
@@ -5,6 +5,8 @@
 
 package ovsmodel
 
+import "maps"
+
 import "github.com/ovn-kubernetes/libovsdb/model"
 
 const NetFlowTable = "NetFlow"
@@ -85,9 +87,7 @@ func copyNetFlowExternalIDs(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 

--- a/internal/ovsmodel/open_vswitch.go
+++ b/internal/ovsmodel/open_vswitch.go
@@ -5,6 +5,8 @@
 
 package ovsmodel
 
+import "maps"
+
 import "github.com/ovn-kubernetes/libovsdb/model"
 
 const OpenvSwitchTable = "Open_vSwitch"
@@ -104,9 +106,7 @@ func copyOpenvSwitchDatapaths(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -182,9 +182,7 @@ func copyOpenvSwitchExternalIDs(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -272,9 +270,7 @@ func copyOpenvSwitchOtherConfig(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -346,9 +342,7 @@ func copyOpenvSwitchStatistics(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 

--- a/internal/ovsmodel/port.go
+++ b/internal/ovsmodel/port.go
@@ -5,6 +5,8 @@
 
 package ovsmodel
 
+import "maps"
+
 import "github.com/ovn-kubernetes/libovsdb/model"
 
 const PortTable = "Port"
@@ -153,9 +155,7 @@ func copyPortExternalIDs(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -263,9 +263,7 @@ func copyPortOtherConfig(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -319,9 +317,7 @@ func copyPortRSTPStatistics(a map[string]int) map[string]int {
 		return nil
 	}
 	b := make(map[string]int, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -349,9 +345,7 @@ func copyPortRSTPStatus(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -379,9 +373,7 @@ func copyPortStatistics(a map[string]int) map[string]int {
 		return nil
 	}
 	b := make(map[string]int, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -409,9 +401,7 @@ func copyPortStatus(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 

--- a/internal/ovsmodel/qos.go
+++ b/internal/ovsmodel/qos.go
@@ -5,6 +5,8 @@
 
 package ovsmodel
 
+import "maps"
+
 import "github.com/ovn-kubernetes/libovsdb/model"
 
 const QoSTable = "QoS"
@@ -31,9 +33,7 @@ func copyQoSExternalIDs(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -61,9 +61,7 @@ func copyQoSOtherConfig(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -91,9 +89,7 @@ func copyQoSQueues(a map[int]string) map[int]string {
 		return nil
 	}
 	b := make(map[int]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 

--- a/internal/ovsmodel/queue.go
+++ b/internal/ovsmodel/queue.go
@@ -5,6 +5,8 @@
 
 package ovsmodel
 
+import "maps"
+
 import "github.com/ovn-kubernetes/libovsdb/model"
 
 const QueueTable = "Queue"
@@ -52,9 +54,7 @@ func copyQueueExternalIDs(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 
@@ -82,9 +82,7 @@ func copyQueueOtherConfig(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 

--- a/internal/ovsmodel/sflow.go
+++ b/internal/ovsmodel/sflow.go
@@ -5,6 +5,8 @@
 
 package ovsmodel
 
+import "maps"
+
 import "github.com/ovn-kubernetes/libovsdb/model"
 
 const SFlowTable = "sFlow"
@@ -55,9 +57,7 @@ func copySFlowExternalIDs(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 

--- a/internal/ovsmodel/ssl.go
+++ b/internal/ovsmodel/ssl.go
@@ -5,6 +5,8 @@
 
 package ovsmodel
 
+import "maps"
+
 import "github.com/ovn-kubernetes/libovsdb/model"
 
 const SSLTable = "SSL"
@@ -44,9 +46,7 @@ func copySSLExternalIDs(a map[string]string) map[string]string {
 		return nil
 	}
 	b := make(map[string]string, len(a))
-	for k, v := range a {
-		b[k] = v
-	}
+	maps.Copy(b, a)
 	return b
 }
 


### PR DESCRIPTION
Run go fix against entire code base

go fix ./...
cd e2etests/ && go fix ./...

See https://go.dev/doc/go1.26#go-command

```
The venerable go fix command has been completely revamped and is now the home of Go’s modernizers. It provides a dependable, push-button way to update Go code bases to the latest idioms and core library APIs. 
```

**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:

Update to latest go idioms with `go fix`

**Special notes for your reviewer**:

Update to latest go idioms with `go fix`

**Release note**:

```release-note
Update to latest go idioms with `go fix`
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
