### PR TITLE
Test: Troubleshooting CI failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG FRR_IMAGE=quay.io/frrouting/frr:10.6.0
+ARG FRR_IMAGE=quay.io/frrouting/frr:10.6.1
 
 # Build the manager binary
 FROM golang:1.26.3 AS builder

--- a/charts/openperouter/templates/router.yaml
+++ b/charts/openperouter/templates/router.yaml
@@ -182,6 +182,16 @@ spec:
               fi
             done
             exec nsenter --net=/var/run/netns/perouter /sbin/tini -- /usr/lib/frr/docker-start
+        # Use the same probe as the reloader. If FRR's health is not o.k., both
+        # the frr and the reloader container must be restarted.
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          timeoutSeconds: 1
+          failureThreshold: 3
         {{- with .Values.openperouter.frr.resources }}
         resources:
           {{- toYaml . | nindent 12 }}

--- a/charts/openperouter/values.schema.json
+++ b/charts/openperouter/values.schema.json
@@ -330,7 +330,7 @@
             "default": {
               "image": {
                 "repository": "quay.io/frrouting/frr",
-                "tag": "10.6.0"
+                "tag": "10.6.1"
               },
               "resources": {},
               "reloader": {}

--- a/clab/multicluster/kind.clab.yml
+++ b/clab/multicluster/kind.clab.yml
@@ -3,7 +3,7 @@ topology:
   groups:
     frr:
       kind: linux
-      image: quay.io/frrouting/frr:10.6.0
+      image: quay.io/frrouting/frr:10.6.1
       binds:
         - ../frrcommon/daemons:/etc/frr/daemons
         - ../frrcommon/vtysh.conf:/etc/frr/vtysh.conf

--- a/clab/scripts/05-load-images.sh
+++ b/clab/scripts/05-load-images.sh
@@ -19,7 +19,7 @@ load_images_to_clusters() {
 
     # Define images to load
     local images=(
-        "quay.io/frrouting/frr:10.6.0 frr10"
+        "quay.io/frrouting/frr:10.6.1 frr10"
         "registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.13.1 rbacproxy"
         "quay.io/metallb/frr-k8s:v0.0.17 frrk8s"
     )

--- a/clab/singlecluster/kind.clab.yml
+++ b/clab/singlecluster/kind.clab.yml
@@ -3,7 +3,7 @@ topology:
   groups:
     frr:
       kind: linux
-      image: quay.io/frrouting/frr:10.6.0
+      image: quay.io/frrouting/frr:10.6.1
       binds:
         - ../frrcommon/daemons:/etc/frr/daemons
         - ../frrcommon/vtysh.conf:/etc/frr/vtysh.conf

--- a/config/all-in-one/crio.yaml
+++ b/config/all-in-one/crio.yaml
@@ -1761,6 +1761,14 @@ spec:
           value: "true"
         image: quay.io/openperouter/router:main
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 9080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          timeoutSeconds: 1
         name: frr
         securityContext:
           capabilities:

--- a/config/all-in-one/openpe.yaml
+++ b/config/all-in-one/openpe.yaml
@@ -1758,6 +1758,14 @@ spec:
           value: "true"
         image: quay.io/openperouter/router:main
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 9080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          timeoutSeconds: 1
         name: frr
         securityContext:
           capabilities:

--- a/config/pods/perouter.yaml
+++ b/config/pods/perouter.yaml
@@ -60,6 +60,16 @@ spec:
               fi
             done
             exec nsenter --net=/var/run/netns/perouter /sbin/tini -- /usr/lib/frr/docker-start
+        # Use the same probe as the reloader. If FRR's health is not o.k., both
+        # the frr and the reloader container must be restarted.
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          timeoutSeconds: 1
+          failureThreshold: 3
       - name: reloader
         image: router:latest
         imagePullPolicy: IfNotPresent

--- a/e2etests/pkg/frr/dump.go
+++ b/e2etests/pkg/frr/dump.go
@@ -43,6 +43,7 @@ func RawDump(exec executor.Executor) string {
 	}
 
 	perNeighborCommands := []string{
+		"show bgp %s neighbors %s received-routes",
 		"show bgp %s neighbors %s advertised-routes",
 		"show bgp %s neighbors %s advertised-routes detail",
 		"show bgp %s neighbors %s graceful-restart",

--- a/e2etests/pkg/infra/testdata/leafkind.tmpl
+++ b/e2etests/pkg/infra/testdata/leafkind.tmpl
@@ -23,8 +23,6 @@ debug bfd peer
 debug bfd zebra
 
 router bgp 64512
- bgp graceful-restart
- bgp graceful-restart preserve-fw-state
  no bgp ebgp-requires-policy
  no bgp network import-check
  no bgp default ipv4-unicast

--- a/internal/frr/docker_test.go
+++ b/internal/frr/docker_test.go
@@ -23,7 +23,7 @@ var (
 )
 
 const (
-	frrImageTag = "10.6.0"
+	frrImageTag = "10.6.1"
 )
 
 func init() {

--- a/internal/frr/templates/neighborsession.tmpl
+++ b/internal/frr/templates/neighborsession.tmpl
@@ -4,6 +4,7 @@
   {{- else }}
   neighbor {{.neighbor.Interface}} interface remote-as {{.neighbor.ASN}}
   {{- end }}
+  neighbor {{ .neighbor.ID }} soft-reconfiguration inbound
   {{- if .neighbor.EBGPMultiHop }}
   neighbor {{.neighbor.ID}} ebgp-multihop
   {{- end }}

--- a/internal/frr/testdata/TestBFDEnabled.golden
+++ b/internal/frr/testdata/TestBFDEnabled.golden
@@ -11,6 +11,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestBFDProfile.golden
+++ b/internal/frr/testdata/TestBFDProfile.golden
@@ -16,6 +16,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestBasic.golden
+++ b/internal/frr/testdata/TestBasic.golden
@@ -14,6 +14,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestBasicWithASNRT.golden
+++ b/internal/frr/testdata/TestBasicWithASNRT.golden
@@ -14,6 +14,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestBasicWithIPRT.golden
+++ b/internal/frr/testdata/TestBasicWithIPRT.golden
@@ -14,6 +14,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestDualStack.golden
+++ b/internal/frr/testdata/TestDualStack.golden
@@ -14,6 +14,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestDualStackWithRT.golden
+++ b/internal/frr/testdata/TestDualStackWithRT.golden
@@ -14,6 +14,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestExternal.golden
+++ b/internal/frr/testdata/TestExternal.golden
@@ -14,6 +14,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as external
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestGracefulRestart.golden
+++ b/internal/frr/testdata/TestGracefulRestart.golden
@@ -15,6 +15,7 @@ router bgp 64512
   bgp graceful-restart restart-time 120
   bgp graceful-restart stalepath-time 360
   neighbor 192.168.1.2 remote-as 64512
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestGracefulRestartCustomTimers.golden
+++ b/internal/frr/testdata/TestGracefulRestartCustomTimers.golden
@@ -15,6 +15,7 @@ router bgp 64512
   bgp graceful-restart restart-time 90
   bgp graceful-restart stalepath-time 180
   neighbor 192.168.1.2 remote-as 64512
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestIPv6Only.golden
+++ b/internal/frr/testdata/TestIPv6Only.golden
@@ -14,6 +14,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 2001:db8::2 remote-as 64513
+  neighbor 2001:db8::2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestIPv6OnlyWithRT.golden
+++ b/internal/frr/testdata/TestIPv6OnlyWithRT.golden
@@ -14,6 +14,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 2001:db8::2 remote-as 64513
+  neighbor 2001:db8::2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestInternal.golden
+++ b/internal/frr/testdata/TestInternal.golden
@@ -14,6 +14,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as internal
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestL3VNIWithLocalNeighborAndRedistributeConnected.golden
+++ b/internal/frr/testdata/TestL3VNIWithLocalNeighborAndRedistributeConnected.golden
@@ -14,6 +14,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestL3VNIWithoutLocalNeighborAndAdvertise.golden
+++ b/internal/frr/testdata/TestL3VNIWithoutLocalNeighborAndAdvertise.golden
@@ -14,6 +14,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestNoVNIs.golden
+++ b/internal/frr/testdata/TestNoVNIs.golden
@@ -11,6 +11,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestPassthroughDual.golden
+++ b/internal/frr/testdata/TestPassthroughDual.golden
@@ -11,6 +11,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestPassthroughExternal.golden
+++ b/internal/frr/testdata/TestPassthroughExternal.golden
@@ -11,6 +11,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestPassthroughNoEVPN.golden
+++ b/internal/frr/testdata/TestPassthroughNoEVPN.golden
@@ -11,6 +11,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestPassthroughV4.golden
+++ b/internal/frr/testdata/TestPassthroughV4.golden
@@ -11,6 +11,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestRawConfig.golden
+++ b/internal/frr/testdata/TestRawConfig.golden
@@ -11,6 +11,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/operator/bindata/deployment/openperouter/templates/router.yaml
+++ b/operator/bindata/deployment/openperouter/templates/router.yaml
@@ -182,6 +182,16 @@ spec:
               fi
             done
             exec nsenter --net=/var/run/netns/perouter /sbin/tini -- /usr/lib/frr/docker-start
+        # Use the same probe as the reloader. If FRR's health is not o.k., both
+        # the frr and the reloader container must be restarted.
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          timeoutSeconds: 1
+          failureThreshold: 3
         {{- with .Values.openperouter.frr.resources }}
         resources:
           {{- toYaml . | nindent 12 }}

--- a/operator/bindata/deployment/openperouter/values.schema.json
+++ b/operator/bindata/deployment/openperouter/values.schema.json
@@ -330,7 +330,7 @@
             "default": {
               "image": {
                 "repository": "quay.io/frrouting/frr",
-                "tag": "10.6.0"
+                "tag": "10.6.1"
               },
               "resources": {},
               "reloader": {}

--- a/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2026-05-25T11:59:32Z"
+    createdAt: "2026-05-26T12:01:51Z"
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: openperouter-operator.v0.0.0

--- a/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2026-05-26T12:01:51Z"
+    createdAt: "2026-05-26T12:03:08Z"
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: openperouter-operator.v0.0.0

--- a/website/content/docs/installation/_index.md
+++ b/website/content/docs/installation/_index.md
@@ -101,7 +101,7 @@ openperouter:
   frr:
     image:
       repository: "quay.io/frrouting/frr"
-      tag: "10.6.0"
+      tag: "10.6.1"
 ```
 
 Then install with custom values:


### PR DESCRIPTION
Fix several issues with the resource dump:
- run bridge fdb show instead of bridge fdb show <hardcoded device>
  which failed in a lot of cases.
- use errors.Join() properly. There's no need to do this on every
  iteration of the loop. Instead, run it once before returning.
- do not continue when an error was found. Instead, print the errors but
  add the output to the log file. Otherwise, if a single command fails,
  we'd not capture anything.
- in `should create two pods connected to the l2 overlay`, dump before
  resetting the leaves.

Add namespace-level debug dump for e2e test failures

Extend dumpIfFails to accept additional namespaces and collect pod lists
and per-container networking info (ip link, address, neigh, routes,
bridge fdb) when a test fails. Wire it up in the EVPN L2 tests to also
dump the test namespace.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

Fix several issues with the resource dump on failure:

**Special notes for your reviewer**:

Fix several issues with the resource dump on failure:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix several issues with the resource dump on failure:
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
