### PR TITLE
Add liveness probe to FRR container to detect unrecoverable daemon failures

### DIFF
--- a/charts/openperouter/templates/router.yaml
+++ b/charts/openperouter/templates/router.yaml
@@ -182,6 +182,16 @@ spec:
               fi
             done
             exec nsenter --net=/var/run/netns/perouter /sbin/tini -- /usr/lib/frr/docker-start
+        # Use the same probe as the reloader. If FRR's health is not o.k., both
+        # the frr and the reloader container must be restarted.
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          timeoutSeconds: 10
+          failureThreshold: 3
         {{- with .Values.openperouter.frr.resources }}
         resources:
           {{- toYaml . | nindent 12 }}
@@ -221,7 +231,7 @@ spec:
             port: 9080
           initialDelaySeconds: 5
           periodSeconds: 10
-          timeoutSeconds: 1
+          timeoutSeconds: 10
           failureThreshold: 3
         livenessProbe:
           httpGet:
@@ -229,7 +239,7 @@ spec:
             port: 9080
           initialDelaySeconds: 15
           periodSeconds: 20
-          timeoutSeconds: 1
+          timeoutSeconds: 10
           failureThreshold: 3
         {{- with .Values.openperouter.frr.reloader.resources }}
         resources:

--- a/config/all-in-one/crio.yaml
+++ b/config/all-in-one/crio.yaml
@@ -1790,6 +1790,14 @@ spec:
           value: "true"
         image: quay.io/openperouter/router:main
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 9080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          timeoutSeconds: 10
         name: frr
         securityContext:
           capabilities:
@@ -1821,7 +1829,7 @@ spec:
             port: 9080
           initialDelaySeconds: 15
           periodSeconds: 20
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         name: reloader
         ports:
         - containerPort: 9080
@@ -1834,7 +1842,7 @@ spec:
             port: 9080
           initialDelaySeconds: 5
           periodSeconds: 10
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         securityContext:
           seLinuxOptions:
             type: spc_t

--- a/config/all-in-one/openpe.yaml
+++ b/config/all-in-one/openpe.yaml
@@ -1787,6 +1787,14 @@ spec:
           value: "true"
         image: quay.io/openperouter/router:main
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 9080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          timeoutSeconds: 10
         name: frr
         securityContext:
           capabilities:
@@ -1818,7 +1826,7 @@ spec:
             port: 9080
           initialDelaySeconds: 15
           periodSeconds: 20
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         name: reloader
         ports:
         - containerPort: 9080
@@ -1831,7 +1839,7 @@ spec:
             port: 9080
           initialDelaySeconds: 5
           periodSeconds: 10
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         securityContext:
           seLinuxOptions:
             type: spc_t

--- a/config/pods/perouter.yaml
+++ b/config/pods/perouter.yaml
@@ -60,6 +60,16 @@ spec:
               fi
             done
             exec nsenter --net=/var/run/netns/perouter /sbin/tini -- /usr/lib/frr/docker-start
+        # Use the same probe as the reloader. If FRR's health is not o.k., both
+        # the frr and the reloader container must be restarted.
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          timeoutSeconds: 10
+          failureThreshold: 3
       - name: reloader
         image: router:latest
         imagePullPolicy: IfNotPresent
@@ -88,7 +98,7 @@ spec:
             port: 9080
           initialDelaySeconds: 5
           periodSeconds: 10
-          timeoutSeconds: 1
+          timeoutSeconds: 10
           failureThreshold: 3
         livenessProbe:
           httpGet:
@@ -96,7 +106,7 @@ spec:
             port: 9080
           initialDelaySeconds: 15
           periodSeconds: 20
-          timeoutSeconds: 1
+          timeoutSeconds: 10
           failureThreshold: 3
       tolerations:
       - effect: NoSchedule

--- a/operator/bindata/deployment/openperouter/templates/router.yaml
+++ b/operator/bindata/deployment/openperouter/templates/router.yaml
@@ -182,6 +182,16 @@ spec:
               fi
             done
             exec nsenter --net=/var/run/netns/perouter /sbin/tini -- /usr/lib/frr/docker-start
+        # Use the same probe as the reloader. If FRR's health is not o.k., both
+        # the frr and the reloader container must be restarted.
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          timeoutSeconds: 10
+          failureThreshold: 3
         {{- with .Values.openperouter.frr.resources }}
         resources:
           {{- toYaml . | nindent 12 }}
@@ -221,7 +231,7 @@ spec:
             port: 9080
           initialDelaySeconds: 5
           periodSeconds: 10
-          timeoutSeconds: 1
+          timeoutSeconds: 10
           failureThreshold: 3
         livenessProbe:
           httpGet:
@@ -229,7 +239,7 @@ spec:
             port: 9080
           initialDelaySeconds: 15
           periodSeconds: 20
-          timeoutSeconds: 1
+          timeoutSeconds: 10
           failureThreshold: 3
         {{- with .Values.openperouter.frr.reloader.resources }}
         resources:

--- a/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2026-06-05T00:29:44Z"
+    createdAt: "2026-06-17T12:54:16Z"
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: openperouter-operator.v0.0.0

--- a/systemdmode/quadlets/frr.container
+++ b/systemdmode/quadlets/frr.container
@@ -45,6 +45,14 @@ Entrypoint=/bin/bash
 # Changes permissions on /var/run/frr for socket access, then starts FRR via tini.
 Exec=-c "chmod -R a+rw /var/run/frr && exec /sbin/tini -- /usr/lib/frr/docker-start"
 
+# Health check - kill container if FRR stops responding,
+# systemd Restart=on-failure handles restart
+HealthCmd=wget -qO- http://127.0.0.1:9080/healthz || exit 1
+HealthInterval=20s
+HealthTimeout=10s
+HealthRetries=3
+HealthOnFailure=kill
+
 [Service]
 # Restart policy - restart container if it fails
 Restart=on-failure


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

When an FRR daemon such as zebra crashes in a way that watchfrr cannot recover by itself, the FRR container keeps running but remains in a broken state. This adds an HTTP liveness probe to the FRR container that queries the reloader's `/healthz` endpoint (port 9080) so that Kubernetes detects the persistent failure and restarts the pod, recovering all FRR daemons.

Fixes #454

**Special notes for your reviewer**:

The FRR container reuses the same `/healthz` probe endpoint already served by the reloader container. If FRR's health is not o.k., both the frr and the reloader container will be restarted.

**Release note**:

```release-note
Add liveness probe to FRR container to restart the pod when FRR daemons crash and cannot be recovered by watchfrr.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.