### PR TITLE
Test: soft reconfiguration inbound

### DIFF
--- a/e2etests/pkg/frr/dump.go
+++ b/e2etests/pkg/frr/dump.go
@@ -3,53 +3,90 @@
 package frr
 
 import (
-	"errors"
+	"encoding/json"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/openperouter/openperouter/e2etests/pkg/executor"
 )
 
-func RawDump(exec executor.Executor) (string, error) {
-	res := ""
-	allerrs := errors.New("")
+type command struct {
+	desc     string
+	cmd      []string
+	optional bool // optional = true means that we will not log anything (not even the failure) in case of an error.
+}
 
-	commands := []struct {
-		desc string
-		cmd  []string
-	}{
-		{"Show version", []string{"vtysh", "-c", "show version"}},
-		{"Show running config", []string{"vtysh", "-c", "show running-config"}},
-		{"BGP Summary", []string{"vtysh", "-c", "show bgp vrf all summary"}},
-		{"BGP Neighbors", []string{"vtysh", "-c", "show bgp vrf all neighbor"}},
-		{"RIB ipv4", []string{"vtysh", "-c", "show ip route"}},
-		{"RIB ipv6", []string{"vtysh", "-c", "show ipv6 route"}},
-		{"BGP route table ipv4", []string{"vtysh", "-c", "show bgp vrf all ipv4"}},
-		{"BGP route table ipv6", []string{"vtysh", "-c", "show bgp vrf all ipv6"}},
-		{"EVPN Routes", []string{"vtysh", "-c", "show bgp l2vpn evpn"}},
-		{"Zebra interface information", []string{"vtysh", "-c", "show interface"}},
-		{"ip link", []string{"bash", "-c", "ip l"}},
-		{"ip address", []string{"bash", "-c", "ip address"}},
-		{"ip neigh", []string{"bash", "-c", "ip neigh"}},
-		{"Detailed interface statistics", []string{"bash", "-c", "ip -s -s link ls"}},
-		{"ip vrf", []string{"bash", "-c", "ip vrf"}},
-		{"ip route table all", []string{"bash", "-c", "ip route show table all"}},
-		{"bridge fdb (vni110)", []string{"bash", "-c", "bridge fdb show dev vni110"}},
-		{"bridge fdb (br-pe-110)", []string{"bash", "-c", "bridge fdb show dev br-pe-110"}},
+func RawDump(exec executor.Executor) string {
+	var res strings.Builder
+
+	commands := []command{
+		{desc: "Show version", cmd: []string{"vtysh", "-c", "show version"}},
+		{desc: "Show running config", cmd: []string{"vtysh", "-c", "show running-config"}},
+		{desc: "BGP Summary", cmd: []string{"vtysh", "-c", "show bgp vrf all summary"}},
+		{desc: "BGP Neighbors", cmd: []string{"vtysh", "-c", "show bgp vrf all neighbor"}},
+		{desc: "RIB ipv4", cmd: []string{"vtysh", "-c", "show ip route"}},
+		{desc: "RIB ipv6", cmd: []string{"vtysh", "-c", "show ipv6 route"}},
+		{desc: "BGP route table ipv4", cmd: []string{"vtysh", "-c", "show bgp vrf all ipv4"}},
+		{desc: "BGP route table ipv6", cmd: []string{"vtysh", "-c", "show bgp vrf all ipv6"}},
+		{desc: "EVPN Routes", cmd: []string{"vtysh", "-c", "show bgp l2vpn evpn"}},
+		{desc: "Zebra interface information", cmd: []string{"vtysh", "-c", "show interface"}},
+		{desc: "ip link", cmd: []string{"bash", "-c", "ip l"}},
+		{desc: "ip address", cmd: []string{"bash", "-c", "ip address"}},
+		{desc: "ip neigh", cmd: []string{"bash", "-c", "ip neigh"}},
+		{desc: "Detailed interface statistics", cmd: []string{"bash", "-c", "ip -s -s link ls"}},
+		{desc: "ip vrf", cmd: []string{"bash", "-c", "ip vrf"}},
+		{desc: "ip route table all", cmd: []string{"bash", "-c", "ip route show table all"}},
+		{desc: "bridge fdb show", cmd: []string{"bash", "-c", "bridge fdb show"}},
 	}
+
+	neighbors, err := getBGPNeighbors(exec)
+	if err == nil {
+		perNeighborCommands := []string{
+			"show ip bgp neighbors %s advertised-routes",
+			"show ip bgp neighbors %s advertised-routes detail",
+			"show bgp neighbors %s graceful-restart",
+		}
+		for _, neighbor := range neighbors {
+			for _, perNeighborCommand := range perNeighborCommands {
+				cmd := fmt.Sprintf(perNeighborCommand, neighbor)
+				commands = append(commands, command{
+					desc: cmd, cmd: []string{"vtysh", "-c", cmd},
+				})
+			}
+		}
+	}
+
+	// Collect logs from /etc/frr/frr.log. This is for the leaf and leafkind
+	// docker containers only and will fail for the router pods.
+	commands = append(commands, command{
+		"cat /etc/frr/frr.log", []string{"bash", "-c", "cat /etc/frr/frr.log"}, true, // Will only work on leaf/leafkind.
+	})
 
 	for _, c := range commands {
-		res += fmt.Sprintf("\n######## %s\n\n", c.desc)
 		out, err := exec.Exec(c.cmd[0], c.cmd[1:]...)
-		if err != nil {
-			allerrs = errors.Join(allerrs, fmt.Errorf("\nFailed exec %q: %v", strings.Join(c.cmd, " "), err))
+		if err != nil && c.optional {
+			continue
 		}
-		res += out
+		fmt.Fprintf(&res, "\n######## %s\n\n", c.desc)
+		if err != nil {
+			fmt.Fprintf(&res, "\nFailed exec %q: %v", strings.Join(c.cmd, " "), err)
+		}
+		res.WriteString(out)
 	}
 
-	if allerrs.Error() == "" {
-		allerrs = nil
-	}
+	return res.String()
+}
 
-	return res, allerrs
+func getBGPNeighbors(exec executor.Executor) ([]string, error) {
+	out, err := exec.Exec("vtysh", "-c", "show ip bgp neighbors json")
+	if err != nil {
+		return nil, fmt.Errorf("getBGPNeighbors: command failed: %w", err)
+	}
+	neighbors := map[string]any{}
+	if err = json.Unmarshal([]byte(out), &neighbors); err != nil {
+		return nil, fmt.Errorf("getBGPNeighbors: unmarchalling failed: out: %s, err: %w", out, err)
+	}
+	return slices.Collect(maps.Keys(neighbors)), nil
 }

--- a/e2etests/pkg/frr/dump.go
+++ b/e2etests/pkg/frr/dump.go
@@ -44,6 +44,7 @@ func RawDump(exec executor.Executor) string {
 	neighbors, err := getBGPNeighbors(exec)
 	if err == nil {
 		perNeighborCommands := []string{
+			"show ip bgp neighbors %s received-routes",
 			"show ip bgp neighbors %s advertised-routes",
 			"show ip bgp neighbors %s advertised-routes detail",
 			"show bgp neighbors %s graceful-restart",

--- a/e2etests/pkg/infra/testdata/leafkind.tmpl
+++ b/e2etests/pkg/infra/testdata/leafkind.tmpl
@@ -16,6 +16,8 @@ debug bgp updates
 debug bgp keepalives
 debug bgp nht
 debug bgp zebra
+debug bgp neighbor
+debug bgp graceful-restart
 debug bfd network
 debug bfd peer
 debug bfd zebra

--- a/e2etests/tests/bridgerefresh.go
+++ b/e2etests/tests/bridgerefresh.go
@@ -160,7 +160,7 @@ var _ = Describe("BridgeRefresher E2E - Type 2 Route Persistence", Ordered, func
 		})
 
 		AfterEach(func() {
-			dumpIfFails(cs)
+			dumpIfFails(cs, testNamespace)
 
 			By("Deleting test namespace")
 			Expect(k8s.DeleteNamespace(cs, testNamespace)).To(Succeed())
@@ -247,7 +247,7 @@ var _ = Describe("BridgeRefresher E2E - Type 2 Route Persistence", Ordered, func
 				Expect(len(nodes)).To(BeNumerically(">=", 2), "Expected at least 2 nodes")
 
 				DeferCleanup(func() {
-					dumpIfFails(cs)
+					dumpIfFails(cs, testNamespace)
 
 					By("Deleting test namespace")
 					Expect(k8s.DeleteNamespace(cs, testNamespace)).To(Succeed())

--- a/e2etests/tests/dump.go
+++ b/e2etests/tests/dump.go
@@ -3,11 +3,13 @@
 package tests
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"path"
 	"regexp"
+	"strings"
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -18,12 +20,17 @@ import (
 	"github.com/openperouter/openperouter/e2etests/pkg/k8s"
 	"github.com/openperouter/openperouter/e2etests/pkg/openperouter"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/yaml"
 )
 
-func dumpIfFails(cs clientset.Interface) {
+func dumpIfFails(cs clientset.Interface, additionalNamespaces ...string) {
 	if ginkgo.CurrentSpecReport().Failed() {
 		dumpBGPInfo(ReportPath, ginkgo.CurrentSpecReport().FullText(), cs, infra.LeafA, infra.LeafB, infra.KindLeaf)
+		for _, namespace := range additionalNamespaces {
+			dumpNamespaceInfo(ReportPath, ginkgo.CurrentSpecReport().FullText(), cs, namespace)
+		}
 		k8s.DumpInfo(K8sReporter, ginkgo.CurrentSpecReport().FullText())
 		if HostMode {
 			dumpPodmanInfo(cs, ReportPath, ginkgo.CurrentSpecReport().FullText())
@@ -34,9 +41,19 @@ func dumpIfFails(cs clientset.Interface) {
 func dumpBGPInfo(basePath, testName string, cs clientset.Interface, clabContainers ...string) {
 	testPath, err := createTestOutput(basePath, testName)
 	if err != nil {
-		ginkgo.GinkgoWriter.Printf("failed to create test dir: %s", err)
+		ginkgo.GinkgoWriter.Printf("dumpBGPInfo: failed to create test dir: %v", err)
 		return
 	}
+
+	// Dump YAML output about all pods in the openperouter namespace.
+	namespace := openperouter.Namespace
+	pods, err := cs.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		ginkgo.GinkgoWriter.Printf("dumpBGPInfo: failed to list pods in namespace %s: %v", namespace, err)
+	} else {
+		dumpPodList(pods.Items, testPath, namespace)
+	}
+
 	executors := map[string]executor.Executor{}
 	for _, c := range clabContainers {
 		exec := executor.ForContainer(c)
@@ -60,22 +77,86 @@ func dumpBGPInfo(basePath, testName string, cs clientset.Interface, clabContaine
 	}
 
 	for name, exec := range executors {
-		dump, err := frr.RawDump(exec)
-		if err != nil {
-			ginkgo.GinkgoWriter.Printf("External frr dump for %s failed %v", name, err)
-			continue
-		}
+		dump := frr.RawDump(exec)
 		f, err := logFileFor(testPath, fmt.Sprintf("frrdump-%s", name))
 		if err != nil {
-			ginkgo.GinkgoWriter.Printf("External frr dump for container %s, failed to open file %v", name, err)
+			ginkgo.GinkgoWriter.Printf("dumpBGPInfo: external frr dump for container %s, failed to open file %v", name, err)
 			continue
 		}
+		defer func() {
+			_ = f.Close()
+		}()
 		fmt.Fprintf(f, "Dumping information for %s", name)
-		_, err = fmt.Fprint(f, dump)
-		if err != nil {
-			ginkgo.GinkgoWriter.Printf("External frr dump for container %s, failed to write to file %v", name, err)
+		if _, err = fmt.Fprint(f, dump); err != nil {
+			ginkgo.GinkgoWriter.Printf("dumpBGPInfo: external frr dump for container %s, failed to write to file %v", name, err)
 			continue
 		}
+	}
+}
+
+// dumpNamespaceInfo gathers the pod list inside namespace and stores it in a file, in YAML format.
+// It also runs an executor inside each pod where it collects basic networking information.
+func dumpNamespaceInfo(basePath, testName string, cs clientset.Interface, namespace string) {
+	testPath, err := createTestOutput(basePath, testName)
+	if err != nil {
+		ginkgo.GinkgoWriter.Printf("dumpNamespaceInfo: failed to create test dir: %s", err)
+		return
+	}
+
+	pods, err := cs.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		ginkgo.GinkgoWriter.Printf("dumpNamespaceInfo: failed to list pods in namespace %s: %v", namespace, err)
+		return
+	}
+	dumpPodList(pods.Items, testPath, namespace)
+
+	executors := map[string]executor.Executor{}
+	for _, pod := range pods.Items {
+		for _, container := range pod.Spec.Containers {
+			exec := executor.ForPod(pod.Namespace, pod.Name, container.Name)
+			executors[fmt.Sprintf("%s-%s-%s", pod.Namespace, pod.Name, container.Name)] = exec
+		}
+	}
+
+	for name, exec := range executors {
+		dump := podRawDump(exec)
+		f, err := logFileFor(testPath, fmt.Sprintf("pod-container-dump-%s", name))
+		if err != nil {
+			ginkgo.GinkgoWriter.Printf("dumpNamespaceInfo: external dump for pod container %s, failed to open file %v", name, err)
+			continue
+		}
+		defer func() {
+			_ = f.Close()
+		}()
+		fmt.Fprintf(f, "Dumping information for %s", name)
+		if _, err = fmt.Fprint(f, dump); err != nil {
+			ginkgo.GinkgoWriter.Printf("dumpNamespaceInfo: external dump for pod container %s, failed to write to file %v", name, err)
+			continue
+		}
+	}
+}
+
+func dumpPodList(pods []corev1.Pod, testPath, namespace string) {
+	fileName := fmt.Sprintf("pod-list-namespace-%s", namespace)
+	f, err := logFileFor(testPath, fileName)
+	if err != nil {
+		ginkgo.GinkgoWriter.Printf("dumpPodList: failed to open file %s for namespace %s: %v",
+			fileName, namespace, err)
+		return
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+	fmt.Fprintf(f, "Dumping information for namespace %s\n", namespace)
+	out, err := yaml.Marshal(pods)
+	if err != nil {
+		ginkgo.GinkgoWriter.Printf("dumpPodList: failed to marshal pods to yaml for namespace %s: %v",
+			namespace, err)
+		return
+	}
+	if _, err = fmt.Fprint(f, string(out)); err != nil {
+		ginkgo.GinkgoWriter.Printf("dumpPodList: failed to write to file %s for namespace %s: %v",
+			fileName, namespace, err)
 	}
 }
 
@@ -91,24 +172,24 @@ func logFileFor(base string, kind string) (*os.File, error) {
 func dumpPodmanInfo(cs clientset.Interface, basePath, testName string) {
 	testPath, err := createTestOutput(basePath, testName)
 	if err != nil {
-		ginkgo.GinkgoWriter.Printf("failed to create test dir: %s", err)
+		ginkgo.GinkgoWriter.Printf("dumpPodmanInfo: failed to create test dir: %s", err)
 		return
 	}
 
 	nodes, err := k8s.GetNodes(cs)
 	if err != nil {
-		ginkgo.GinkgoWriter.Printf("Failed to get nodes for podman dump: %v", err)
+		ginkgo.GinkgoWriter.Printf("dumpPodmanInfo: failed to get nodes: %v", err)
 		return
 	}
 
 	dump, err := openperouter.DumpPodmanLogs(nodes)
 	if err != nil {
-		ginkgo.GinkgoWriter.Printf("Podman dump failed: %v", err)
+		ginkgo.GinkgoWriter.Printf("dumpPodmanInfo: failed to dump podman logs: %v", err)
 	}
 
 	f, err := logFileFor(testPath, "podmandump")
 	if err != nil {
-		ginkgo.GinkgoWriter.Printf("Podman dump failed to open file: %v", err)
+		ginkgo.GinkgoWriter.Printf("dumpPodmanInfo: failed to open file: %v", err)
 		return
 	}
 	defer f.Close()
@@ -116,7 +197,7 @@ func dumpPodmanInfo(cs clientset.Interface, basePath, testName string) {
 	fmt.Fprint(f, "Dumping podman information\n")
 	_, err = fmt.Fprint(f, dump)
 	if err != nil {
-		ginkgo.GinkgoWriter.Printf("Podman dump failed to write to file: %v", err)
+		ginkgo.GinkgoWriter.Printf("dumpPodmanInfo: failed to write to file: %v", err)
 		return
 	}
 }
@@ -144,4 +225,29 @@ func createTestOutput(basePath, testName string) (string, error) {
 		return "", fmt.Errorf("failed to create test dir: %w", err)
 	}
 	return testPath, nil
+}
+
+func podRawDump(exec executor.Executor) string {
+	var res strings.Builder
+
+	commands := []struct {
+		desc string
+		cmd  []string
+	}{
+		{"ip link", []string{"bash", "-c", "ip l"}},
+		{"ip address", []string{"bash", "-c", "ip address"}},
+		{"ip neigh", []string{"bash", "-c", "ip neigh"}},
+		{"Detailed interface statistics", []string{"bash", "-c", "ip -s -s link ls"}},
+		{"ip route table all", []string{"bash", "-c", "ip route show table all"}},
+	}
+
+	for _, c := range commands {
+		fmt.Fprintf(&res, "\n######## %s\n\n", c.desc)
+		out, err := exec.Exec(c.cmd[0], c.cmd[1:]...)
+		if err != nil {
+			fmt.Fprintf(&res, "\nFailed exec %q: %v", strings.Join(c.cmd, " "), err)
+		}
+		res.WriteString(out)
+	}
+	return res.String()
 }

--- a/e2etests/tests/evpn_l2.go
+++ b/e2etests/tests/evpn_l2.go
@@ -124,9 +124,9 @@ var _ = Describe("Routes between bgp and the fabric", Ordered, func() {
 		nadMaster                                                         string              // Bridge name for NAD (defaults to "br-hs-110")
 	}
 	AfterEach(func() {
+		dumpIfFails(cs, testNamespace)
 		Expect(infra.LeafAConfig.Reset()).To(Succeed())
 		Expect(infra.LeafBConfig.Reset()).To(Succeed())
-		dumpIfFails(cs)
 		err := Updater.CleanButUnderlay()
 		Expect(err).NotTo(HaveOccurred())
 		err = k8s.DeleteNamespace(cs, testNamespace)
@@ -427,8 +427,8 @@ var _ = Describe("Routes between bgp and the fabric - vtepInterface", func() {
 	})
 
 	AfterEach(func() {
+		dumpIfFails(cs, testNamespace)
 		resetLeafKindConfig(nodes)
-		dumpIfFails(cs)
 		err := Updater.CleanAll()
 		Expect(err).NotTo(HaveOccurred())
 

--- a/e2etests/tests/evpn_routes.go
+++ b/e2etests/tests/evpn_routes.go
@@ -337,7 +337,7 @@ var _ = Describe("Routes between bgp and the fabric", Ordered, func() {
 		})
 
 		AfterEach(func() {
-			dumpIfFails(cs)
+			dumpIfFails(cs, testNamespace)
 		})
 
 		DescribeTable("should be able to reach the hosts from the test pod and vice versa", func(
@@ -517,7 +517,7 @@ var _ = Describe("Routes between bgp and the fabric with iBGP testing e2e integr
 	})
 
 	AfterEach(func() {
-		dumpIfFails(cs)
+		dumpIfFails(cs, testNamespace)
 
 		By("Deleting the test namespace")
 		err := k8s.DeleteNamespace(cs, testNamespace)

--- a/e2etests/tests/frr_restart.go
+++ b/e2etests/tests/frr_restart.go
@@ -118,9 +118,9 @@ var _ = Describe("North/south traffic after FRR container restart", Ordered, fun
 		Expect(err).NotTo(HaveOccurred())
 
 		DeferCleanup(func() {
+			dumpIfFails(cs, testNamespace)
 			Expect(infra.LeafAConfig.Reset()).To(Succeed())
 			Expect(infra.LeafBConfig.Reset()).To(Succeed())
-			dumpIfFails(cs)
 			err := Updater.CleanButUnderlay()
 			Expect(err).NotTo(HaveOccurred())
 			err = k8s.DeleteNamespace(cs, testNamespace)

--- a/e2etests/tests/passthrough_routes.go
+++ b/e2etests/tests/passthrough_routes.go
@@ -221,7 +221,7 @@ var _ = Describe("Routes between bgp and the fabric", Label("passthrough"), Orde
 		})
 
 		AfterEach(func() {
-			dumpIfFails(cs)
+			dumpIfFails(cs, testNamespace)
 		})
 
 		It("host and the pod from each other with the expected ips", func() {

--- a/e2etests/tests/resiliency.go
+++ b/e2etests/tests/resiliency.go
@@ -342,7 +342,7 @@ var _ = Describe("Beta: Named netns auto-rebuilds after deletion", Ordered, func
 	const testNamespace = "test-namespace-rebuild"
 
 	AfterEach(func() {
-		dumpIfFails(cs)
+		dumpIfFails(cs, testNamespace)
 		dumpUnderlayVeths(cs, "Beta AfterEach before cleanup")
 		err := Updater.CleanButUnderlay()
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/frr/templates/frr.tmpl
+++ b/internal/frr/templates/frr.tmpl
@@ -11,6 +11,8 @@ debug bgp updates
 debug bgp keepalives
 debug bgp nht
 debug bgp zebra
+debug bgp neighbor
+debug bgp graceful-restart
 debug bfd network
 debug bfd peer
 debug bfd zebra

--- a/internal/frr/templates/neighborsession.tmpl
+++ b/internal/frr/templates/neighborsession.tmpl
@@ -1,5 +1,6 @@
 {{- define "neighborsession"}}
   neighbor {{.neighbor.Addr}} remote-as {{.neighbor.ASN}}
+  neighbor {{ .neighbor.Addr }} soft-reconfiguration inbound
   {{- if .neighbor.EBGPMultiHop }}
   neighbor {{.neighbor.Addr}} ebgp-multihop
   {{- end }}

--- a/internal/frr/testdata/TestBFDEnabled.golden
+++ b/internal/frr/testdata/TestBFDEnabled.golden
@@ -11,6 +11,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestBFDProfile.golden
+++ b/internal/frr/testdata/TestBFDProfile.golden
@@ -16,6 +16,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestBasic.golden
+++ b/internal/frr/testdata/TestBasic.golden
@@ -14,6 +14,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestBasicWithASNRT.golden
+++ b/internal/frr/testdata/TestBasicWithASNRT.golden
@@ -14,6 +14,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestBasicWithIPRT.golden
+++ b/internal/frr/testdata/TestBasicWithIPRT.golden
@@ -14,6 +14,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestDualStack.golden
+++ b/internal/frr/testdata/TestDualStack.golden
@@ -14,6 +14,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestDualStackWithRT.golden
+++ b/internal/frr/testdata/TestDualStackWithRT.golden
@@ -14,6 +14,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestExternal.golden
+++ b/internal/frr/testdata/TestExternal.golden
@@ -14,6 +14,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as external
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestGracefulRestart.golden
+++ b/internal/frr/testdata/TestGracefulRestart.golden
@@ -15,6 +15,7 @@ router bgp 64512
   bgp graceful-restart restart-time 120
   bgp graceful-restart stalepath-time 360
   neighbor 192.168.1.2 remote-as 64512
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestGracefulRestartCustomTimers.golden
+++ b/internal/frr/testdata/TestGracefulRestartCustomTimers.golden
@@ -15,6 +15,7 @@ router bgp 64512
   bgp graceful-restart restart-time 90
   bgp graceful-restart stalepath-time 180
   neighbor 192.168.1.2 remote-as 64512
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestIPv6Only.golden
+++ b/internal/frr/testdata/TestIPv6Only.golden
@@ -14,6 +14,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 2001:db8::2 remote-as 64513
+  neighbor 2001:db8::2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestIPv6OnlyWithRT.golden
+++ b/internal/frr/testdata/TestIPv6OnlyWithRT.golden
@@ -14,6 +14,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 2001:db8::2 remote-as 64513
+  neighbor 2001:db8::2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestInternal.golden
+++ b/internal/frr/testdata/TestInternal.golden
@@ -14,6 +14,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as internal
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestL3VNIWithLocalNeighborAndRedistributeConnected.golden
+++ b/internal/frr/testdata/TestL3VNIWithLocalNeighborAndRedistributeConnected.golden
@@ -14,6 +14,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestL3VNIWithoutLocalNeighborAndAdvertise.golden
+++ b/internal/frr/testdata/TestL3VNIWithoutLocalNeighborAndAdvertise.golden
@@ -14,6 +14,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestNoVNIs.golden
+++ b/internal/frr/testdata/TestNoVNIs.golden
@@ -11,6 +11,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestPassthroughDual.golden
+++ b/internal/frr/testdata/TestPassthroughDual.golden
@@ -11,6 +11,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestPassthroughExternal.golden
+++ b/internal/frr/testdata/TestPassthroughExternal.golden
@@ -11,6 +11,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestPassthroughNoEVPN.golden
+++ b/internal/frr/testdata/TestPassthroughNoEVPN.golden
@@ -11,6 +11,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestPassthroughV4.golden
+++ b/internal/frr/testdata/TestPassthroughV4.golden
@@ -11,6 +11,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   

--- a/internal/frr/testdata/TestRawConfig.golden
+++ b/internal/frr/testdata/TestRawConfig.golden
@@ -11,6 +11,7 @@ router bgp 64512
   no bgp default ipv4-unicast
   bgp router-id 10.0.0.1
   neighbor 192.168.1.2 remote-as 64513
+  neighbor 192.168.1.2 soft-reconfiguration inbound
   
   
   


### PR DESCRIPTION
- **Fix resource dump on failures and collect more information**
- **Add debug for BGP graceful restart**
- **For troubleshooting, configure soft-reconf inbound and dump**

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
