### PR TITLE
fix: pre-delete netns devices before ip netns delete

### DIFF
--- a/e2etests/pkg/openperouter/netns.go
+++ b/e2etests/pkg/openperouter/netns.go
@@ -3,6 +3,8 @@
 package openperouter
 
 import (
+	"fmt"
+	"log"
 	"strings"
 
 	"github.com/openperouter/openperouter/e2etests/pkg/executor"
@@ -39,10 +41,17 @@ func NamedNetnsHasInterfaceType(nodeName, linkType string) (bool, error) {
 	return strings.TrimSpace(out) != "", nil
 }
 
-// DeleteNamedNetns runs "ip netns delete perouter" on nodeName.
+// DeleteNamedNetns pre-deletes all non-loopback devices inside the perouter
+// netns, then runs "ip netns delete perouter" on nodeName. Pre-deleting
+// devices accelerates the kernel's async cleanup_net() from ~28s to <2s.
 func DeleteNamedNetns(nodeName string) error {
-	exec := executor.ForContainer(nodeName)
-	_, err := exec.Exec("ip", "netns", "delete", namedNetns)
+	e := executor.ForContainer(nodeName)
+
+	if err := deleteNetnsDevices(e); err != nil {
+		log.Printf("pre-deletion of devices failed for %q, proceeding with netns delete: %v", nodeName, err)
+	}
+
+	_, err := e.Exec("ip", "netns", "delete", namedNetns)
 	return err
 }
 
@@ -66,4 +75,40 @@ func UnderlayVethExists(nodeName string) bool {
 		return true
 	}
 	return false
+}
+
+// deleteNetnsDevices lists all devices inside the perouter netns and deletes
+// them one by one, skipping loopback.
+func deleteNetnsDevices(e executor.Executor) error {
+	out, err := e.Exec("ip", "netns", "exec", namedNetns, "ip", "-o", "link", "show")
+	if err != nil {
+		return err
+	}
+
+	for _, line := range strings.Split(out, "\n") {
+		name, err := ifaceName(line)
+		if err != nil {
+			log.Printf("could not get interface name from line %v", err)
+			continue
+		}
+		if name == "lo" {
+			continue
+		}
+		if out, err := e.Exec("ip", "netns", "exec", namedNetns, "ip", "link", "delete", name); err != nil {
+			if strings.Contains(out, "Cannot find device") {
+				continue
+			}
+			return fmt.Errorf("failed to delete link %q; output %q; error: %v", name, out, err)
+		}
+	}
+	return nil
+}
+
+func ifaceName(line string) (string, error) {
+	// ip -o link show format: "N: name[@suffix]: <flags> ..."
+	parts := strings.SplitN(line, ": ", 3)
+	if len(parts) < 2 {
+		return "", fmt.Errorf("unexpected line from 'ip -o link show': %q", line)
+	}
+	return strings.SplitN(parts[1], "@", 2)[0], nil
 }

--- a/internal/netnamespace/ensure.go
+++ b/internal/netnamespace/ensure.go
@@ -3,10 +3,13 @@
 package netnamespace
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os/exec"
+	"syscall"
 
+	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 )
 
@@ -46,13 +49,64 @@ func EnsureNamespace() error {
 }
 
 // DeleteNamespace removes the named network namespace "perouter".
-// This is used during non-recoverable errors so the next pod starts
-// with a clean namespace rebuilt from scratch by the controller.
 func DeleteNamespace() error {
 	slog.Info("deleting named netns", "path", NamedNSPath)
+
+	if err := deleteAllDevices(NamedNSPath); err != nil {
+		slog.Warn("pre-deletion of devices failed, proceeding with netns delete", "error", err)
+	}
+
 	out, err := exec.Command("ip", "netns", "delete", NamedNSName).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to delete named netns: %w, output: %s", err, string(out))
 	}
 	return nil
+}
+
+// deleteAllDevices enters the given network namespace and deletes all
+// non-loopback devices. This accelerates kernel netns cleanup by reducing
+// the number of devices that cleanup_net() must tear down asynchronously.
+// Deletion is best-effort: individual failures are accumulated and returned
+// as a joined error, but do not prevent deletion of remaining devices.
+func deleteAllDevices(nsPath string) error {
+	ns, err := netns.GetFromPath(nsPath)
+	if err != nil {
+		return fmt.Errorf("failed to open netns %s: %w", nsPath, err)
+	}
+	defer func() {
+		if err := ns.Close(); err != nil {
+			slog.Error("failed to close namespace handle", "namespace", nsPath, "error", err)
+		}
+	}()
+
+	return In(ns, func() error {
+		links, err := netlink.LinkList()
+		if err != nil {
+			return fmt.Errorf("failed to list devices: %w", err)
+		}
+
+		slog.Info("pre-deleting devices from netns", "path", nsPath, "count", len(links))
+
+		var failedDeletes []error
+		for _, l := range links {
+			name := l.Attrs().Name
+			if name == "lo" {
+				continue
+			}
+			if err := netlink.LinkDel(l); err != nil {
+				var notFound netlink.LinkNotFoundError
+				if errors.As(err, &notFound) {
+					continue
+				}
+				if errors.Is(err, syscall.EOPNOTSUPP) {
+					continue
+				}
+				slog.Warn("failed to delete device", "device", name, "error", err)
+				failedDeletes = append(failedDeletes, fmt.Errorf("delete %s: %w", name, err))
+				continue
+			}
+			slog.Info("deleted device from netns", "device", name)
+		}
+		return errors.Join(failedDeletes...)
+	})
 }

