### PR TITLE
Replace lound dummy interface with namespace loopback (lo) for VTEP IP

### DIFF
--- a/e2etests/pkg/openperouter/netns.go
+++ b/e2etests/pkg/openperouter/netns.go
@@ -56,12 +56,37 @@ func DeleteNamedNetns(nodeName string) error {
 }
 
 // UnderlayConfigured checks whether the underlay is configured inside
-// the perouter netns on nodeName by looking for the VTEP loopback (lound).
-// RemoveUnderlay deletes lound when tearing down the underlay.
-func UnderlayConfigured(nodeName string) bool {
+// the perouter netns on nodeName by looking for any IP addresses other than
+// the default loopback interfaces on the VTEP loopback (lo), and by checking
+// that `lo` is up.
+func UnderlayConfigured(nodeName string) (bool, error) {
 	exec := executor.ForContainer(nodeName)
-	_, err := exec.Exec("ip", "netns", "exec", namedNetns, "ip", "link", "show", "lound")
-	return err == nil
+
+	out, err := exec.Exec("ip", "netns", "list")
+	if err != nil {
+		return false, err
+	}
+	if !strings.Contains(out, namedNetns) {
+		return false, nil
+	}
+
+	out, err = exec.Exec("ip", "netns", "exec", namedNetns, "ip", "-o", "link", "show", "dev", "lo")
+	if err != nil {
+		return false, err
+	}
+	if !strings.Contains(out, "LOOPBACK,UP,LOWER_UP") {
+		return false, nil
+	}
+
+	out, err = exec.Exec("ip", "netns", "exec", namedNetns, "ip", "address", "show", "dev", "lo", "scope", "global")
+	if err != nil {
+		return false, err
+	}
+	if len(strings.TrimSpace(out)) > 0 {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 // UnderlayVethExists checks whether the toswitch interfaces exist on nodeName,

--- a/e2etests/tests/sessions.go
+++ b/e2etests/tests/sessions.go
@@ -59,9 +59,11 @@ var _ = Describe("Router Host configuration", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 		By("waiting for the underlay to be removed from all nodes")
 		for _, node := range nodes {
-			Eventually(func() bool {
-				return openperouter.UnderlayConfigured(node.Name)
-			}, 2*time.Minute, time.Second).Should(BeFalse())
+			Eventually(func(g Gomega) {
+				isConfigured, err := openperouter.UnderlayConfigured(node.Name)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(isConfigured).To(BeFalse())
+			}, 2*time.Minute, time.Second).Should(Succeed())
 		}
 	})
 
@@ -570,9 +572,11 @@ var _ = Describe("Underlay external and internal configuration", Ordered, func()
 
 		By("waiting for the underlay to be removed from all nodes")
 		for _, node := range nodes {
-			Eventually(func() bool {
-				return openperouter.UnderlayConfigured(node.Name)
-			}, 2*time.Minute, time.Second).Should(BeFalse())
+			Eventually(func(g Gomega) {
+				isConfigured, err := openperouter.UnderlayConfigured(node.Name)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(isConfigured).To(BeFalse())
+			}, 2*time.Minute, time.Second).Should(Succeed())
 		}
 	})
 
@@ -706,9 +710,11 @@ var _ = Describe("Underlay BFD Configuration", Ordered, func() {
 
 		By("waiting for the underlay to be removed from all nodes")
 		for _, node := range nodes {
-			Eventually(func() bool {
-				return openperouter.UnderlayConfigured(node.Name)
-			}, 2*time.Minute, time.Second).Should(BeFalse())
+			Eventually(func(g Gomega) {
+				isConfigured, err := openperouter.UnderlayConfigured(node.Name)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(isConfigured).To(BeFalse())
+			}, 2*time.Minute, time.Second).Should(Succeed())
 		}
 
 		Expect(infra.LeafKind1Config.UpdateConfig(nodes, infra.LeafKindConfiguration{})).NotTo(HaveOccurred())
@@ -861,9 +867,11 @@ var _ = Describe("Add extra neighbor", Ordered, func() {
 
 		By("waiting for the underlay to be removed from all nodes")
 		for _, node := range nodes {
-			Eventually(func() bool {
-				return openperouter.UnderlayConfigured(node.Name)
-			}, 2*time.Minute, time.Second).Should(BeFalse())
+			Eventually(func(g Gomega) {
+				isConfigured, err := openperouter.UnderlayConfigured(node.Name)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(isConfigured).To(BeFalse())
+			}, 2*time.Minute, time.Second).Should(Succeed())
 		}
 	})
 

--- a/internal/hostnetwork/external_suite_test.go
+++ b/internal/hostnetwork/external_suite_test.go
@@ -136,7 +136,7 @@ func readParamsFromFile[T any](filePath string) (T, error) {
 }
 
 func validateUnderlayIsNotConfigured(g Gomega, params UnderlayParams) {
-	checkLinkdeleted(g, UnderlayLoopback)
+	checkInterfaceHasNoNonLoopbackIPs(g, loopbackName)
 	for _, iface := range params.UnderlayInterfaces {
 		checkLinkdeleted(g, iface)
 	}

--- a/internal/hostnetwork/underlay.go
+++ b/internal/hostnetwork/underlay.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	UnderlayLoopback = "lound"
+	loopbackName = "lo"
 )
 
 // underlayGroupID is the link group ID assigned to all underlay interfaces
@@ -104,25 +104,23 @@ func (e UnderlayExistsError) Error() string {
 }
 
 func ensureLoopback(ctx context.Context, ns netns.NsHandle, vtepIP string) error {
-	slog.DebugContext(ctx, "setup underlay", "step", "creating loopback interface")
-	defer slog.DebugContext(ctx, "setup underlay", "step", "loopback interface created")
+	slog.DebugContext(ctx, "setup underlay", "step", "setting up loopback interface")
+	defer slog.DebugContext(ctx, "setup underlay", "step", "loopback interface set up")
 
 	if err := netnamespace.In(ns, func() error {
-		loopback, err := netlink.LinkByName(UnderlayLoopback)
-		if errors.As(err, &netlink.LinkNotFoundError{}) {
-			slog.DebugContext(ctx, "setup underlay", "step", "creating loopback interface")
-			loopback = &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: UnderlayLoopback}}
-			if err := netlink.LinkAdd(loopback); err != nil {
-				return fmt.Errorf("assignVTEPToLoopback: failed to create loopback underlay - %w", err)
-			}
+		loopback, err := netlink.LinkByName(loopbackName)
+		if err != nil {
+			return fmt.Errorf("ensureLoopback: failed to retrieve %s, err: %w", loopbackName, err)
 		}
 
 		err = assignIPToInterface(loopback, vtepIP)
 		if err != nil {
 			return err
 		}
+		// The link is already set up during namespace creation. However, in order to be idempotent, do this here again,
+		// in case something external set the link to down.
 		if err := netlink.LinkSetUp(loopback); err != nil {
-			return fmt.Errorf("ensureLoopback: failed to bring up %s: %w", UnderlayLoopback, err)
+			return fmt.Errorf("ensureLoopback: failed to bring up %s: %w", loopbackName, err)
 		}
 
 		return nil
@@ -135,7 +133,7 @@ func ensureLoopback(ctx context.Context, ns netns.NsHandle, vtepIP string) error
 
 // RemoveUnderlay removes the underlay state from the named network namespace:
 // it resets the group ID on underlay NICs (so HasUnderlayInterface
-// returns false on the next reconcile) and deletes the VTEP loopback (lound).
+// returns false on the next reconcile) and clears all IP addresses from the VTEP loopback (lo).
 func RemoveUnderlay(targetNS string) error {
 	ns, err := netns.GetFromPath(targetNS)
 	if err != nil {
@@ -148,13 +146,8 @@ func RemoveUnderlay(targetNS string) error {
 	}()
 
 	return netnamespace.In(ns, func() error {
-		lound, err := netlink.LinkByName(UnderlayLoopback)
-		if err != nil {
-			if !errors.As(err, &netlink.LinkNotFoundError{}) {
-				return fmt.Errorf("failed to find %s: %w", UnderlayLoopback, err)
-			}
-		} else if err := netlink.LinkDel(lound); err != nil {
-			return fmt.Errorf("failed to delete %s: %w", UnderlayLoopback, err)
+		if err := clearNonDefaultLoopbackIPs(loopbackName); err != nil {
+			return err
 		}
 
 		links, err := netlink.LinkList()
@@ -237,4 +230,27 @@ func findUnderlayMTU(ns netns.NsHandle) (int, error) {
 		return 0, err
 	}
 	return minMTU, nil
+}
+
+func clearNonDefaultLoopbackIPs(intf string) error {
+	lo, err := netlink.LinkByName(intf)
+	if err != nil {
+		return fmt.Errorf("failed to find %s: %w", intf, err)
+	}
+
+	addresses, err := netlink.AddrList(lo, netlink.FAMILY_ALL)
+	if err != nil {
+		return fmt.Errorf("failed to list addresses on %s: %w", intf, err)
+	}
+
+	var errs []error
+	for _, address := range addresses {
+		if address.IP.IsLoopback() {
+			continue
+		}
+		if err := netlink.AddrDel(lo, &address); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }

--- a/internal/hostnetwork/underlay_test.go
+++ b/internal/hostnetwork/underlay_test.go
@@ -171,13 +171,13 @@ func validateUnderlayInNS(g Gomega, ns netns.NsHandle, params UnderlayParams) {
 func validateUnderlay(g Gomega, params UnderlayParams, interfaceIPs ...string) {
 	links, err := netlink.LinkList()
 	g.Expect(err).NotTo(HaveOccurred())
-	loopbackFound := false
 	foundInterfaces := map[string]bool{}
 	for _, l := range links {
-		if l.Attrs().Name == UnderlayLoopback {
-			loopbackFound = true
+		if l.Attrs().Name == loopbackName {
 			if params.EVPN != nil && params.EVPN.VtepIP != "" {
 				validateIP(g, l, params.EVPN.VtepIP)
+			} else {
+				checkInterfaceHasNoNonLoopbackIPs(g, loopbackName)
 			}
 		}
 		for _, underlayIface := range params.UnderlayInterfaces {
@@ -190,11 +190,7 @@ func validateUnderlay(g Gomega, params UnderlayParams, interfaceIPs ...string) {
 			}
 		}
 	}
-	if params.EVPN != nil && params.EVPN.VtepIP == "" {
-		g.Expect(loopbackFound).To(BeFalse(), fmt.Sprintf("loopback should not exist when vtepIP is empty, links %v", links))
-	} else if params.EVPN != nil {
-		g.Expect(loopbackFound).To(BeTrue(), fmt.Sprintf("failed to find loopback in ns, links %v", links))
-	}
+
 	for _, underlayIface := range params.UnderlayInterfaces {
 		g.Expect(foundInterfaces).To(HaveKey(underlayIface),
 			fmt.Sprintf("underlay interface %s not found in ns, links %v", underlayIface, links))
@@ -246,7 +242,7 @@ func cleanTest(namespace string) {
 	err = removeLinkByName(PassthroughNames.HostSide)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = removeLinkByName(UnderlayLoopback)
+	err = clearNonDefaultLoopbackIPs(loopbackName)
 	Expect(err).NotTo(HaveOccurred())
 }
 

--- a/internal/hostnetwork/vni_test.go
+++ b/internal/hostnetwork/vni_test.go
@@ -700,8 +700,8 @@ func validateL2VNI(g Gomega, params L2VNIParams) {
 }
 
 func validateVNI(g Gomega, params VNIParams) {
-	vtepDev, err := netlink.LinkByName(UnderlayLoopback)
-	g.Expect(err).NotTo(HaveOccurred(), "vtep device not found %q", UnderlayLoopback)
+	vtepDev, err := netlink.LinkByName(loopbackName)
+	g.Expect(err).NotTo(HaveOccurred(), "vtep device not found %q", loopbackName)
 
 	vxlanLink, err := netlink.LinkByName(vxLanNameFromVNI(params.VNI))
 	g.Expect(err).NotTo(HaveOccurred(), "vxlan link not found %q", vxLanNameFromVNI(params.VNI))
@@ -751,6 +751,23 @@ func checkLinkdeleted(g Gomega, name string) {
 	g.Expect(errors.As(err, &netlink.LinkNotFoundError{})).To(BeTrue(), "link not deleted", name, err)
 }
 
+func checkInterfaceHasNoNonLoopbackIPs(g Gomega, intf string) {
+	lo, err := netlink.LinkByName(intf)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	addresses, err := netlink.AddrList(lo, netlink.FAMILY_ALL)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	numAddresses := 0
+	for _, address := range addresses {
+		if address.IP.IsLoopback() {
+			continue
+		}
+		numAddresses++
+	}
+	g.Expect(numAddresses).To(Equal(0))
+}
+
 func checkLinkExists(g Gomega, name string) {
 	_, err := netlink.LinkByName(name)
 	g.Expect(err).NotTo(HaveOccurred(), "link not found %q", name)
@@ -774,15 +791,13 @@ func checkAddrGenModeNone(l netlink.Link) bool {
 }
 
 func setupLoopback(ns netns.NsHandle) {
-	_ = netnamespace.In(ns, func() error {
-		_, err := netlink.LinkByName(UnderlayLoopback)
-		if errors.As(err, &netlink.LinkNotFoundError{}) {
-			loopback := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: UnderlayLoopback}}
-			err = netlink.LinkAdd(loopback)
-			Expect(err).NotTo(HaveOccurred(), "failed to create loopback", UnderlayLoopback)
-		}
-		return nil
-	})
+	handle, err := netlink.NewHandleAt(ns)
+	Expect(err).NotTo(HaveOccurred())
+	defer handle.Close()
+
+	lo, err := handle.LinkByName(loopbackName)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(handle.LinkSetUp(lo)).To(Succeed())
 }
 
 func createLinuxBridge(name string) {

--- a/internal/hostnetwork/vxlan.go
+++ b/internal/hostnetwork/vxlan.go
@@ -63,9 +63,9 @@ func checkVXLanConfigured(vxLan *netlink.Vxlan, bridgeIndex, loopbackIndex int, 
 }
 
 func createVXLan(params VNIParams, bridge *netlink.Bridge) (*netlink.Vxlan, error) {
-	loopback, err := net.InterfaceByName(UnderlayLoopback)
+	loopback, err := net.InterfaceByName(loopbackName)
 	if err != nil {
-		return nil, fmt.Errorf("failed looking for vtep loopback interface %s: %w", UnderlayLoopback, err)
+		return nil, fmt.Errorf("failed looking for vtep loopback interface %s: %w", loopbackName, err)
 	}
 
 	vtepIP, _, err := net.ParseCIDR(params.VTEPIP)

--- a/internal/netnamespace/ensure.go
+++ b/internal/netnamespace/ensure.go
@@ -15,6 +15,7 @@ import (
 
 const NamedNSName = "perouter"
 const NamedNSPath = "/var/run/netns/" + NamedNSName
+const loopbackName = "lo"
 
 // EnsureNamespace ensures the named network namespace "perouter" exists at
 // /var/run/netns/perouter. It is idempotent: if the namespace already exists
@@ -40,11 +41,28 @@ func EnsureNamespace() error {
 	if err != nil {
 		return fmt.Errorf("named netns created but failed to verify: %w", err)
 	}
-	if closeErr := ns.Close(); closeErr != nil {
-		slog.Error("failed to close namespace handle", "error", closeErr)
+	defer func() {
+		if closeErr := ns.Close(); closeErr != nil {
+			slog.Error("failed to close namespace handle", "error", closeErr)
+		}
+	}()
+
+	slog.Info("setting named netns loopback to up", "path", NamedNSPath, "loopback", loopbackName)
+	handle, err := netlink.NewHandleAt(ns)
+	if err != nil {
+		return fmt.Errorf("failed to get handle for netns %s, err: %w", NamedNSPath, err)
+	}
+	defer handle.Close()
+
+	loopback, err := handle.LinkByName(loopbackName)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve %s in %s, err: %w", loopbackName, NamedNSPath, err)
+	}
+	if err := handle.LinkSetUp(loopback); err != nil {
+		return fmt.Errorf("failed to bring up %s in %s: %w", loopbackName, NamedNSPath, err)
 	}
 
-	slog.Info("named netns created successfully", "path", NamedNSPath)
+	slog.Info("named netns set up successfully", "path", NamedNSPath)
 	return nil
 }
 

--- a/website/content/docs/architecture.md
+++ b/website/content/docs/architecture.md
@@ -77,7 +77,7 @@ The named network namespace (`/var/run/netns/perouter`) is held open by a bind m
 | VRFs, bridges, VXLAN interfaces | Yes | Kernel objects tied to the namespace |
 | Veth pairs (pe/host) | Yes | Kernel objects tied to the namespace |
 | Underlay physical NIC | Yes | Stays inside the namespace |
-| VTEP loopback (lound) | Yes | Kernel dummy interface |
+| VTEP loopback (lo) | Yes | Kernel loopback interface |
 | Kernel routing tables | Yes | Installed by zebra, persist in the namespace |
 | Bridge FDB entries | Yes | Kernel bridge state |
 | ARP / neighbor entries | Yes | Kernel neighbor table |

--- a/website/content/docs/concepts/resiliency.md
+++ b/website/content/docs/concepts/resiliency.md
@@ -27,7 +27,7 @@ All kernel networking objects live inside this namespace:
 - **VXLAN interfaces** — handling tunnel encapsulation/decapsulation
 - **Veth pairs** — connecting VRFs to the host network namespace
 - **Underlay physical NIC** — the interface connected to the ToR switch
-- **VTEP loopback (lound)** — the dummy interface carrying the VTEP IP
+- **VTEP loopback (lo)** — the namespace loopback interface carrying the VTEP IP
 - **Kernel routing tables, bridge FDB entries, ARP/neighbor entries, IP addresses**
 
 When FRR crashes, all of these survive. The kernel continues forwarding packets using existing routes and FDB entries. There is **zero data-plane disruption**.
@@ -39,7 +39,7 @@ When FRR crashes, all of these survive. The kernel continues forwarding packets 
 | VRFs, bridges, VXLAN interfaces | Yes | Kernel objects tied to the namespace, not to FRR |
 | Veth pairs (pe ↔ host) | Yes | Kernel objects |
 | Underlay physical NIC | Yes | Stays inside the namespace |
-| VTEP loopback (lound) | Yes | Kernel dummy interface |
+| VTEP loopback (lo) | Yes | Kernel loopback interface |
 | Kernel routing tables | Yes | Installed by zebra, persist in the namespace |
 | Bridge FDB entries (MAC→VTEP) | Yes | Kernel bridge state |
 | ARP / neighbor entries | Yes | Kernel neighbor table |


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

Replaces the custom `lound` dummy interface with the namespace's built-in `lo` loopback interface to carry the VTEP IP address.

Since the introduction of the perouter named network namespace, the `lo` interface inside it is down by default. FRR requires the VRF loopback to be up for leaked nexthops to be valid (see [bgp_mplsvpn.c](https://github.com/FRRouting/frr/blob/frr-10.6.0/bgpd/bgp_mplsvpn.c#L1158-L1161)). Using a separate `lound` dummy interface instead of `lo` left `lo` down, causing route import failures in VRFs.

This PR:
- Sets `lo` to UP and assigns/clears VTEP IP addresses on it directly, instead of creating/deleting the `lound` dummy device
- Updates `RemoveUnderlay` to clear IPs from `lo` rather than deleting `lound`
- Updates `UnderlayConfigured` (e2e helper) to check `lo` state and non-default IPs instead of checking for `lound` existence
- Updates documentation (architecture, resiliency) to reflect the change

Fixes https://github.com/openperouter/openperouter/issues/466

**Special notes for your reviewer**:

The `lound` interface was a dummy device whose `lo` prefix was misleading. Using the real `lo` interface simplifies the setup and avoids the bug where FRR's VRF route import silently fails because the loopback is down.

**Release note**:

```release-note
Fix VRF route import failures caused by namespace loopback (lo) being down. The VTEP IP is now assigned directly to lo instead of a separate lound dummy interface.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.