### PR TITLE
Set up generation and collection of core dumps in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -263,7 +263,7 @@ jobs:
           if [ ${{ matrix.deployment }} = "systemdmode" ]; then MAKE_RULE="deploy-hostmode"; fi
           if [ ${{ matrix.deployment }} = "hostmode-boot" ]; then MAKE_RULE="deploy-hostmode-boot"; fi
           if [ ${{ matrix.deployment }} = "operator" ]; then MAKE_RULE="deploy-operator-with-olm"; IMG_REPO="localhost:5000"; export USE_HTTP=--use-http; export TLS_VERIFY=false; export KUBECONFIG=bin/kubeconfig; fi
-          IMG_REPO=$IMG_REPO make $MAKE_RULE
+          COREDUMP=true IMG_REPO=$IMG_REPO make $MAKE_RULE
           if [ ${{ matrix.deployment }} = "operator" ]; then IMG_REPO="quay.io/openperouter" make load-on-kind; kubectl apply -f operator/config/samples/openperouter.yaml; sleep 5; kubectl -n openperouter-system wait --for=condition=Ready pods -l "component in (controller,router,nodemarker)" --timeout 300s; fi
 
       - name: Run e2e tests

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,12 @@ SHELL = /usr/bin/env bash -o pipefail
 # file to deploy. It defauls to the single cluster variant
 CLAB_TOPOLOGY_FILE ?= singlecluster/kind.clab.yml
 
+# COREDUMP determines if we want to setup the coredump via our scripts. We
+# do not want to do this in local setups, but this is needed for CI environments.
+COREDUMP ?= false
+
+KIND_EXPORT_LOGS ?=/tmp/kind_logs
+
 .PHONY: all
 all: build
 
@@ -357,13 +363,15 @@ parse-scale-report: ## Parse scale test JSON report and print summary tables.
 
 .PHONY: clab-cluster
 clab-cluster: kind-node-image-build kubectl
-	KUBECONFIG_PATH=$(KUBECONFIG_PATH) KIND=$(KIND) KUBECTL=$(KUBECTL) CLAB_TOPOLOGY=$(CLAB_TOPOLOGY_FILE) clab/setup.sh
+	KUBECONFIG_PATH=$(KUBECONFIG_PATH) KIND=$(KIND) KUBECTL=$(KUBECTL) CLAB_TOPOLOGY=$(CLAB_TOPOLOGY_FILE) \
+	  KIND_EXPORT_LOGS=$(KIND_EXPORT_LOGS) COREDUMP=$(COREDUMP) clab/setup.sh
 	@echo 'kind cluster created, to use it please'
 	@echo 'export KUBECONFIG=${KUBECONFIG_PATH}'
 
 .PHONY: clab-multi-cluster
 clab-multi-cluster: kind-node-image-build kubectl ## Deploy multi-cluster setup with 2 kindleafs, 2 kind switches, and 2 kind clusters (control plane + worker each)
-	KUBECONFIG_PATH=$(KUBECONFIG_PATH) KIND=$(KIND) KUBECTL=$(KUBECTL) CLAB_TOPOLOGY=multicluster/kind.clab.yml clab/setup.sh pe-kind-a pe-kind-b
+	KUBECONFIG_PATH=$(KUBECONFIG_PATH) KIND=$(KIND) KUBECTL=$(KUBECTL) CLAB_TOPOLOGY=multicluster/kind.clab.yml \
+	  KIND_EXPORT_LOGS=$(KIND_EXPORT_LOGS) COREDUMP=$(COREDUMP) clab/setup.sh pe-kind-a pe-kind-b
 	@echo 'Multi-cluster deployment created:'
 	@echo '  - Cluster A: export KUBECONFIG=${KUBECONFIG_PATH}-pe-kind-a'
 	@echo '  - Cluster B: export KUBECONFIG=${KUBECONFIG_PATH}-pe-kind-b'
@@ -430,8 +438,6 @@ bump-k8s-deps: ## Bump all k8s.io and sigs.k8s.io dependencies (K8S_VERSION=v0.3
 .PHONY: bump-go-version
 bump-go-version: ## Bump Go version across the project (GO_VERSION=1.25.7 or omit for latest)
 	hack/bump_go_version.sh $(GO_VERSION)
-
-KIND_EXPORT_LOGS ?=/tmp/kind_logs
 
 .PHONY: kind-export-logs
 kind-export-logs: create-export-logs

