### PR TITLE
Also run go fix against e2etests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 .PHONY: fix
 fix: ## Run go fix against code.
 	@go fix $(shell go list ./... | grep -vE 'internal/ovsmodel')
+	@cd e2etests && go fix ./...
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.

--- a/e2etests/pkg/frr/bgp.go
+++ b/e2etests/pkg/frr/bgp.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/openperouter/openperouter/e2etests/pkg/executor"
 )
@@ -31,12 +32,7 @@ func (r BGPRoutes) HaveRoute(prefix, expectedNexthop string) bool {
 	if !ok {
 		return false
 	}
-	for _, n := range nextHops {
-		if n == expectedNexthop {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(nextHops, expectedNexthop)
 }
 
 func BGPRoutesFor(exec executor.Executor) (BGPRoutes, BGPRoutes, error) {

--- a/e2etests/pkg/frr/evpn.go
+++ b/e2etests/pkg/frr/evpn.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -279,10 +280,5 @@ func vnisFromExtendedCommunity(extendedCommunity string) ([]int, error) {
 }
 
 func containsVNI(vnis []int, vni int) bool {
-	for _, v := range vnis {
-		if v == vni {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(vnis, vni)
 }

--- a/e2etests/pkg/k8s/reporter.go
+++ b/e2etests/pkg/k8s/reporter.go
@@ -5,6 +5,7 @@ package k8s
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"time"
 
 	frrk8sv1beta1 "github.com/metallb/frr-k8s/api/v1beta1"
@@ -30,12 +31,7 @@ func InitReporter(kubeconfig, path string, namespaces ...string) (*k8sreporter.K
 
 	// The namespaces we want to dump resources for (including pods and pod logs)
 	dumpNamespace := func(ns string) bool {
-		for _, n := range namespaces {
-			if n == ns {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(namespaces, ns)
 	}
 
 	// The list of CRDs we want to dump

--- a/e2etests/pkg/openperouter/dump_podman.go
+++ b/e2etests/pkg/openperouter/dump_podman.go
@@ -15,54 +15,54 @@ import (
 // For each node, it lists all containers in the router pod and dumps their logs.
 func DumpPodmanLogs(nodes []corev1.Node) (string, error) {
 	allerrs := errors.New("")
-	res := ""
+	var res strings.Builder
 
 	for _, node := range nodes {
-		res += fmt.Sprintf("####### Node: %s\n", node.Name)
+		res.WriteString(fmt.Sprintf("####### Node: %s\n", node.Name))
 
 		exec := executor.ForContainer(node.Name)
 
-		res += fmt.Sprintf("### Podman pods on %s:\n", node.Name)
+		res.WriteString(fmt.Sprintf("### Podman pods on %s:\n", node.Name))
 		podList, err := exec.Exec("podman", "pod", "ps", "--format", "{{.Name}}")
 		if err != nil {
 			allerrs = errors.Join(allerrs, fmt.Errorf("\nFailed to list pods on node %s: %v", node.Name, err))
-			res += fmt.Sprintf("Failed to list pods: %v\n", err)
+			res.WriteString(fmt.Sprintf("Failed to list pods: %v\n", err))
 			continue
 		}
-		res += podList + "\n"
+		res.WriteString(podList + "\n")
 
-		res += fmt.Sprintf("### Podman containers on %s:\n", node.Name)
+		res.WriteString(fmt.Sprintf("### Podman containers on %s:\n", node.Name))
 		containerList, err := exec.Exec("podman", "ps", "--format", "{{.Names}}")
 		if err != nil {
 			allerrs = errors.Join(allerrs, fmt.Errorf("\nFailed to list containers on node %s: %v", node.Name, err))
-			res += fmt.Sprintf("Failed to list containers: %v\n", err)
+			res.WriteString(fmt.Sprintf("Failed to list containers: %v\n", err))
 			continue
 		}
-		res += containerList + "\n"
+		res.WriteString(containerList + "\n")
 
-		containers := strings.Split(strings.TrimSpace(containerList), "\n")
-		for _, containerName := range containers {
+		containers := strings.SplitSeq(strings.TrimSpace(containerList), "\n")
+		for containerName := range containers {
 			containerName = strings.TrimSpace(containerName)
 			if containerName == "" {
 				continue
 			}
 
-			res += fmt.Sprintf("\n### %s container logs on %s:\n", containerName, node.Name)
+			res.WriteString(fmt.Sprintf("\n### %s container logs on %s:\n", containerName, node.Name))
 			logs, err := exec.Exec("podman", "logs", "--since", "10m", containerName)
 			if err != nil {
 				allerrs = errors.Join(allerrs, fmt.Errorf("\nFailed to get %s logs on node %s: %v", containerName, node.Name, err))
-				res += fmt.Sprintf("Failed to get %s logs: %v\n", containerName, err)
+				res.WriteString(fmt.Sprintf("Failed to get %s logs: %v\n", containerName, err))
 			} else {
-				res += logs + "\n"
+				res.WriteString(logs + "\n")
 			}
 		}
 
-		res += "\n"
+		res.WriteString("\n")
 	}
 
 	if allerrs.Error() == "" {
 		allerrs = nil
 	}
 
-	return res, allerrs
+	return res.String(), allerrs
 }

--- a/e2etests/pkg/openperouter/interface.go
+++ b/e2etests/pkg/openperouter/interface.go
@@ -40,7 +40,7 @@ func InterfaceIPAddresses(nodeName, intf string) (string, error) {
 		return "", err
 	}
 	var addrs []string
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		m := addrRegexp.FindStringSubmatch(line)
 		if len(m) < 2 {
 			continue

--- a/e2etests/pkg/openperouter/netns.go
+++ b/e2etests/pkg/openperouter/netns.go
@@ -21,7 +21,7 @@ func NamedNetnsExists(nodeName string) (bool, error) {
 	}
 	// Each line of "ip netns list" is "<name>" or "<name> (id: N)".
 	// Use exact name comparison to avoid "perouter" matching inside "openperouter".
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		fields := strings.Fields(line)
 		if len(fields) > 0 && fields[0] == NamedNetns {
 			return true, nil
@@ -112,7 +112,7 @@ func deleteNetnsDevices(e executor.Executor) error {
 		return err
 	}
 
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		name, err := ifaceName(line)
 		if err != nil {
 			log.Printf("could not get interface name from line %v", err)

--- a/e2etests/pkg/openperouter/webhooks.go
+++ b/e2etests/pkg/openperouter/webhooks.go
@@ -59,7 +59,7 @@ func DisableWebhooksForNamespace(cs clientset.Interface, namespace string) error
 }
 
 func RestoreWebhooks(cs clientset.Interface, namespace string) error {
-	labelPatch, _ := json.Marshal([]map[string]interface{}{
+	labelPatch, _ := json.Marshal([]map[string]any{
 		{
 			"op":   "remove",
 			"path": "/metadata/labels/" + jsonPatchEscape(skipWebhookLabel),

--- a/e2etests/scale_tests/scale.go
+++ b/e2etests/scale_tests/scale.go
@@ -226,7 +226,7 @@ func generateL2VNIs(count int, namespace, bridgeType string) []v1alpha1.L2VNI {
 	const baseVNI = 1000
 
 	vnis := make([]v1alpha1.L2VNI, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		vrfName := fmt.Sprintf("vrf%03d", i+1)
 		vnis[i] = v1alpha1.L2VNI{
 			ObjectMeta: metav1.ObjectMeta{
@@ -250,7 +250,7 @@ func generateL3VNIsWithL2VNIs(count int, namespace, bridgeType string) ([]v1alph
 	l3vnis := make([]v1alpha1.L3VNI, count)
 	l2vnis := make([]v1alpha1.L2VNI, count)
 
-	for i := 0; i < count; i++ {
+	for i := range count {
 		vrfName := fmt.Sprintf("vrf%03d", i+1)
 
 		l3vnis[i] = v1alpha1.L3VNI{

--- a/e2etests/tests/dump.go
+++ b/e2etests/tests/dump.go
@@ -111,9 +111,9 @@ func dumpFRRInfo(basePath, testName string, opts ...func(dumpOptions *dumpOption
 
 	for name, exec := range dumpOptions.executors {
 		func() {
-			dump := ""
+			var dump strings.Builder
 			for _, infoRetriever := range dumpOptions.infoRetrievers {
-				dump += infoRetriever(exec) + "\n\n"
+				dump.WriteString(infoRetriever(exec) + "\n\n")
 			}
 
 			f, err := logFileFor(testPath, fmt.Sprintf("frrdump-%s", name))
@@ -127,7 +127,7 @@ func dumpFRRInfo(basePath, testName string, opts ...func(dumpOptions *dumpOption
 				}
 			}()
 			fmt.Fprintf(f, "Dumping information for %s", name)
-			if _, err = fmt.Fprint(f, dump); err != nil {
+			if _, err = fmt.Fprint(f, dump.String()); err != nil {
 				ginkgo.GinkgoWriter.Printf("dumpFRRInfo: external frr dump for container %s, failed to write to file %v", name, err)
 				return
 			}

--- a/e2etests/tests/ipv6_vtep.go
+++ b/e2etests/tests/ipv6_vtep.go
@@ -20,7 +20,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("IPv6 VTEP", Ordered, func() {
@@ -54,12 +53,12 @@ var _ = Describe("IPv6 VTEP", Ordered, func() {
 			},
 			Neighbors: []v1alpha1.Neighbor{
 				{
-					ASN:     ptr.To(int64(64512)),
-					Address: ptr.To("192.168.11.2"),
+					ASN:     new(int64(64512)),
+					Address: new("192.168.11.2"),
 				},
 				{
-					ASN:     ptr.To(int64(64513)),
-					Address: ptr.To("192.168.12.2"),
+					ASN:     new(int64(64513)),
+					Address: new("192.168.12.2"),
 				},
 			},
 			TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
@@ -85,13 +84,13 @@ var _ = Describe("IPv6 VTEP", Ordered, func() {
 			Namespace: openperouter.Namespace,
 		},
 		Spec: v1alpha1.L2VNISpec{
-			VRF:          ptr.To("red"),
+			VRF:          new("red"),
 			VNI:          110,
 			L2GatewayIPs: []string{"192.171.24.1/24"},
 			HostMaster: &v1alpha1.HostMaster{
 				Type: linuxBridgeHostAttachment,
 				LinuxBridge: &v1alpha1.LinuxBridgeConfig{
-					AutoCreate: ptr.To(true),
+					AutoCreate: new(true),
 				},
 			},
 		},
@@ -105,7 +104,7 @@ var _ = Describe("IPv6 VTEP", Ordered, func() {
 		Spec: v1alpha1.L3VNISpec{
 			VRF:                   "green",
 			VNI:                   300,
-			UnderlayAddressFamily: ptr.To("ipv6"),
+			UnderlayAddressFamily: new("ipv6"),
 		},
 	}
 
@@ -115,14 +114,14 @@ var _ = Describe("IPv6 VTEP", Ordered, func() {
 			Namespace: openperouter.Namespace,
 		},
 		Spec: v1alpha1.L2VNISpec{
-			VRF:                   ptr.To("green"),
+			VRF:                   new("green"),
 			VNI:                   310,
-			UnderlayAddressFamily: ptr.To("ipv6"),
+			UnderlayAddressFamily: new("ipv6"),
 			L2GatewayIPs:          []string{"192.173.24.1/24"},
 			HostMaster: &v1alpha1.HostMaster{
 				Type: linuxBridgeHostAttachment,
 				LinuxBridge: &v1alpha1.LinuxBridgeConfig{
-					AutoCreate: ptr.To(true),
+					AutoCreate: new(true),
 				},
 			},
 		},

--- a/e2etests/tests/l3vpn_l2.go
+++ b/e2etests/tests/l3vpn_l2.go
@@ -62,10 +62,10 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 			VRF: "red",
 			HostSession: &v1alpha1.HostSession{
 				ASN:     64514,
-				HostASN: ptr.To(int64(64515)),
+				HostASN: new(int64(64515)),
 				LocalCIDR: v1alpha1.LocalCIDRConfig{
-					IPv4: ptr.To("192.169.10.0/24"),
-					IPv6: ptr.To("2001:db8:1::/64"),
+					IPv4: new("192.169.10.0/24"),
+					IPv6: new("2001:db8:1::/64"),
 				},
 			},
 			RDAssignedNumber: rdAssignedNumber,
@@ -86,12 +86,12 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 			Namespace: openperouter.Namespace,
 		},
 		Spec: v1alpha1.L2VNISpec{
-			VRF: ptr.To("red"),
+			VRF: new("red"),
 			VNI: vniID,
 			HostMaster: &v1alpha1.HostMaster{
 				Type: linuxBridgeHostAttachment,
 				LinuxBridge: &v1alpha1.LinuxBridgeConfig{
-					AutoCreate: ptr.To(true),
+					AutoCreate: new(true),
 				},
 			},
 		},
@@ -349,7 +349,7 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 			hostMaster: v1alpha1.HostMaster{
 				Type: linuxBridgeHostAttachment,
 				LinuxBridge: &v1alpha1.LinuxBridgeConfig{
-					AutoCreate: ptr.To(true),
+					AutoCreate: new(true),
 				},
 			},
 		}),
@@ -361,7 +361,7 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 			hostMaster: v1alpha1.HostMaster{
 				Type: linuxBridgeHostAttachment,
 				LinuxBridge: &v1alpha1.LinuxBridgeConfig{
-					AutoCreate: ptr.To(true),
+					AutoCreate: new(true),
 				},
 			},
 		}),
@@ -373,7 +373,7 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 			hostMaster: v1alpha1.HostMaster{
 				Type: linuxBridgeHostAttachment,
 				LinuxBridge: &v1alpha1.LinuxBridgeConfig{
-					AutoCreate: ptr.To(true),
+					AutoCreate: new(true),
 				},
 			},
 		}),
@@ -385,7 +385,7 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 			hostMaster: v1alpha1.HostMaster{
 				Type: ovsBridgeHostAttachment,
 				OVSBridge: &v1alpha1.OVSBridgeConfig{
-					AutoCreate: ptr.To(true),
+					AutoCreate: new(true),
 				},
 			},
 		}),
@@ -397,7 +397,7 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 			hostMaster: v1alpha1.HostMaster{
 				Type: ovsBridgeHostAttachment,
 				OVSBridge: &v1alpha1.OVSBridgeConfig{
-					AutoCreate: ptr.To(true),
+					AutoCreate: new(true),
 				},
 			},
 		}),
@@ -409,7 +409,7 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 			hostMaster: v1alpha1.HostMaster{
 				Type: ovsBridgeHostAttachment,
 				OVSBridge: &v1alpha1.OVSBridgeConfig{
-					AutoCreate: ptr.To(true),
+					AutoCreate: new(true),
 				},
 			},
 		}),
@@ -422,7 +422,7 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 				Type: ovsBridgeHostAttachment,
 				OVSBridge: &v1alpha1.OVSBridgeConfig{
 					Name:       ptr.To(preExistingOVSBridge),
-					AutoCreate: ptr.To(false),
+					AutoCreate: new(false),
 				},
 			},
 		}),
@@ -435,7 +435,7 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 				Type: ovsBridgeHostAttachment,
 				OVSBridge: &v1alpha1.OVSBridgeConfig{
 					Name:       ptr.To(preExistingOVSBridge),
-					AutoCreate: ptr.To(false),
+					AutoCreate: new(false),
 				},
 			},
 		}),
@@ -448,7 +448,7 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 				Type: ovsBridgeHostAttachment,
 				OVSBridge: &v1alpha1.OVSBridgeConfig{
 					Name:       ptr.To(preExistingOVSBridge),
-					AutoCreate: ptr.To(false),
+					AutoCreate: new(false),
 				},
 			},
 		}),

--- a/e2etests/tests/l3vpn_routes.go
+++ b/e2etests/tests/l3vpn_routes.go
@@ -47,10 +47,10 @@ var _ = Describe("SRV6 routes between bgp and the fabric", Ordered, func() {
 			VRF: "red",
 			HostSession: &v1alpha1.HostSession{
 				ASN:     64514,
-				HostASN: ptr.To(int64(64515)),
+				HostASN: new(int64(64515)),
 				LocalCIDR: v1alpha1.LocalCIDRConfig{
-					IPv4: ptr.To("192.169.10.0/24"),
-					IPv6: ptr.To("2001:db8:1::/64"),
+					IPv4: new("192.169.10.0/24"),
+					IPv6: new("2001:db8:1::/64"),
 				},
 			},
 			RDAssignedNumber: 100,
@@ -75,10 +75,10 @@ var _ = Describe("SRV6 routes between bgp and the fabric", Ordered, func() {
 			VRF: "blue",
 			HostSession: &v1alpha1.HostSession{
 				ASN:     64514,
-				HostASN: ptr.To(int64(64515)),
+				HostASN: new(int64(64515)),
 				LocalCIDR: v1alpha1.LocalCIDRConfig{
-					IPv4: ptr.To("192.169.11.0/24"),
-					IPv6: ptr.To("2001:db8:2::/64"),
+					IPv4: new("192.169.11.0/24"),
+					IPv6: new("2001:db8:2::/64"),
 				},
 			},
 			RDAssignedNumber: 200,
@@ -428,10 +428,10 @@ var _ = Describe("SRV6 routes between bgp and the fabric with iBGP testing e2e i
 			VRF: "red",
 			HostSession: &v1alpha1.HostSession{
 				ASN:     64514,
-				HostASN: ptr.To(int64(64515)),
+				HostASN: new(int64(64515)),
 				LocalCIDR: v1alpha1.LocalCIDRConfig{
-					IPv4: ptr.To("192.169.10.0/24"),
-					IPv6: ptr.To("2001:db8:1::/64"),
+					IPv4: new("192.169.10.0/24"),
+					IPv6: new("2001:db8:1::/64"),
 				},
 			},
 			RDAssignedNumber: 100,

--- a/e2etests/tests/singlesession.go
+++ b/e2etests/tests/singlesession.go
@@ -24,7 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/utils/ptr"
 )
 
 var singleSessionUnderlay = v1alpha1.Underlay{
@@ -37,7 +36,7 @@ var singleSessionUnderlay = v1alpha1.Underlay{
 		Interfaces: []v1alpha1.UnderlayInterface{{Type: "NetworkDevice", NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "toswitch1"}}},
 		Neighbors: []v1alpha1.Neighbor{
 			{
-				ASN:     ptr.To(int64(64512)),
+				ASN:     new(int64(64512)),
 				Address: new("192.168.11.2"),
 			},
 		},
@@ -56,10 +55,10 @@ var vniRedSingleSession = v1alpha1.L3VNI{
 		VRF: "red",
 		HostSession: &v1alpha1.HostSession{
 			ASN:     64514,
-			HostASN: ptr.To(int64(64515)),
+			HostASN: new(int64(64515)),
 			LocalCIDR: v1alpha1.LocalCIDRConfig{
-				IPv4: ptr.To("192.169.10.0/24"),
-				IPv6: ptr.To("2001:db8:169:10::/64"),
+				IPv4: new("192.169.10.0/24"),
+				IPv6: new("2001:db8:169:10::/64"),
 			},
 		},
 		VNI: 100,
@@ -72,13 +71,13 @@ var l2vniRedSingleSession = v1alpha1.L2VNI{
 		Namespace: openperouter.Namespace,
 	},
 	Spec: v1alpha1.L2VNISpec{
-		VRF:          ptr.To("red"),
+		VRF:          new("red"),
 		VNI:          110,
 		L2GatewayIPs: []string{"192.171.24.1/24"},
 		HostMaster: &v1alpha1.HostMaster{
 			Type: "linux-bridge",
 			LinuxBridge: &v1alpha1.LinuxBridgeConfig{
-				AutoCreate: ptr.To(true),
+				AutoCreate: new(true),
 			},
 		},
 	},

--- a/e2etests/tests/underlay_address_families.go
+++ b/e2etests/tests/underlay_address_families.go
@@ -21,7 +21,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/utils/ptr"
 )
 
 // Test IPv6 and Unnumbered peering in a separate context, and run a handful of tests only for l2vpn, l3vpn and
@@ -60,10 +59,10 @@ var runUnderlayTests = func(af ipfamily.Family, underlay v1alpha1.Underlay) {
 		Spec: v1alpha1.L3PassthroughSpec{
 			HostSession: v1alpha1.HostSession{
 				ASN:     64514,
-				HostASN: ptr.To(int64(64515)),
+				HostASN: new(int64(64515)),
 				LocalCIDR: v1alpha1.LocalCIDRConfig{
-					IPv4: ptr.To("192.169.10.0/24"),
-					IPv6: ptr.To("2001:db8:1::/64"),
+					IPv4: new("192.169.10.0/24"),
+					IPv6: new("2001:db8:1::/64"),
 				},
 			},
 		},
@@ -75,13 +74,13 @@ var runUnderlayTests = func(af ipfamily.Family, underlay v1alpha1.Underlay) {
 			Namespace: openperouter.Namespace,
 		},
 		Spec: v1alpha1.L2VNISpec{
-			VRF:          ptr.To("red"),
+			VRF:          new("red"),
 			VNI:          110,
 			L2GatewayIPs: []string{l2GatewayIP},
 			HostMaster: &v1alpha1.HostMaster{
 				Type: linuxBridgeHostAttachment,
 				LinuxBridge: &v1alpha1.LinuxBridgeConfig{
-					AutoCreate: ptr.To(true),
+					AutoCreate: new(true),
 				},
 			},
 		},


### PR DESCRIPTION
Run go fix against entire code base

go fix ./...
cd e2etests/ && go fix ./...

See https://go.dev/doc/go1.26#go-command

```
The venerable go fix command has been completely revamped and is now the home of Go’s modernizers. It provides a dependable, push-button way to update Go code bases to the latest idioms and core library APIs. 
```

**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:

Update to latest go idioms with `go fix`

**Special notes for your reviewer**:

Update to latest go idioms with `go fix`

**Release note**:

```release-note
Update to latest go idioms with `go fix` for e2etests
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