--- a/internal/netnamespace/ensure_test.go
+++ b/internal/netnamespace/ensure_test.go
@@ -1,23 +1,17 @@
 // SPDX-License-Identifier:Apache-2.0
 
+//go:build runasroot
+
 package netnamespace
 
 import (
-	"os"
-	"os/exec"
 	"testing"
 
+	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 )
 
 func TestEnsureNamespace(t *testing.T) {
-	if os.Getuid() != 0 {
-		t.Skip("skipping test: requires root privileges")
-	}
-
-	// Clean up in case it already exists from a previous test run
-	_ = exec.Command("ip", "netns", "delete", "perouter").Run()
-
 	// First call should create the namespace
 	if err := EnsureNamespace(); err != nil {
 		t.Fatalf("first EnsureNamespace() failed: %v", err)
@@ -38,7 +32,64 @@ func TestEnsureNamespace(t *testing.T) {
 	}
 
 	// Clean up
-	if err := exec.Command("ip", "netns", "delete", "perouter").Run(); err != nil {
+	if err := DeleteNamespace(); err != nil {
 		t.Logf("cleanup: failed to delete netns: %v", err)
+	}
+}
+
+func TestDeleteNamespacePreDeletesDevices(t *testing.T) {
+	if err := EnsureNamespace(); err != nil {
+		t.Fatalf("EnsureNamespace() failed: %v", err)
+	}
+
+	ns, err := netns.GetFromPath(NamedNSPath)
+	if err != nil {
+		t.Fatalf("failed to open netns: %v", err)
+	}
+	defer ns.Close()
+
+	// Add a dummy device and a veth pair inside the netns
+	if err := In(ns, func() error {
+		if err := netlink.LinkAdd(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "test-dummy"}}); err != nil {
+			return err
+		}
+		return netlink.LinkAdd(&netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{Name: "test-veth0"},
+			PeerName:  "test-veth1",
+		})
+	}); err != nil {
+		t.Fatalf("failed to add devices to netns: %v", err)
+	}
+
+	// DeleteNamespace should pre-delete devices then remove the netns
+	if err := DeleteNamespace(); err != nil {
+		t.Fatalf("DeleteNamespace() failed: %v", err)
+	}
+
+	// Verify the namespace is gone
+	if _, err := netns.GetFromPath(NamedNSPath); err == nil {
+		t.Fatal("namespace should not exist after DeleteNamespace()")
+	}
+}
+
+func TestDeleteNamespaceEmptyNetns(t *testing.T) {
+	if err := EnsureNamespace(); err != nil {
+		t.Fatalf("EnsureNamespace() failed: %v", err)
+	}
+
+	// DeleteNamespace on a netns with only lo should succeed
+	if err := DeleteNamespace(); err != nil {
+		t.Fatalf("DeleteNamespace() on empty netns failed: %v", err)
+	}
+
+	if _, err := netns.GetFromPath(NamedNSPath); err == nil {
+		t.Fatal("namespace should not exist after DeleteNamespace()")
+	}
+}
+
+func TestDeleteNamespaceNonexistent(t *testing.T) {
+	// DeleteNamespace should return an error from ip netns delete
+	if err := DeleteNamespace(); err == nil {
+		t.Fatal("DeleteNamespace() on nonexistent netns should fail")
 	}
 }


### PR DESCRIPTION


<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug

/kind cleanup

> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
Enter the perouter network namespace and delete all non-loopback devices before calling `ip netns delete`. This reduces the kernel's async cleanup_net() from ~28s to <2s on CI VMs by leaving it with an almost empty netns to tear down.

The pattern follows CNI plugins (Cilium, Calico, bridge) which delete devices inside the netns during DEL before the netns is destroyed.

Applied to both:
- DeleteNamespace() in internal/netnamespace/ensure.go (production)
- DeleteNamedNetns() in e2etests/pkg/openperouter/netns.go (E2E helper)

Both paths use best-effort deletion: individual device failures are logged and skipped. Physical NICs return EOPNOTSUPP from LinkDel and are safely ignored — the kernel moves them back to the host netns during cleanup_net().

Fixes the Beta resiliency test flake where cleanup_net() exceeded the 30s test timeout.

**Special notes for your reviewer**:
Fixes: #462 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Pre-delete all interfaces in the router netns as part of the recovery procedure. This will greatly reduce the time it take the kernel to async delete the network namespace via `cleanup_net()`
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