--- a/clab/setup.sh
+++ b/clab/setup.sh
@@ -8,6 +8,10 @@ source common.sh
 CALICO_MODE=${CALICO_MODE:-false}
 CLAB_TOPOLOGY="${CLAB_TOPOLOGY:-singlecluster/kind.clab.yml}"
 IP_MAP_FILE=${IP_MAP_FILE:-"singlecluster/ip_map.txt"}
+KIND_EXPORT_LOGS=${KIND_EXPORT_LOGS:-/tmp/kind_logs}
+
+COREDUMP=${COREDUMP:-false}
+CORE_DUMP_DIR="${KIND_EXPORT_LOGS}/core_dumps"
 
 # Get cluster names from command line arguments or environment variable, default to single cluster
 if [[ $# -gt 0 ]]; then
@@ -79,6 +83,24 @@ echo "=== 10/11 Container setup ==="
 
 echo "=== 11/11 Veth monitoring ==="
 ./scripts/10-veth-monitoring.sh "${CLUSTER_ARRAY[@]}"
+
+# Setting up coredumps is finicky. The sysctl settings are global, so core_pattern
+# must be the same for all containers and pods. Without using a pipe, the core
+# dumps would be stored on the container or inside the pods. However, in that case,
+# we would have to mount e.g. /tmp/core on the container into the pod to make sure
+# that the core dump is captures (and not discarded when the pod dies).
+# In order to avoid this, we use a pipe which will run on the host system. However,
+# we might run into issues with SELinux in such a scenario. E.g., on Fedora,
+# this requires setenforce 0 or building a custom selinux module.
+setup_coredumps() {
+    if [[ "$COREDUMP" != "true" ]]; then
+        return
+    fi
+    mkdir -p "${CORE_DUMP_DIR}"
+    sudo sysctl -w kernel.core_pattern="|/usr/bin/dd of=${CORE_DUMP_DIR}/core.%E.%P.%h.%s.%t bs=1M status=none"
+}
+
+setup_coredumps
 
 echo "=== ${CLUSTER_MODE^} cluster deployment completed ==="
 if [[ "$CLUSTER_MODE" == "single" ]]; then


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:

    Set up generation and collection of core dumps in CI
    
    Setting up coredumps is finicky. The sysctl settings are global,
    so core_pattern must be the same for all containers and pods.
    Without using a pipe, the core dumps would be stored on the container
    or inside the pods. However, in that case, we would have to mount e.g.
    /tmp/core on the container into the pod to make sure that the core dump
    is captured (and not discarded when the pod dies). In order to avoid
    this, we use a pipe which will capture the coredump on the host system.
    However, we might run into issues with SELinux in such a scenario.
    E.g., on Fedora, this requires setenforce 0 or building a custom
    selinux module. Therefore, we set this only in CI environments via
    a variable

**Special notes for your reviewer**:

For context for why this is needed, see: https://github.com/openperouter/openperouter/issues/454
The OVNK team also hit crashes in FRR's EVPN code: https://github.com/frrouting/frr/issues/21794
We should gather coredumps in CI and report anything that we can find upstream.

Can be tested with:
```
diff --git a/e2etests/tests/evpn_l2.go b/e2etests/tests/evpn_l2.go
index 4939ed1b..72db7e74 100644
--- a/e2etests/tests/evpn_l2.go
+++ b/e2etests/tests/evpn_l2.go
@@ -89,6 +89,19 @@ var _ = Describe("Routes between bgp and the fabric", Ordered, func() {
                        _, err = exec.Exec("ovs-vsctl", "add-br", preExistingOVSBridge)
                        Expect(err).NotTo(HaveOccurred())
                }
+               n := []string{infra.KindControlPlane, infra.KindWorker, infra.KindLeaf}
+               for _, i := range n {
+                       exec := executor.ForContainer(i)
+                       pids, err := exec.Exec("pidof", "zebra")
+                       for _, pid := range strings.Fields(pids) {
+                               fmt.Println("killing pid", pid)
+                               Expect(err).NotTo(HaveOccurred())
+                               _, err = exec.Exec("kill", "-s", "SIGABRT", strings.TrimSpace(pid))
+                               fmt.Println("killed pid", pid)
+                               Expect(err).NotTo(HaveOccurred())
+                       }
+               }
+               Expect(nil).To(HaveOccurred())
        })
 
        AfterAll(func() {
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Generation of coredumps when FRR processes crash in CI.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
