### PR TITLE
Mirror static resources to k8s api

### DIFF
--- a/Claude.md
+++ b/Claude.md
@@ -23,6 +23,10 @@ Run `make test` to execute unit tests.
 - **Prerequisites:** Requires active deployment
 - **Before running:** Always verify cluster is running and deployment version is current
 - **Validation only:** You can run the command to check if e2e test code compiles, but confirm with the user before executing against a cluster
+- **Filtering tests:** Use `GINKGO_ARGS` with `--focus` to run specific tests, and `TEST_ARGS` for deployment mode:
+  ```
+  KUBECONFIG=bin/kubeconfig TEST_ARGS="--systemdmode" GINKGO_ARGS='--focus="Mirror static config"' make e2etests
+  ```
 
 **Development environment**
 

--- a/clab/scripts/10-veth-monitoring.sh
+++ b/clab/scripts/10-veth-monitoring.sh
@@ -36,13 +36,11 @@ setup_veth_monitoring() {
 
     CHECK_VETHS_LOG="/tmp/check_veths.log"
     if [[ ${#CLUSTER_NAMES[@]} -eq 1 && "${CLUSTER_NAMES[0]}" == "pe-kind" ]]; then
-        # Single cluster mode
-        sudo tools/check_veths/bin/check_veths -f singlecluster/check-veths.yaml -p "${PID_FILE}" 2>&1 | \
-          awk '{print strftime("%Y-%m-%dT%H:%M:%S"), $0; fflush()}' > "$CHECK_VETHS_LOG" &
+        sudo tools/check_veths/bin/check_veths -f singlecluster/check-veths.yaml -p "${PID_FILE}" \
+          > "$CHECK_VETHS_LOG" 2>&1 &
     else
-        # Multi-cluster mode
-        sudo tools/check_veths/bin/check_veths -f multicluster/check-veths.yaml -p "${PID_FILE}" 2>&1 | \
-          awk '{print strftime("%Y-%m-%dT%H:%M:%S"), $0; fflush()}' > "$CHECK_VETHS_LOG" &
+        sudo tools/check_veths/bin/check_veths -f multicluster/check-veths.yaml -p "${PID_FILE}" \
+          > "$CHECK_VETHS_LOG" 2>&1 &
     fi
 
     popd

--- a/clab/tools/check_veths/check_veths.go
+++ b/clab/tools/check_veths/check_veths.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"io"
 	"log"
@@ -31,11 +32,10 @@ func main() {
 	flag.Parse()
 
 	if *pidFileName != "" {
-		pf := pidFile(*pidFileName)
-		if err := pf.Lock(); err != nil {
-			log.Fatalf("could not lock PID file, err: %q", err)
+		pf, ok := lockPIDFile(*pidFileName)
+		if !ok {
+			return
 		}
-
 		defer func() {
 			if err := pf.Unlock(); err != nil {
 				log.Fatalf("could not unlock PID file, err: %q", err)
@@ -98,4 +98,16 @@ func main() {
 		}
 	}
 	<-ctx.Done()
+}
+
+func lockPIDFile(name string) (pidFile, bool) {
+	pf := pidFile(name)
+	if err := pf.Lock(); err != nil {
+		if errors.Is(err, errAlreadyRunning) {
+			log.Printf("process already running, exiting: %v", err)
+			return "", false
+		}
+		log.Fatalf("could not lock PID file, err: %q", err)
+	}
+	return pf, true
 }

--- a/clab/tools/check_veths/pid_file.go
+++ b/clab/tools/check_veths/pid_file.go
@@ -11,6 +11,8 @@ import (
 	"syscall"
 )
 
+var errAlreadyRunning = errors.New("already running")
+
 type pidFile string
 
 // Unlock simply deletes the pid file.
@@ -18,9 +20,8 @@ func (p pidFile) Unlock() error {
 	return os.Remove(string(p))
 }
 
-// Lock writes our PID to the pid file if the file doesn't exist.
-// Otherwise, it reads the PID file, and checks if a process with the PID exists.
-// If so, it throws an error. Otherwise, if no such process is running, it writes our PID to the pid file.
+// Lock writes our PID to the pid file. If a previous process is still
+// running, it returns errAlreadyRunning.
 func (p pidFile) Lock() error {
 	currentPid := os.Getpid()
 
@@ -34,8 +35,8 @@ func (p pidFile) Lock() error {
 		return err
 	}
 	proc, _ := os.FindProcess(pid)
-	if err := proc.Signal(syscall.Signal(0)); !errors.Is(err, os.ErrProcessDone) {
-		return fmt.Errorf("process with PID %d already running", pid)
+	if err := proc.Signal(syscall.Signal(0)); !errors.Is(err, os.ErrProcessDone) && !errors.Is(err, syscall.ESRCH) {
+		return fmt.Errorf("process with PID %d: %w", pid, errAlreadyRunning)
 	}
 	return os.WriteFile(string(p), []byte(strconv.Itoa(currentPid)), 0644)
 }

--- a/cmd/hostcontroller/main.go
+++ b/cmd/hostcontroller/main.go
@@ -265,8 +265,9 @@ func runK8sConfigReconcilerHostMode(ctx context.Context,
 		RouterHealthCheckPort: hostModeParams.routerHealthCheckPort,
 	}
 
-	// Create trigger channel for file watcher
+	// Create trigger channels for both controllers
 	triggerChan := make(chan event.GenericEvent, 1)
+	mirrorTriggerChan := make(chan event.GenericEvent, 1)
 
 	apiReconciler := &routerconfiguration.PERouterReconciler{
 		Client:          mgr.GetClient(),
@@ -305,15 +306,32 @@ func runK8sConfigReconcilerHostMode(ctx context.Context,
 		return fmt.Errorf("unable to start FRR restart watcher: %w", err)
 	}
 
-	// Setup file watcher to trigger API reconciler on static file changes
-	fw, err := filewatcher.New(hostModeParams.configurationDir, triggerChan, logger)
-	if err != nil {
-		return fmt.Errorf("unable to create file watcher for API reconciler: %w", err)
+	mirrorController := &routerconfiguration.MirrorController{
+		Client:      mgr.GetClient(),
+		Scheme:      mgr.GetScheme(),
+		Logger:      logger,
+		MyNode:      args.nodeName,
+		MyNamespace: args.namespace,
+		ConfigDir:   hostModeParams.configurationDir,
+		TriggerChan: mirrorTriggerChan,
 	}
 
-	if err := fw.Start(ctx); err != nil {
-		return fmt.Errorf("unable to start file watcher for API reconciler: %w", err)
+	if err := mirrorController.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create mirror controller: %w", err)
 	}
+
+	// Setup file watcher to trigger controllers on static file changes
+	filesChangedChan := make(chan event.GenericEvent, 1)
+	watcher, err := filewatcher.New(hostModeParams.configurationDir, filesChangedChan, logger)
+	if err != nil {
+		return fmt.Errorf("unable to create file watcher: %w", err)
+	}
+
+	if err := watcher.Start(ctx); err != nil {
+		return fmt.Errorf("unable to start file watcher: %w", err)
+	}
+
+	go fanOut(ctx, filesChangedChan, triggerChan, mirrorTriggerChan)
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctx); err != nil {
@@ -400,6 +418,8 @@ func runStaticConfigReconciler(ctx context.Context,
 		FRRReloadSocket: args.reloaderSocket,
 		RouterProvider:  staticRouterProvider,
 		ConfigDir:       hostModeParams.configurationDir,
+		MyNode:          args.nodeName,
+		MyNamespace:     args.namespace,
 	}
 	if err = staticReconciler.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller: %w", err)
@@ -571,4 +591,20 @@ func overrideHostMode(args *parameters, nodeConfig static.NodeConfig) error {
 	}
 	setupLog.Info("nodename not provided, using hostname", "nodename", args.nodeName)
 	return nil
+}
+
+func fanOut(ctx context.Context, in <-chan event.GenericEvent, outs ...chan<- event.GenericEvent) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case evt, ok := <-in:
+			if !ok {
+				return
+			}
+			for _, out := range outs {
+				out <- evt
+			}
+		}
+	}
 }

--- a/config/all-in-one/crio.yaml
+++ b/config/all-in-one/crio.yaml
@@ -1371,6 +1371,7 @@ rules:
   - l2vnis
   - l3passthroughs
   - l3vnis
+  - rawfrrconfigs
   - routernodeconfigurationstatuses
   - underlays
   verbs:
@@ -1387,6 +1388,7 @@ rules:
   - l2vnis/finalizers
   - l3passthroughs/finalizers
   - l3vnis/finalizers
+  - rawfrrconfigs/finalizers
   - underlays/finalizers
   verbs:
   - update
@@ -1396,26 +1398,13 @@ rules:
   - l2vnis/status
   - l3passthroughs/status
   - l3vnis/status
+  - rawfrrconfigs/status
   - routernodeconfigurationstatuses/status
   - underlays/status
   verbs:
   - get
   - patch
   - update
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
-  - rawfrrconfigs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
-  - rawfrrconfigs/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/config/all-in-one/openpe.yaml
+++ b/config/all-in-one/openpe.yaml
@@ -1371,6 +1371,7 @@ rules:
   - l2vnis
   - l3passthroughs
   - l3vnis
+  - rawfrrconfigs
   - routernodeconfigurationstatuses
   - underlays
   verbs:
@@ -1387,6 +1388,7 @@ rules:
   - l2vnis/finalizers
   - l3passthroughs/finalizers
   - l3vnis/finalizers
+  - rawfrrconfigs/finalizers
   - underlays/finalizers
   verbs:
   - update
@@ -1396,26 +1398,13 @@ rules:
   - l2vnis/status
   - l3passthroughs/status
   - l3vnis/status
+  - rawfrrconfigs/status
   - routernodeconfigurationstatuses/status
   - underlays/status
   verbs:
   - get
   - patch
   - update
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
-  - rawfrrconfigs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
-  - rawfrrconfigs/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -45,6 +45,7 @@ rules:
   - l2vnis
   - l3passthroughs
   - l3vnis
+  - rawfrrconfigs
   - routernodeconfigurationstatuses
   - underlays
   verbs:
@@ -61,6 +62,7 @@ rules:
   - l2vnis/finalizers
   - l3passthroughs/finalizers
   - l3vnis/finalizers
+  - rawfrrconfigs/finalizers
   - underlays/finalizers
   verbs:
   - update
@@ -70,23 +72,10 @@ rules:
   - l2vnis/status
   - l3passthroughs/status
   - l3vnis/status
+  - rawfrrconfigs/status
   - routernodeconfigurationstatuses/status
   - underlays/status
   verbs:
   - get
   - patch
   - update
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
-  - rawfrrconfigs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - openpe.openperouter.github.io
-  resources:
-  - rawfrrconfigs/status
-  verbs:
-  - get

--- a/e2etests/tests/static_mirror.go
+++ b/e2etests/tests/static_mirror.go
@@ -1,0 +1,546 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openperouter/openperouter/api/v1alpha1"
+	"github.com/openperouter/openperouter/e2etests/pkg/config"
+	"github.com/openperouter/openperouter/e2etests/pkg/infra"
+	"github.com/openperouter/openperouter/e2etests/pkg/k8s"
+	"github.com/openperouter/openperouter/e2etests/pkg/k8sclient"
+	"github.com/openperouter/openperouter/e2etests/pkg/openperouter"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	staticSourceLabelKey   = "openperouter.github.io/source"
+	staticSourceLabelValue = "static"
+)
+
+// staticUnderlayYAML is a minimal underlay for static mirroring tests.
+var staticUnderlayYAML = fmt.Sprintf(`underlays:
+  - asn: %d
+    nics:
+      - toswitch
+    neighbors:
+      - asn: 64512
+        address: "192.168.11.2"
+    tunnelEndpoint:
+      cidrs:
+        - "100.65.0.0/24"
+`, infra.Underlay.Spec.ASN)
+
+var staticL3VNIYAML = `l3vnis:
+  - vrf: mirror-red
+    vni: 8100
+    hostsession:
+      asn: 64514
+      hostasn: 64515
+      localcidr:
+        ipv4: "192.169.80.0/24"
+`
+
+var staticL3VNIUpdatedYAML = `l3vnis:
+  - vrf: mirror-red
+    vni: 8200
+    hostsession:
+      asn: 64514
+      hostasn: 64515
+      localcidr:
+        ipv4: "192.169.80.0/24"
+`
+
+var _ = Describe("Mirror static config to Kubernetes", Label("systemdmode"), Ordered, func() {
+	var cs clientset.Interface
+	var configPods []*corev1.Pod
+	var nodes []corev1.Node
+	var cl client.Reader
+
+	validateL3VNIs := func(expectedVNI int32) func() error {
+		return func() error {
+			l3vniList := &v1alpha1.L3VNIList{}
+			err := cl.List(context.Background(), l3vniList,
+				client.InNamespace(openperouter.Namespace),
+				client.MatchingLabels{staticSourceLabelKey: staticSourceLabelValue})
+			if err != nil {
+				return fmt.Errorf("failed to list l3vnis: %w", err)
+			}
+			if len(l3vniList.Items) < len(nodes) {
+				return fmt.Errorf("expected at least %d mirrored l3vnis, got %d",
+					len(nodes), len(l3vniList.Items))
+			}
+			for _, v := range l3vniList.Items {
+				if v.Spec.NodeSelector == nil {
+					return fmt.Errorf("mirrored L3VNI %s has nil node selector", v.Name)
+				}
+				if v.Spec.VNI != expectedVNI {
+					return fmt.Errorf("mirrored L3VNI %s has VNI %d, expected %d", v.Name, v.Spec.VNI, expectedVNI)
+				}
+			}
+			return nil
+		}
+	}
+
+	validateL2VNIs := func(expectedVNI int32) func() error {
+		return func() error {
+			l2vniList := &v1alpha1.L2VNIList{}
+			err := cl.List(context.Background(), l2vniList,
+				client.InNamespace(openperouter.Namespace),
+				client.MatchingLabels{staticSourceLabelKey: staticSourceLabelValue})
+			if err != nil {
+				return fmt.Errorf("failed to list l2vnis: %w", err)
+			}
+			if len(l2vniList.Items) == 0 {
+				return fmt.Errorf("expected mirrored L2VNIs, got 0")
+			}
+			for _, v := range l2vniList.Items {
+				if v.Spec.VNI == expectedVNI {
+					return nil
+				}
+			}
+			return fmt.Errorf("mirrored L2VNI with VNI=%d not found", expectedVNI)
+		}
+	}
+
+	BeforeAll(func() {
+		var err error
+
+		err = Updater.CleanAll()
+		Expect(err).NotTo(HaveOccurred())
+
+		cs = k8sclient.New()
+
+		nodes, err = k8s.GetNodes(cs)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nodes).NotTo(BeEmpty(), "need at least one node")
+
+		cl = Updater.Client()
+
+		By("Creating config helper DaemonSet and waiting for pods to be ready")
+		configPods, err = createConfigHelperDaemonSet(cs)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Cleaning any existing static configuration files on all nodes")
+		for _, pod := range configPods {
+			_, err = execInConfigPod(pod, fmt.Sprintf("rm -f %s/openpe_*.yaml", podConfigMount))
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+
+	AfterAll(func() {
+		By("Removing static configuration files on all nodes")
+		for _, pod := range configPods {
+			_, err := execInConfigPod(pod, fmt.Sprintf("rm -f %s/openpe_*.yaml", podConfigMount))
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		By("Deleting config helper DaemonSet")
+		err := cs.AppsV1().DaemonSets(openperouter.Namespace).Delete(
+			context.Background(), "config-helper", metav1.DeleteOptions{})
+		if err != nil {
+			GinkgoWriter.Printf("Warning: failed to delete DaemonSet: %v\n", err)
+		}
+
+		By("Waiting for config helper pods to be removed")
+		Eventually(func() error {
+			pods, err := cs.CoreV1().Pods(openperouter.Namespace).List(context.Background(), metav1.ListOptions{
+				LabelSelector: "app=config-helper",
+			})
+			if err != nil {
+				return err
+			}
+			if len(pods.Items) > 0 {
+				return fmt.Errorf("still waiting for %d config helper pods to be removed", len(pods.Items))
+			}
+			return nil
+		}, 60*time.Second, 1*time.Second).Should(Succeed())
+
+		err = Updater.CleanAll()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	writeBaselineStaticFiles := func() {
+		for _, pod := range configPods {
+			_, err := execInConfigPod(pod, fmt.Sprintf("cat > %s/openpe_underlay.yaml << 'EOF'\n%s\nEOF",
+				podConfigMount, staticUnderlayYAML))
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = execInConfigPod(pod, fmt.Sprintf("cat > %s/openpe_l3vni.yaml << 'EOF'\n%s\nEOF",
+				podConfigMount, staticL3VNIYAML))
+			Expect(err).NotTo(HaveOccurred())
+		}
+	}
+
+	validateUnderlays := func() error {
+		underlayList := &v1alpha1.UnderlayList{}
+		err := cl.List(context.Background(), underlayList,
+			client.InNamespace(openperouter.Namespace),
+			client.MatchingLabels{staticSourceLabelKey: staticSourceLabelValue})
+		if err != nil {
+			return fmt.Errorf("failed to list underlays: %w", err)
+		}
+		if len(underlayList.Items) != len(nodes) {
+			return fmt.Errorf("expected %d mirrored underlays (one per node), got %d",
+				len(nodes), len(underlayList.Items))
+		}
+		for _, u := range underlayList.Items {
+			if u.Spec.NodeSelector == nil {
+				return fmt.Errorf("mirrored underlay %s has nil node selector", u.Name)
+			}
+			if u.Spec.ASN != infra.Underlay.Spec.ASN {
+				return fmt.Errorf("mirrored underlay %s has ASN %d, expected %d", u.Name, u.Spec.ASN, infra.Underlay.Spec.ASN)
+			}
+			if len(u.Spec.Nics) != 1 || u.Spec.Nics[0] != "toswitch" {
+				return fmt.Errorf("mirrored underlay %s has nics %v, expected [toswitch]", u.Name, u.Spec.Nics)
+			}
+			if len(u.Spec.Neighbors) != 1 || u.Spec.Neighbors[0].Address == nil || *u.Spec.Neighbors[0].Address != "192.168.11.2" {
+				return fmt.Errorf("mirrored underlay %s has unexpected neighbors", u.Name)
+			}
+			if u.Spec.TunnelEndpoint == nil || len(u.Spec.TunnelEndpoint.CIDRs) != 1 || u.Spec.TunnelEndpoint.CIDRs[0] != "100.65.0.0/24" {
+				return fmt.Errorf("mirrored underlay %s has unexpected tunnel endpoint config", u.Name)
+			}
+		}
+		return nil
+	}
+
+	BeforeEach(func() {
+		writeBaselineStaticFiles()
+	})
+
+	AfterEach(func() {
+		for _, pod := range configPods {
+			_, err := execInConfigPod(pod, fmt.Sprintf("rm -f %s/openpe_*.yaml", podConfigMount))
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		err := Updater.CleanAll()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("mirrors static underlay and L3VNI to Kubernetes CRDs", func() {
+		By("waiting for mirrored underlay to appear with static source label")
+		Eventually(validateUnderlays, "60s", "2s").Should(Succeed())
+
+		By("waiting for mirrored L3VNI to appear with static source label")
+		Eventually(validateL3VNIs(8100), "60s", "2s").Should(Succeed())
+	})
+
+	It("updates mirrored L3VNI when static file changes", func() {
+		By("waiting for baseline L3VNI to be mirrored")
+		Eventually(validateL3VNIs(8100), "60s", "2s").Should(Succeed())
+
+		By("overwriting static L3VNI file with updated VNI on all nodes")
+		for _, pod := range configPods {
+			_, err := execInConfigPod(pod, fmt.Sprintf("cat > %s/openpe_l3vni.yaml << 'EOF'\n%s\nEOF",
+				podConfigMount, staticL3VNIUpdatedYAML))
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		By("waiting for mirrored L3VNI to show updated VNI=8200")
+		Eventually(validateL3VNIs(8200), "30s", "2s").Should(Succeed())
+	})
+
+	It("creates new mirrored resource when a new static file is added", func() {
+		By("waiting for baseline resources to be mirrored")
+		Eventually(validateL3VNIs(8100), "60s", "2s").Should(Succeed())
+
+		By("writing a new L2VNI static file on all nodes")
+		l2vniYAML := `l2vnis:
+  - vni: 8300
+    vxlanport: 4789
+    vrf: sl2vni8300
+`
+		for _, pod := range configPods {
+			_, err := execInConfigPod(pod, fmt.Sprintf("cat > %s/openpe_l2vni.yaml << 'EOF'\n%s\nEOF",
+				podConfigMount, l2vniYAML))
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		By("waiting for new mirrored L2VNI to appear")
+		Eventually(validateL2VNIs(8300), "30s", "2s").Should(Succeed())
+	})
+
+	It("deletes mirrored resource when static file is removed", func() {
+		By("writing a L2VNI static file on all nodes")
+		l2vniYAML := `l2vnis:
+  - vni: 8300
+    vxlanport: 4789
+    vrf: sl2vni8300
+`
+		for _, pod := range configPods {
+			_, err := execInConfigPod(pod, fmt.Sprintf("cat > %s/openpe_l2vni.yaml << 'EOF'\n%s\nEOF",
+				podConfigMount, l2vniYAML))
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		By("waiting for mirrored L2VNI to appear")
+		Eventually(validateL2VNIs(8300), "60s", "2s").Should(Succeed())
+
+		By("removing L2VNI static file from all nodes")
+		for _, pod := range configPods {
+			_, err := execInConfigPod(pod, fmt.Sprintf("rm -f %s/openpe_l2vni.yaml", podConfigMount))
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		By("waiting for mirrored L2VNIs to be deleted")
+		Eventually(func() error {
+			l2vniList := &v1alpha1.L2VNIList{}
+			err := cl.List(context.Background(), l2vniList,
+				client.InNamespace(openperouter.Namespace),
+				client.MatchingLabels{staticSourceLabelKey: staticSourceLabelValue})
+			if err != nil {
+				return fmt.Errorf("failed to list l2vnis: %w", err)
+			}
+			if len(l2vniList.Items) > 0 {
+				return fmt.Errorf("expected 0 mirrored L2VNIs after file removal, got %d", len(l2vniList.Items))
+			}
+			return nil
+		}, "30s", "2s").Should(Succeed())
+
+		By("verifying underlay mirrored resources still exist")
+		Eventually(validateUnderlays, "30s", "2s").Should(Succeed())
+	})
+
+	It("re-creates mirrored resource after manual deletion", func() {
+		By("waiting for baseline L3VNI to be mirrored")
+		l3vniList := &v1alpha1.L3VNIList{}
+		Eventually(func() error {
+			err := cl.List(context.Background(), l3vniList,
+				client.InNamespace(openperouter.Namespace),
+				client.MatchingLabels{staticSourceLabelKey: staticSourceLabelValue})
+			if err != nil {
+				return err
+			}
+			if len(l3vniList.Items) == 0 {
+				return fmt.Errorf("no mirrored L3VNIs found")
+			}
+			return nil
+		}, "60s", "2s").Should(Succeed())
+
+		targetName := l3vniList.Items[0].Name
+		targetNs := l3vniList.Items[0].Namespace
+
+		By(fmt.Sprintf("deleting mirrored L3VNI %s via kubectl", targetName))
+		toDelete := l3vniList.Items[0].DeepCopy()
+		err := Updater.Client().Delete(context.Background(), toDelete)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("waiting for mirrored L3VNI to be re-created")
+		Eventually(func() error {
+			var v v1alpha1.L3VNI
+			err := cl.Get(context.Background(), client.ObjectKey{
+				Name:      targetName,
+				Namespace: targetNs,
+			}, &v)
+			if err != nil {
+				return fmt.Errorf("mirrored L3VNI %s not yet re-created: %w", targetName, err)
+			}
+			if v.Labels[staticSourceLabelKey] != staticSourceLabelValue {
+				return fmt.Errorf("re-created L3VNI missing static source label")
+			}
+			return nil
+		}, "30s", "2s").Should(Succeed())
+	})
+
+	It("webhook rejects a new K8s-managed L3VNI with same VNI as mirrored one", func() {
+		By("ensuring mirrored L3VNIs exist with VNI=8100")
+		Eventually(validateL3VNIs(8100), "60s", "2s").Should(Succeed())
+
+		By("attempting to create a K8s-managed L3VNI with VNI=8100 (same as mirrored)")
+		conflictingVNI := v1alpha1.L3VNI{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "conflict-vni-test",
+				Namespace: openperouter.Namespace,
+			},
+			Spec: v1alpha1.L3VNISpec{
+				VRF: "conflict-vrf",
+				VNI: 8100,
+				HostSession: &v1alpha1.HostSession{
+					ASN:     64514,
+					HostASN: new(int64(64518)),
+					LocalCIDR: v1alpha1.LocalCIDRConfig{
+						IPv4: new("192.169.90.0/24"),
+					},
+				},
+			},
+		}
+		err := Updater.Update(config.Resources{
+			L3VNIs: []v1alpha1.L3VNI{conflictingVNI},
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("duplicate vni"))
+	})
+
+	It("webhook allows a new K8s-managed L3VNI that does not conflict with mirrored", func() {
+		By("ensuring mirrored L3VNIs exist")
+		Eventually(validateL3VNIs(8100), "60s", "2s").Should(Succeed())
+
+		nonConflicting := v1alpha1.L3VNI{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "noconflict-vni-test",
+				Namespace: openperouter.Namespace,
+			},
+			Spec: v1alpha1.L3VNISpec{
+				VRF: "noconflict-vrf",
+				VNI: 9999,
+				HostSession: &v1alpha1.HostSession{
+					ASN:     64514,
+					HostASN: new(int64(64519)),
+					LocalCIDR: v1alpha1.LocalCIDRConfig{
+						IPv4: new("192.169.91.0/24"),
+					},
+				},
+			},
+		}
+		err := Updater.Update(config.Resources{
+			L3VNIs: []v1alpha1.L3VNI{nonConflicting},
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("reverts mirrored L3VNI spec after manual edit", func() {
+		By("waiting for baseline L3VNI to be mirrored")
+		var l3vni v1alpha1.L3VNI
+		Eventually(func() error {
+			l3vniList := &v1alpha1.L3VNIList{}
+			err := cl.List(context.Background(), l3vniList,
+				client.InNamespace(openperouter.Namespace),
+				client.MatchingLabels{staticSourceLabelKey: staticSourceLabelValue})
+			if err != nil {
+				return err
+			}
+			if len(l3vniList.Items) == 0 {
+				return fmt.Errorf("no mirrored L3VNIs found")
+			}
+			l3vni = l3vniList.Items[0]
+			return nil
+		}, "60s", "2s").Should(Succeed())
+
+		originalVNI := l3vni.Spec.VNI
+		Expect(originalVNI).NotTo(BeZero())
+
+		By(fmt.Sprintf("patching mirrored L3VNI %s VNI from %d to 9876", l3vni.Name, originalVNI))
+		patch, err := json.Marshal(map[string]any{
+			"spec": map[string]any{
+				"vni": 9876,
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		err = Updater.Client().Patch(context.Background(), &l3vni, client.RawPatch(types.MergePatchType, patch))
+		Expect(err).NotTo(HaveOccurred())
+
+		By(fmt.Sprintf("waiting for VNI to revert to %d", originalVNI))
+		Eventually(func() int32 {
+			var v v1alpha1.L3VNI
+			err := cl.Get(context.Background(), client.ObjectKey{
+				Name:      l3vni.Name,
+				Namespace: l3vni.Namespace,
+			}, &v)
+			if err != nil {
+				return 0
+			}
+			return v.Spec.VNI
+		}, "30s", "2s").Should(Equal(originalVNI))
+	})
+
+	It("webhook rejects a new K8s-managed L2VNI with same VNI as mirrored one", func() {
+		By("writing a static L2VNI file on all nodes")
+		l2vniYAML := `l2vnis:
+  - vni: 8400
+    vxlanport: 4789
+    vrf: sl2vni8400
+`
+		for _, pod := range configPods {
+			_, err := execInConfigPod(pod, fmt.Sprintf("cat > %s/openpe_l2vni_webhook.yaml << 'EOF'\n%s\nEOF",
+				podConfigMount, l2vniYAML))
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		By("waiting for mirrored L2VNI to appear")
+		Eventually(validateL2VNIs(8400), "60s", "2s").Should(Succeed())
+
+		By("attempting to create a K8s-managed L2VNI with VNI=8400 (same as mirrored)")
+		err := Updater.Update(config.Resources{
+			L2VNIs: []v1alpha1.L2VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cnfl2test",
+						Namespace: openperouter.Namespace,
+					},
+					Spec: v1alpha1.L2VNISpec{
+						VNI:       8400,
+						VXLanPort: new(int32(4789)),
+					},
+				},
+			},
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("duplicate vni"))
+
+		By("cleaning up static L2VNI file")
+		for _, pod := range configPods {
+			_, err := execInConfigPod(pod, fmt.Sprintf("rm -f %s/openpe_l2vni_webhook.yaml", podConfigMount))
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		By("waiting for mirrored L2VNI to be cleaned up")
+		Eventually(func() error {
+			l2vniList := &v1alpha1.L2VNIList{}
+			err := cl.List(context.Background(), l2vniList,
+				client.InNamespace(openperouter.Namespace),
+				client.MatchingLabels{staticSourceLabelKey: staticSourceLabelValue})
+			if err != nil {
+				return err
+			}
+			for _, v := range l2vniList.Items {
+				if v.Spec.VNI == 8400 {
+					return fmt.Errorf("mirrored L2VNI VNI=8400 still exists")
+				}
+			}
+			return nil
+		}, "30s", "2s").Should(Succeed())
+	})
+
+	It("webhook rejects a new K8s-managed underlay when mirrored one already exists on same node", func() {
+		By("waiting for mirrored underlay to exist")
+		Eventually(validateUnderlays, "60s", "2s").Should(Succeed())
+
+		By("attempting to create a K8s-managed underlay (conflicts: can't have >1 underlay per node)")
+		err := Updater.Update(config.Resources{
+			Underlays: []v1alpha1.Underlay{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "conflict-underlay-test",
+						Namespace: openperouter.Namespace,
+					},
+					Spec: v1alpha1.UnderlaySpec{
+						ASN: 64520,
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								ASN:     new(int64(64521)),
+								Address: new("192.168.99.2"),
+							},
+						},
+						Nics: []string{"eth0"},
+						TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+							CIDRs: []string{"100.66.0.0/24"},
+						},
+					},
+				},
+			},
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("can't have more than one underlay per node"))
+	})
+})

--- a/internal/controller/routerconfiguration/mirror_controller.go
+++ b/internal/controller/routerconfiguration/mirror_controller.go
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package routerconfiguration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/openperouter/openperouter/api/v1alpha1"
+	"github.com/openperouter/openperouter/internal/conversion"
+	"github.com/openperouter/openperouter/internal/staticconfiguration"
+)
+
+// MirrorController mirrors static configuration files to Kubernetes CRDs.
+type MirrorController struct {
+	client.Client
+	Scheme      *runtime.Scheme
+	Logger      *slog.Logger
+	MyNode      string
+	MyNamespace string
+	ConfigDir   string
+	TriggerChan chan event.GenericEvent
+}
+
+func (r *MirrorController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := r.Logger.With("controller", "MirrorController", "request", req.String())
+	logger.Info("start reconcile")
+	defer logger.Info("end reconcile")
+
+	var noConfigErr *staticconfiguration.NoConfigAvailable
+	staticConfig, err := readStaticConfigs(r.ConfigDir, r.MyNode, r.MyNamespace)
+	if errors.As(err, &noConfigErr) {
+		logger.Info("no static configuration available, cleaning up mirrored resources", "dir", r.ConfigDir)
+		staticConfig = conversion.APIConfigData{}
+	} else if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to read static configs from %s: %w", r.ConfigDir, err)
+	}
+
+	var mirrorErrors []error
+	if err := r.mirrorAndClean(ctx, &v1alpha1.UnderlayList{}, toObjects(staticConfig.Underlays), logger, "underlay"); err != nil {
+		mirrorErrors = append(mirrorErrors, err)
+	}
+
+	if err := r.mirrorAndClean(ctx, &v1alpha1.L3VNIList{}, toObjects(staticConfig.L3VNIs), logger, "l3vni"); err != nil {
+		mirrorErrors = append(mirrorErrors, err)
+	}
+
+	if err := r.mirrorAndClean(ctx, &v1alpha1.L2VNIList{}, toObjects(staticConfig.L2VNIs), logger, "l2vni"); err != nil {
+		mirrorErrors = append(mirrorErrors, err)
+	}
+
+	if err := r.mirrorAndClean(ctx, &v1alpha1.L3PassthroughList{}, toObjects(staticConfig.L3Passthrough), logger, "l3passthrough"); err != nil {
+		mirrorErrors = append(mirrorErrors, err)
+	}
+
+	if err := r.mirrorAndClean(ctx, &v1alpha1.RawFRRConfigList{}, toObjects(staticConfig.RawFRRConfigs), logger, "rawfrrconfig"); err != nil {
+		mirrorErrors = append(mirrorErrors, err)
+	}
+
+	return ctrl.Result{}, errors.Join(mirrorErrors...)
+}
+
+// SetupWithManager registers the mirror controller with the manager.
+func (r *MirrorController) SetupWithManager(mgr ctrl.Manager) error {
+	staticSourcePredicate := predicate.NewPredicateFuncs(func(object client.Object) bool {
+		labels := object.GetLabels()
+		if labels == nil {
+			return false
+		}
+		return labels[StaticSourceLabel] == StaticSourceValue && labels[StaticNodeLabel] == r.MyNode
+	})
+
+	b := ctrl.NewControllerManagedBy(mgr).
+		Named("mirror-controller").
+		WatchesRawSource(source.Channel(r.TriggerChan, &handler.EnqueueRequestForObject{})).
+		Watches(&v1alpha1.Underlay{}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(staticSourcePredicate)).
+		Watches(&v1alpha1.L3VNI{}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(staticSourcePredicate)).
+		Watches(&v1alpha1.L2VNI{}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(staticSourcePredicate)).
+		Watches(&v1alpha1.L3Passthrough{}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(staticSourcePredicate)).
+		Watches(&v1alpha1.RawFRRConfig{}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(staticSourcePredicate))
+
+	return b.Complete(r)
+}
+
+func (r *MirrorController) mirrorAndClean(ctx context.Context, listObj client.ObjectList, desired []client.Object, logger *slog.Logger, kind string) error {
+	matchLabels := client.MatchingLabels{
+		StaticSourceLabel: StaticSourceValue,
+		StaticNodeLabel:   r.MyNode,
+	}
+	inNamespace := client.InNamespace(r.MyNamespace)
+
+	if err := r.List(ctx, listObj, matchLabels, inNamespace); err != nil {
+		return fmt.Errorf("failed to list mirrored %ss: %w", kind, err)
+	}
+
+	existing := extractItems(listObj)
+	existingByName := map[string]client.Object{}
+	for _, item := range existing {
+		existingByName[item.GetName()] = item
+	}
+
+	var mirrorErrors []error
+	desiredNames := map[string]struct{}{}
+	for _, d := range desired {
+		desiredNames[d.GetName()] = struct{}{}
+		if ex, ok := existingByName[d.GetName()]; ok && resourceMatchesDesired(ex, d) {
+			continue
+		}
+		if _, err := r.createOrUpdateMirrored(ctx, d, logger, kind); err != nil {
+			mirrorErrors = append(mirrorErrors, err)
+		}
+	}
+
+	for _, item := range existing {
+		if _, ok := desiredNames[item.GetName()]; ok {
+			continue
+		}
+		logger.Info("deleting stale mirrored resource", "kind", kind, "name", item.GetName())
+		if err := client.IgnoreNotFound(r.Delete(ctx, item)); err != nil {
+			mirrorErrors = append(mirrorErrors, fmt.Errorf("failed to delete stale %s %s: %w", kind, item.GetName(), err))
+		}
+	}
+
+	return errors.Join(mirrorErrors...)
+}
+
+func (r *MirrorController) createOrUpdateMirrored(ctx context.Context, desired client.Object, logger *slog.Logger, kind string) (controllerutil.OperationResult, error) {
+	obj, err := newEmptyObject(desired)
+	if err != nil {
+		return controllerutil.OperationResultNone, err
+	}
+	obj.SetName(desired.GetName())
+	obj.SetNamespace(desired.GetNamespace())
+	result, err := controllerutil.CreateOrUpdate(ctx, r.Client, obj, func() error {
+		obj.SetLabels(desired.GetLabels())
+		copySpec(desired, obj)
+		return nil
+	})
+	if err != nil {
+		return result, fmt.Errorf("failed to create/update %s %s: %w", kind, desired.GetName(), err)
+	}
+	logger.Info("mirrored resource", "kind", kind, "name", desired.GetName(), "result", result)
+	return result, nil
+}
+
+func newEmptyObject(obj client.Object) (client.Object, error) {
+	switch obj.(type) {
+	case *v1alpha1.Underlay:
+		return &v1alpha1.Underlay{}, nil
+	case *v1alpha1.L3VNI:
+		return &v1alpha1.L3VNI{}, nil
+	case *v1alpha1.L2VNI:
+		return &v1alpha1.L2VNI{}, nil
+	case *v1alpha1.L3Passthrough:
+		return &v1alpha1.L3Passthrough{}, nil
+	case *v1alpha1.RawFRRConfig:
+		return &v1alpha1.RawFRRConfig{}, nil
+	}
+	return nil, fmt.Errorf("unsupported object type: %T", obj)
+}
+
+func copySpec(src, dst client.Object) {
+	switch s := src.(type) {
+	case *v1alpha1.Underlay:
+		s.Spec.DeepCopyInto(&dst.(*v1alpha1.Underlay).Spec)
+	case *v1alpha1.L3VNI:
+		s.Spec.DeepCopyInto(&dst.(*v1alpha1.L3VNI).Spec)
+	case *v1alpha1.L2VNI:
+		s.Spec.DeepCopyInto(&dst.(*v1alpha1.L2VNI).Spec)
+	case *v1alpha1.L3Passthrough:
+		s.Spec.DeepCopyInto(&dst.(*v1alpha1.L3Passthrough).Spec)
+	case *v1alpha1.RawFRRConfig:
+		s.Spec.DeepCopyInto(&dst.(*v1alpha1.RawFRRConfig).Spec)
+	}
+}
+
+func resourceMatchesDesired(existing, desired client.Object) bool {
+	if !equality.Semantic.DeepEqual(existing.GetLabels(), desired.GetLabels()) {
+		return false
+	}
+	switch e := existing.(type) {
+	case *v1alpha1.Underlay:
+		return equality.Semantic.DeepEqual(e.Spec, desired.(*v1alpha1.Underlay).Spec)
+	case *v1alpha1.L3VNI:
+		return equality.Semantic.DeepEqual(e.Spec, desired.(*v1alpha1.L3VNI).Spec)
+	case *v1alpha1.L2VNI:
+		return equality.Semantic.DeepEqual(e.Spec, desired.(*v1alpha1.L2VNI).Spec)
+	case *v1alpha1.L3Passthrough:
+		return equality.Semantic.DeepEqual(e.Spec, desired.(*v1alpha1.L3Passthrough).Spec)
+	case *v1alpha1.RawFRRConfig:
+		return equality.Semantic.DeepEqual(e.Spec, desired.(*v1alpha1.RawFRRConfig).Spec)
+	}
+	return false
+}
+
+// toObjects converts a typed slice of K8s resources to a slice of client.Object.
+func toObjects[T any, PT interface {
+	*T
+	client.Object
+}](items []T) []client.Object {
+	result := make([]client.Object, len(items))
+	for i := range items {
+		result[i] = PT(&items[i])
+	}
+	return result
+}
+
+func extractItems(listObj client.ObjectList) []client.Object {
+	switch l := listObj.(type) {
+	case *v1alpha1.UnderlayList:
+		return toObjects(l.Items)
+	case *v1alpha1.L3VNIList:
+		return toObjects(l.Items)
+	case *v1alpha1.L2VNIList:
+		return toObjects(l.Items)
+	case *v1alpha1.L3PassthroughList:
+		return toObjects(l.Items)
+	case *v1alpha1.RawFRRConfigList:
+		return toObjects(l.Items)
+	}
+	return nil
+}

--- a/internal/controller/routerconfiguration/mirror_controller_test.go
+++ b/internal/controller/routerconfiguration/mirror_controller_test.go
@@ -1,0 +1,621 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package routerconfiguration
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openperouter/openperouter/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+const (
+	testNodeName  = "worker-1"
+	testNamespace = "openperouter-system"
+	testNodeUID   = "test-uid-12345"
+)
+
+func TestMirrorController(t *testing.T) {
+	tests := []struct {
+		name        string
+		files       map[string]string
+		expectedCRs expectedResources
+		updateFiles map[string]string  // optional: files to write after initial reconcile
+		deleteFiles []string           // optional: files to delete after initial reconcile
+		updatedCRs  *expectedResources // optional: expected state after update
+		preExisting []client.Object    // optional: resources that already exist
+	}{
+		{
+			name: "creates underlay from static file",
+			files: map[string]string{
+				"openpe_underlay.yaml": `underlays:
+  - asn: 64514
+    routeridcidr: "10.0.0.0/24"
+    nics:
+      - eth0
+    neighbors:
+      - asn: 64512
+        address: "192.168.11.2"
+    tunnelEndpoint:
+      cidrs:
+        - "100.65.0.0/24"
+`,
+			},
+			expectedCRs: expectedResources{
+				underlays:        1,
+				validateUnderlay: validateUnderlayLabelsAndSelector,
+			},
+		},
+		{
+			name: "creates multiple resource types",
+			files: map[string]string{
+				"openpe_underlay.yaml": `underlays:
+  - asn: 64514
+    nics:
+      - eth0
+    neighbors:
+      - asn: 64512
+        address: "192.168.11.2"
+    tunnelEndpoint:
+      cidrs:
+        - "100.65.0.0/24"
+`,
+				"openpe_l3vni.yaml": `l3vnis:
+  - vrf: red
+    vni: 100
+  - vrf: blue
+    vni: 200
+`,
+				"openpe_l2vni.yaml": `l2vnis:
+  - vni: 300
+    vxlanport: 4789
+`,
+			},
+			expectedCRs: expectedResources{
+				underlays:     1,
+				l3vnis:        2,
+				l2vnis:        1,
+				validateL3VNI: validateL3VNI(map[string]int32{"red": 100, "blue": 200}),
+				validateL2VNI: validateL2VNI(300),
+			},
+		},
+		{
+			name: "updates resource when static file changes",
+			files: map[string]string{
+				"openpe_underlay.yaml": `underlays:
+  - asn: 64514
+    nics:
+      - eth0
+    neighbors:
+      - asn: 64512
+        address: "192.168.11.2"
+    tunnelEndpoint:
+      cidrs:
+        - "100.65.0.0/24"
+`,
+			},
+			expectedCRs: expectedResources{
+				underlays:        1,
+				validateUnderlay: validateUnderlayASN(64514),
+			},
+			updateFiles: map[string]string{
+				"openpe_underlay.yaml": `underlays:
+  - asn: 64515
+    nics:
+      - eth0
+    neighbors:
+      - asn: 64512
+        address: "192.168.11.2"
+    tunnelEndpoint:
+      cidrs:
+        - "100.65.0.0/24"
+`,
+			},
+			updatedCRs: &expectedResources{
+				underlays:        1,
+				validateUnderlay: validateUnderlayASNAndLabel(64515),
+			},
+		},
+		{
+			name: "deletes stale resources when removed from config",
+			files: map[string]string{
+				"openpe_l3vni.yaml": `l3vnis:
+  - vrf: red
+    vni: 100
+  - vrf: blue
+    vni: 200
+`,
+			},
+			expectedCRs: expectedResources{
+				l3vnis: 2,
+			},
+			updateFiles: map[string]string{
+				"openpe_l3vni.yaml": `l3vnis:
+  - vrf: red
+    vni: 100
+`,
+			},
+			updatedCRs: &expectedResources{
+				l3vnis:        1,
+				validateL3VNI: validateL3VNI(map[string]int32{"red": 100}),
+			},
+		},
+		{
+			name: "deletes all when static files removed",
+			files: map[string]string{
+				"openpe_underlay.yaml": `underlays:
+  - asn: 64514
+    nics:
+      - eth0
+    neighbors:
+      - asn: 64512
+        address: "192.168.11.2"
+    tunnelEndpoint:
+      cidrs:
+        - "100.65.0.0/24"
+`,
+				"openpe_l3vni.yaml": `l3vnis:
+  - vrf: red
+    vni: 100
+`,
+			},
+			expectedCRs: expectedResources{
+				underlays: 1,
+				l3vnis:    1,
+			},
+			deleteFiles: []string{"openpe_underlay.yaml", "openpe_l3vni.yaml"},
+			updatedCRs: &expectedResources{
+				underlays: 0,
+				l3vnis:    0,
+			},
+		},
+		{
+			name: "does not delete resources from other nodes",
+			preExisting: []client.Object{
+				&v1alpha1.L3VNI{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "static-node-b-l3vni-0",
+						Namespace: testNamespace,
+						Labels: map[string]string{
+							StaticSourceLabel: StaticSourceValue,
+							StaticNodeLabel:   "node-b",
+						},
+					},
+					Spec: v1alpha1.L3VNISpec{VRF: "green", VNI: 500},
+				},
+			},
+			files: map[string]string{
+				"openpe_l3vni.yaml": `l3vnis:
+  - vrf: red
+    vni: 100
+`,
+			},
+			expectedCRs: expectedResources{
+				l3vnis:        2, // worker-1 + node-b
+				validateL3VNI: validateNodeBL3VNIUnchanged,
+			},
+			deleteFiles: []string{"openpe_l3vni.yaml"},
+			updatedCRs: &expectedResources{
+				l3vnis: 1, // only node-b remains
+			},
+		},
+		{
+			name: "adds new file while preserving existing",
+			files: map[string]string{
+				"openpe_underlay.yaml": `underlays:
+  - asn: 64514
+    nics:
+      - eth0
+    neighbors:
+      - asn: 64512
+        address: "192.168.11.2"
+    tunnelEndpoint:
+      cidrs:
+        - "100.65.0.0/24"
+`,
+			},
+			expectedCRs: expectedResources{
+				underlays: 1,
+			},
+			updateFiles: map[string]string{
+				"openpe_l3vni.yaml": `l3vnis:
+  - vrf: red
+    vni: 100
+`,
+			},
+			updatedCRs: &expectedResources{
+				underlays: 1,
+				l3vnis:    1,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			// Write initial files
+			for name, content := range tt.files {
+				writeStaticFile(t, dir, name, content)
+			}
+
+			mc := newMirrorController(t, dir, append([]client.Object{testNode()}, tt.preExisting...)...)
+			reconcile(t, mc)
+
+			// Check initial state
+			assertExpectedResources(t, mc, tt.expectedCRs)
+
+			// Apply updates if specified
+			if len(tt.updateFiles) > 0 || len(tt.deleteFiles) > 0 {
+				for name, content := range tt.updateFiles {
+					writeStaticFile(t, dir, name, content)
+				}
+				for _, name := range tt.deleteFiles {
+					removeStaticFile(t, dir, name)
+				}
+				reconcile(t, mc)
+
+				if tt.updatedCRs != nil {
+					assertExpectedResources(t, mc, *tt.updatedCRs)
+				}
+			}
+		})
+	}
+}
+
+type expectedResources struct {
+	underlays         int
+	l3vnis            int
+	l2vnis            int
+	l3passthroughs    int
+	rawfrrconfigs     int
+	validateUnderlay  func(*testing.T, *v1alpha1.Underlay)
+	validateL3VNI     func(*testing.T, *v1alpha1.L3VNI)
+	validateL2VNI     func(*testing.T, *v1alpha1.L2VNI)
+	validateL3PT      func(*testing.T, *v1alpha1.L3Passthrough)
+	validateRawConfig func(*testing.T, *v1alpha1.RawFRRConfig)
+}
+
+func assertExpectedResources(t *testing.T, mc *MirrorController, expected expectedResources) {
+	t.Helper()
+	ctx := context.Background()
+	matchLabels := client.MatchingLabels{StaticSourceLabel: StaticSourceValue}
+	inNs := client.InNamespace(testNamespace)
+
+	var underlays v1alpha1.UnderlayList
+	if err := mc.List(ctx, &underlays, matchLabels, inNs); err != nil {
+		t.Fatalf("failed to list underlays: %v", err)
+	}
+	if len(underlays.Items) != expected.underlays {
+		t.Errorf("expected %d underlays, got %d", expected.underlays, len(underlays.Items))
+	}
+	if expected.validateUnderlay != nil {
+		for i := range underlays.Items {
+			expected.validateUnderlay(t, &underlays.Items[i])
+		}
+	}
+
+	var l3vnis v1alpha1.L3VNIList
+	if err := mc.List(ctx, &l3vnis, matchLabels, inNs); err != nil {
+		t.Fatalf("failed to list l3vnis: %v", err)
+	}
+	if len(l3vnis.Items) != expected.l3vnis {
+		t.Errorf("expected %d l3vnis, got %d", expected.l3vnis, len(l3vnis.Items))
+	}
+	if expected.validateL3VNI != nil {
+		for i := range l3vnis.Items {
+			expected.validateL3VNI(t, &l3vnis.Items[i])
+		}
+	}
+
+	var l2vnis v1alpha1.L2VNIList
+	if err := mc.List(ctx, &l2vnis, matchLabels, inNs); err != nil {
+		t.Fatalf("failed to list l2vnis: %v", err)
+	}
+	if len(l2vnis.Items) != expected.l2vnis {
+		t.Errorf("expected %d l2vnis, got %d", expected.l2vnis, len(l2vnis.Items))
+	}
+	if expected.validateL2VNI != nil {
+		for i := range l2vnis.Items {
+			expected.validateL2VNI(t, &l2vnis.Items[i])
+		}
+	}
+
+	var l3pts v1alpha1.L3PassthroughList
+	if err := mc.List(ctx, &l3pts, matchLabels, inNs); err != nil {
+		t.Fatalf("failed to list l3passthroughs: %v", err)
+	}
+	if len(l3pts.Items) != expected.l3passthroughs {
+		t.Errorf("expected %d l3passthroughs, got %d", expected.l3passthroughs, len(l3pts.Items))
+	}
+	if expected.validateL3PT != nil {
+		for i := range l3pts.Items {
+			expected.validateL3PT(t, &l3pts.Items[i])
+		}
+	}
+
+	var rawCfgs v1alpha1.RawFRRConfigList
+	if err := mc.List(ctx, &rawCfgs, matchLabels, inNs); err != nil {
+		t.Fatalf("failed to list rawfrrconfigs: %v", err)
+	}
+	if len(rawCfgs.Items) != expected.rawfrrconfigs {
+		t.Errorf("expected %d rawfrrconfigs, got %d", expected.rawfrrconfigs, len(rawCfgs.Items))
+	}
+	if expected.validateRawConfig != nil {
+		for i := range rawCfgs.Items {
+			expected.validateRawConfig(t, &rawCfgs.Items[i])
+		}
+	}
+}
+
+func TestMirrorController_RecreatesExternallyDeletedResource(t *testing.T) {
+	dir := t.TempDir()
+	writeStaticFile(t, dir, "openpe_l3vni.yaml", `l3vnis:
+  - vrf: red
+    vni: 100
+`)
+	mc := newMirrorController(t, dir, testNode())
+	reconcile(t, mc)
+
+	ctx := context.Background()
+	key := client.ObjectKey{Name: "static-worker-1-l3vni-0", Namespace: testNamespace}
+	var v v1alpha1.L3VNI
+	if err := mc.Get(ctx, key, &v); err != nil {
+		t.Fatalf("expected L3VNI to exist: %v", err)
+	}
+	if err := mc.Delete(ctx, &v); err != nil {
+		t.Fatalf("failed to delete L3VNI: %v", err)
+	}
+	reconcile(t, mc)
+	if err := mc.Get(ctx, key, &v); err != nil {
+		t.Fatalf("expected L3VNI to be recreated: %v", err)
+	}
+	if v.Spec.VNI != 100 {
+		t.Errorf("expected VNI 100, got %d", v.Spec.VNI)
+	}
+}
+
+func TestMirrorController_IdempotentMultipleReconciles(t *testing.T) {
+	dir := t.TempDir()
+	writeStaticFile(t, dir, "openpe_underlay.yaml", `underlays:
+  - asn: 64514
+    nics:
+      - eth0
+    neighbors:
+      - asn: 64512
+        address: "192.168.11.2"
+    tunnelEndpoint:
+      cidrs:
+        - "100.65.0.0/24"
+`)
+	writeStaticFile(t, dir, "openpe_l3vni.yaml", `l3vnis:
+  - vrf: red
+    vni: 100
+`)
+	mc := newMirrorController(t, dir, testNode())
+
+	for range 3 {
+		reconcile(t, mc)
+	}
+
+	assertExpectedResources(t, mc, expectedResources{
+		underlays: 1,
+		l3vnis:    1,
+	})
+}
+
+func TestMirrorController_OverwritesExternallyModifiedResource(t *testing.T) {
+	dir := t.TempDir()
+	writeStaticFile(t, dir, "openpe_l3vni.yaml", `l3vnis:
+  - vrf: red
+    vni: 100
+`)
+	mc := newMirrorController(t, dir, testNode())
+	reconcile(t, mc)
+
+	ctx := context.Background()
+	key := client.ObjectKey{Name: "static-worker-1-l3vni-0", Namespace: testNamespace}
+
+	// External actor changes VNI
+	var v v1alpha1.L3VNI
+	if err := mc.Get(ctx, key, &v); err != nil {
+		t.Fatalf("expected L3VNI to exist: %v", err)
+	}
+	v.Spec.VNI = 999
+	if err := mc.Update(ctx, &v); err != nil {
+		t.Fatalf("failed to update L3VNI externally: %v", err)
+	}
+
+	// Reconcile should revert
+	reconcile(t, mc)
+
+	var reverted v1alpha1.L3VNI
+	if err := mc.Get(ctx, key, &reverted); err != nil {
+		t.Fatalf("expected L3VNI to exist after revert: %v", err)
+	}
+	if reverted.Spec.VNI != 100 {
+		t.Errorf("expected VNI reverted to 100, got %d", reverted.Spec.VNI)
+	}
+}
+
+func TestMirrorController_RestoresLabelAfterExternalRemoval(t *testing.T) {
+	dir := t.TempDir()
+	writeStaticFile(t, dir, "openpe_l3vni.yaml", `l3vnis:
+  - vrf: red
+    vni: 100
+`)
+	mc := newMirrorController(t, dir, testNode())
+	reconcile(t, mc)
+
+	ctx := context.Background()
+	key := client.ObjectKey{Name: "static-worker-1-l3vni-0", Namespace: testNamespace}
+
+	// External actor removes label
+	var v v1alpha1.L3VNI
+	if err := mc.Get(ctx, key, &v); err != nil {
+		t.Fatalf("expected L3VNI to exist: %v", err)
+	}
+	v.Labels = map[string]string{}
+	if err := mc.Update(ctx, &v); err != nil {
+		t.Fatalf("failed to remove label externally: %v", err)
+	}
+
+	// Reconcile should restore
+	reconcile(t, mc)
+
+	var restored v1alpha1.L3VNI
+	if err := mc.Get(ctx, key, &restored); err != nil {
+		t.Fatalf("expected L3VNI to exist after restore: %v", err)
+	}
+	if restored.Labels[StaticSourceLabel] != StaticSourceValue {
+		t.Errorf("expected label restored, got %v", restored.Labels)
+	}
+}
+
+func validateUnderlayLabelsAndSelector(t *testing.T, u *v1alpha1.Underlay) {
+	t.Helper()
+	if u.Spec.ASN != 64514 {
+		t.Errorf("expected ASN 64514, got %d", u.Spec.ASN)
+	}
+	if u.Labels[StaticSourceLabel] != StaticSourceValue {
+		t.Errorf("missing static source label")
+	}
+	if u.Labels[StaticNodeLabel] != testNodeName {
+		t.Errorf("expected node label %s, got %s", testNodeName, u.Labels[StaticNodeLabel])
+	}
+	if u.Spec.NodeSelector == nil || u.Spec.NodeSelector.MatchLabels["kubernetes.io/hostname"] != testNodeName {
+		t.Errorf("expected node selector for %s", testNodeName)
+	}
+	if u.Spec.TunnelEndpoint == nil || len(u.Spec.TunnelEndpoint.CIDRs) != 1 || u.Spec.TunnelEndpoint.CIDRs[0] != "100.65.0.0/24" {
+		t.Errorf("expected tunnel endpoint with CIDR 100.65.0.0/24, got %+v", u.Spec.TunnelEndpoint)
+	}
+}
+
+func validateUnderlayASN(expectedASN int64) func(*testing.T, *v1alpha1.Underlay) {
+	return func(t *testing.T, u *v1alpha1.Underlay) {
+		t.Helper()
+		if u.Spec.ASN != expectedASN {
+			t.Errorf("expected ASN %d, got %d", expectedASN, u.Spec.ASN)
+		}
+	}
+}
+
+func validateUnderlayASNAndLabel(expectedASN int64) func(*testing.T, *v1alpha1.Underlay) {
+	return func(t *testing.T, u *v1alpha1.Underlay) {
+		t.Helper()
+		if u.Spec.ASN != expectedASN {
+			t.Errorf("expected ASN %d, got %d", expectedASN, u.Spec.ASN)
+		}
+		if u.Labels[StaticSourceLabel] != StaticSourceValue {
+			t.Error("label lost after update")
+		}
+	}
+}
+
+func validateL3VNI(expected map[string]int32) func(*testing.T, *v1alpha1.L3VNI) {
+	return func(t *testing.T, l *v1alpha1.L3VNI) {
+		t.Helper()
+		expectedVNI, ok := expected[l.Spec.VRF]
+		if !ok {
+			t.Errorf("unexpected L3VNI VRF %s", l.Spec.VRF)
+			return
+		}
+		if l.Spec.VNI != expectedVNI {
+			t.Errorf("L3VNI VRF %s: expected VNI %d, got %d", l.Spec.VRF, expectedVNI, l.Spec.VNI)
+		}
+	}
+}
+
+func validateL2VNI(expectedVNI int32) func(*testing.T, *v1alpha1.L2VNI) {
+	return func(t *testing.T, l *v1alpha1.L2VNI) {
+		t.Helper()
+		if l.Spec.VNI != expectedVNI {
+			t.Errorf("expected L2VNI VNI %d, got %d", expectedVNI, l.Spec.VNI)
+		}
+	}
+}
+
+func validateNodeBL3VNIUnchanged(t *testing.T, l *v1alpha1.L3VNI) {
+	t.Helper()
+	if l.Name == "static-node-b-l3vni-0" && l.Spec.VNI != 500 {
+		t.Errorf("node-b resource was modified")
+	}
+}
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add v1alpha1 to scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
+	return s
+}
+
+func testNode() *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testNodeName,
+			UID:  types.UID(testNodeUID),
+		},
+	}
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func newMirrorController(t *testing.T, configDir string, objects ...client.Object) *MirrorController {
+	t.Helper()
+	s := testScheme(t)
+	cli := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(objects...).
+		WithStatusSubresource(&v1alpha1.Underlay{}, &v1alpha1.L3VNI{}, &v1alpha1.L2VNI{},
+			&v1alpha1.L3Passthrough{}, &v1alpha1.RawFRRConfig{}).
+		Build()
+	return &MirrorController{
+		Client:      cli,
+		Scheme:      s,
+		Logger:      testLogger(),
+		MyNode:      testNodeName,
+		MyNamespace: testNamespace,
+		ConfigDir:   configDir,
+		TriggerChan: make(chan event.GenericEvent, 1),
+	}
+}
+
+func reconcile(t *testing.T, mc *MirrorController) {
+	t.Helper()
+	_, err := mc.Reconcile(context.Background(), ctrl.Request{})
+	if err != nil {
+		t.Fatalf("Reconcile() returned error: %v", err)
+	}
+}
+
+func writeStaticFile(t *testing.T, dir, filename, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, filename), []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write static file %s: %v", filename, err)
+	}
+}
+
+func removeStaticFile(t *testing.T, dir, filename string) {
+	t.Helper()
+	if err := os.Remove(filepath.Join(dir, filename)); err != nil {
+		t.Fatalf("failed to remove static file %s: %v", filename, err)
+	}
+}

--- a/internal/controller/routerconfiguration/static_configuration_controller.go
+++ b/internal/controller/routerconfiguration/static_configuration_controller.go
@@ -30,6 +30,8 @@ type StaticConfigReconciler struct {
 	FRRReloadSocket string
 	RouterProvider  RouterProvider
 	ConfigDir       string
+	MyNode          string
+	MyNamespace     string
 
 	TriggerChan chan event.GenericEvent
 }
@@ -41,7 +43,7 @@ func (r *StaticConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	logger.Info("using config dir", "dir", r.ConfigDir)
 	// Read and merge router configs from directory
-	apiConfig, err := readStaticConfigs(r.ConfigDir)
+	apiConfig, err := readStaticConfigs(r.ConfigDir, r.MyNode, r.MyNamespace)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to read static router configurations from %s: %w", r.ConfigDir, err)
 	}

--- a/internal/controller/routerconfiguration/static_configuration_reader.go
+++ b/internal/controller/routerconfiguration/static_configuration_reader.go
@@ -27,7 +27,16 @@ var (
 	rawFRRConfigGVK  = schema.GroupVersionKind{Group: "openpe.openperouter.github.io", Version: "v1alpha1", Kind: "RawFRRConfig"}
 )
 
-func readStaticConfigs(configDir string) (conversion.APIConfigData, error) {
+const (
+	// StaticSourceLabel is the label key used to identify resources mirrored from static config.
+	StaticSourceLabel = "openperouter.github.io/source"
+	// StaticSourceValue is the label value for resources mirrored from static config.
+	StaticSourceValue = "static"
+	// StaticNodeLabel is the label key for the node name that owns static resources.
+	StaticNodeLabel = "openperouter.github.io/static-node"
+)
+
+func readStaticConfigs(configDir, nodeName, namespace string) (conversion.APIConfigData, error) {
 	routerConfigs, err := staticconfiguration.ReadRouterConfigs(configDir)
 	if err != nil {
 		return conversion.APIConfigData{}, fmt.Errorf("failed to read router configs: %w", err)
@@ -35,7 +44,7 @@ func readStaticConfigs(configDir string) (conversion.APIConfigData, error) {
 
 	apiConfigs := make([]conversion.APIConfigData, len(routerConfigs))
 	for i, rc := range routerConfigs {
-		cfg, err := staticConfigToAPIConfig(rc)
+		cfg, err := staticConfigToAPIConfig(rc, nodeName, namespace)
 		if err != nil {
 			return conversion.APIConfigData{}, fmt.Errorf("failed to convert static config to API config: %w", err)
 		}
@@ -50,18 +59,30 @@ func readStaticConfigs(configDir string) (conversion.APIConfigData, error) {
 	return merged, nil
 }
 
-func staticConfigToAPIConfig(staticConfig *static.PERouterConfig) (conversion.APIConfigData, error) {
+func staticConfigToAPIConfig(staticConfig *static.PERouterConfig, nodeName, namespace string) (conversion.APIConfigData, error) {
 	var allErrors field.ErrorList
+
+	nodeSelector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"kubernetes.io/hostname": nodeName,
+		},
+	}
 
 	underlays := make([]v1alpha1.Underlay, len(staticConfig.Underlays))
 	for i, spec := range staticConfig.Underlays {
+		spec.NodeSelector = nodeSelector
 		underlays[i] = v1alpha1.Underlay{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Underlay",
 				APIVersion: "openpe.openperouter.github.io/v1alpha1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("static-underlay-%d", i),
+				Name:      fmt.Sprintf("static-%s-underlay-%d", nodeName, i),
+				Namespace: namespace,
+				Labels: map[string]string{
+					StaticSourceLabel: StaticSourceValue,
+					StaticNodeLabel:   nodeName,
+				},
 			},
 			Spec: spec,
 		}
@@ -75,13 +96,19 @@ func staticConfigToAPIConfig(staticConfig *static.PERouterConfig) (conversion.AP
 
 	l3vnis := make([]v1alpha1.L3VNI, len(staticConfig.L3VNIs))
 	for i, spec := range staticConfig.L3VNIs {
+		spec.NodeSelector = nodeSelector
 		l3vnis[i] = v1alpha1.L3VNI{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "L3VNI",
 				APIVersion: "openpe.openperouter.github.io/v1alpha1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("static-l3vni-%d", i),
+				Name:      fmt.Sprintf("static-%s-l3vni-%d", nodeName, i),
+				Namespace: namespace,
+				Labels: map[string]string{
+					StaticSourceLabel: StaticSourceValue,
+					StaticNodeLabel:   nodeName,
+				},
 			},
 			Spec: spec,
 		}
@@ -95,13 +122,19 @@ func staticConfigToAPIConfig(staticConfig *static.PERouterConfig) (conversion.AP
 
 	l2vnis := make([]v1alpha1.L2VNI, len(staticConfig.L2VNIs))
 	for i, spec := range staticConfig.L2VNIs {
+		spec.NodeSelector = nodeSelector
 		l2vnis[i] = v1alpha1.L2VNI{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "L2VNI",
 				APIVersion: "openpe.openperouter.github.io/v1alpha1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("static-l2vni-%d", i),
+				Name:      fmt.Sprintf("static-%s-l2vni-%d", nodeName, i),
+				Namespace: namespace,
+				Labels: map[string]string{
+					StaticSourceLabel: StaticSourceValue,
+					StaticNodeLabel:   nodeName,
+				},
 			},
 			Spec: spec,
 		}
@@ -115,15 +148,22 @@ func staticConfigToAPIConfig(staticConfig *static.PERouterConfig) (conversion.AP
 
 	var l3passthrough []v1alpha1.L3Passthrough
 	if staticConfig.BGPPassthrough.HostSession.ASN > 0 {
+		passthroughSpec := staticConfig.BGPPassthrough
+		passthroughSpec.NodeSelector = nodeSelector
 		pt := v1alpha1.L3Passthrough{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "L3Passthrough",
 				APIVersion: "openpe.openperouter.github.io/v1alpha1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "static-l3passthrough",
+				Name:      fmt.Sprintf("static-%s-l3passthrough", nodeName),
+				Namespace: namespace,
+				Labels: map[string]string{
+					StaticSourceLabel: StaticSourceValue,
+					StaticNodeLabel:   nodeName,
+				},
 			},
-			Spec: staticConfig.BGPPassthrough,
+			Spec: passthroughSpec,
 		}
 		result, errs := applyDefaultsAndValidate(&pt, l3passthroughGVK)
 		if len(errs) > 0 {
@@ -136,13 +176,19 @@ func staticConfigToAPIConfig(staticConfig *static.PERouterConfig) (conversion.AP
 
 	rawFRRConfigs := make([]v1alpha1.RawFRRConfig, len(staticConfig.RawFRRConfigs))
 	for i, spec := range staticConfig.RawFRRConfigs {
+		spec.NodeSelector = nodeSelector
 		rawFRRConfigs[i] = v1alpha1.RawFRRConfig{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "RawFRRConfig",
 				APIVersion: "openpe.openperouter.github.io/v1alpha1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("static-rawfrrconfig-%d", i),
+				Name:      fmt.Sprintf("static-%s-rawfrrconfig-%d", nodeName, i),
+				Namespace: namespace,
+				Labels: map[string]string{
+					StaticSourceLabel: StaticSourceValue,
+					StaticNodeLabel:   nodeName,
+				},
 			},
 			Spec: spec,
 		}

--- a/internal/controller/routerconfiguration/static_configuration_reader_test.go
+++ b/internal/controller/routerconfiguration/static_configuration_reader_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/openperouter/openperouter/api/static"
 	"github.com/openperouter/openperouter/api/v1alpha1"
 	"github.com/openperouter/openperouter/internal/conversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,7 +40,7 @@ l2vnis:
         name: "br-storage"
 `)
 
-	apiConfig, err := readStaticConfigs(dir)
+	apiConfig, err := readStaticConfigs(dir, "test-node", "test-namespace")
 	if err != nil {
 		t.Fatalf("readStaticConfigs() unexpected error: %v", err)
 	}
@@ -71,7 +72,7 @@ l3vnis:
     vni: 100
 `)
 
-	apiConfig, err := readStaticConfigs(dir)
+	apiConfig, err := readStaticConfigs(dir, "test-node", "test-namespace")
 	if err != nil {
 		t.Fatalf("readStaticConfigs() unexpected error: %v", err)
 	}
@@ -99,7 +100,7 @@ underlays:
       - "100.65.0.0/24"
 `)
 
-	apiConfig, err := readStaticConfigs(dir)
+	apiConfig, err := readStaticConfigs(dir, "test-node", "test-namespace")
 	if err != nil {
 		t.Fatalf("readStaticConfigs() unexpected error: %v", err)
 	}
@@ -136,7 +137,7 @@ l2vnis:
         name: "br-storage"
 `)
 
-	apiConfig, err := readStaticConfigs(dir)
+	apiConfig, err := readStaticConfigs(dir, "test-node", "test-namespace")
 	if err != nil {
 		t.Fatalf("readStaticConfigs() unexpected error: %v", err)
 	}
@@ -175,7 +176,7 @@ l2vnis:
         name: "br-storage"
 `)
 
-	apiConfig, err := readStaticConfigs(dir)
+	apiConfig, err := readStaticConfigs(dir, "test-node", "test-namespace")
 	if err != nil {
 		t.Fatalf("readStaticConfigs() unexpected error: %v", err)
 	}
@@ -201,7 +202,7 @@ underlays:
       - "100.65.0.0/24"
 `)
 
-	apiConfig, err := readStaticConfigs(dir)
+	apiConfig, err := readStaticConfigs(dir, "test-node", "test-namespace")
 	if err != nil {
 		t.Fatalf("readStaticConfigs() unexpected error: %v", err)
 	}
@@ -236,7 +237,7 @@ l2vnis:
         name: "br-storage"
 `)
 
-	apiConfig, err := readStaticConfigs(dir)
+	apiConfig, err := readStaticConfigs(dir, "test-node", "test-namespace")
 	if err != nil {
 		t.Fatalf("readStaticConfigs() unexpected error: %v", err)
 	}
@@ -259,7 +260,7 @@ l2vnis:
 func TestReadStaticConfigs_ExistingTestdata(t *testing.T) {
 	testdataDir := "../../staticconfiguration/testdata"
 
-	apiConfig, err := readStaticConfigs(testdataDir)
+	apiConfig, err := readStaticConfigs(testdataDir, "test-node", "test-namespace")
 	if err != nil {
 		t.Fatalf("readStaticConfigs() with existing testdata unexpected error: %v", err)
 	}
@@ -267,8 +268,15 @@ func TestReadStaticConfigs_ExistingTestdata(t *testing.T) {
 	expected := conversion.APIConfigData{
 		Underlays: []v1alpha1.Underlay{
 			{
-				TypeMeta:   metav1.TypeMeta{Kind: "Underlay", APIVersion: "openpe.openperouter.github.io/v1alpha1"},
-				ObjectMeta: metav1.ObjectMeta{Name: "static-underlay-0"},
+				TypeMeta: metav1.TypeMeta{Kind: "Underlay", APIVersion: "openpe.openperouter.github.io/v1alpha1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "static-test-node-underlay-0",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						StaticSourceLabel: StaticSourceValue,
+						StaticNodeLabel:   "test-node",
+					},
+				},
 				Spec: v1alpha1.UnderlaySpec{
 					ASN:          64514,
 					RouterIDCIDR: new(defaultRouterIDCIDR),
@@ -286,66 +294,107 @@ func TestReadStaticConfigs_ExistingTestdata(t *testing.T) {
 						},
 					},
 					TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{CIDRs: []string{"100.65.0.0/24"}},
+					NodeSelector:   &metav1.LabelSelector{MatchLabels: map[string]string{"kubernetes.io/hostname": "test-node"}},
 				},
 			},
 		},
 		L3VNIs: []v1alpha1.L3VNI{
 			{
-				TypeMeta:   metav1.TypeMeta{Kind: "L3VNI", APIVersion: "openpe.openperouter.github.io/v1alpha1"},
-				ObjectMeta: metav1.ObjectMeta{Name: "static-l3vni-0"},
+				TypeMeta: metav1.TypeMeta{Kind: "L3VNI", APIVersion: "openpe.openperouter.github.io/v1alpha1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "static-test-node-l3vni-0",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						StaticSourceLabel: StaticSourceValue,
+						StaticNodeLabel:   "test-node",
+					},
+				},
 				Spec: v1alpha1.L3VNISpec{
 					VRF: "red", VNI: 100, VXLanPort: new(int32(4789)),
 					HostSession: &v1alpha1.HostSession{
 						ASN: 64514, HostASN: new(int64(64515)),
 						LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.169.10.0/24"), IPv6: new("2001:db8:1::/64")},
 					},
+					NodeSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"kubernetes.io/hostname": "test-node"}},
 				},
 			},
 			{
-				TypeMeta:   metav1.TypeMeta{Kind: "L3VNI", APIVersion: "openpe.openperouter.github.io/v1alpha1"},
-				ObjectMeta: metav1.ObjectMeta{Name: "static-l3vni-1"},
+				TypeMeta: metav1.TypeMeta{Kind: "L3VNI", APIVersion: "openpe.openperouter.github.io/v1alpha1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "static-test-node-l3vni-1",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						StaticSourceLabel: StaticSourceValue,
+						StaticNodeLabel:   "test-node",
+					},
+				},
 				Spec: v1alpha1.L3VNISpec{
 					VRF: "blue", VNI: 200, VXLanPort: new(int32(4789)),
 					HostSession: &v1alpha1.HostSession{
 						ASN: 64514, HostASN: new(int64(64516)),
 						LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.169.11.0/24"), IPv6: new("2001:db8:2::/64")},
 					},
+					NodeSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"kubernetes.io/hostname": "test-node"}},
 				},
 			},
 		},
 		L2VNIs: []v1alpha1.L2VNI{
 			{
-				TypeMeta:   metav1.TypeMeta{Kind: "L2VNI", APIVersion: "openpe.openperouter.github.io/v1alpha1"},
-				ObjectMeta: metav1.ObjectMeta{Name: "static-l2vni-0"},
+				TypeMeta: metav1.TypeMeta{Kind: "L2VNI", APIVersion: "openpe.openperouter.github.io/v1alpha1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "static-test-node-l2vni-0",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						StaticSourceLabel: StaticSourceValue,
+						StaticNodeLabel:   "test-node",
+					},
+				},
 				Spec: v1alpha1.L2VNISpec{
 					VRF: new("storage"), VNI: 300, VXLanPort: new(int32(4789)),
 					HostMaster: &v1alpha1.HostMaster{
 						Type:        v1alpha1.LinuxBridge,
 						LinuxBridge: &v1alpha1.LinuxBridgeConfig{Name: new("br-storage"), AutoCreate: new(false)},
 					},
+					NodeSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"kubernetes.io/hostname": "test-node"}},
 				},
 			},
 			{
-				TypeMeta:   metav1.TypeMeta{Kind: "L2VNI", APIVersion: "openpe.openperouter.github.io/v1alpha1"},
-				ObjectMeta: metav1.ObjectMeta{Name: "static-l2vni-1"},
+				TypeMeta: metav1.TypeMeta{Kind: "L2VNI", APIVersion: "openpe.openperouter.github.io/v1alpha1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "static-test-node-l2vni-1",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						StaticSourceLabel: StaticSourceValue,
+						StaticNodeLabel:   "test-node",
+					},
+				},
 				Spec: v1alpha1.L2VNISpec{
 					VRF: new("management"), VNI: 400, VXLanPort: new(int32(4789)),
 					HostMaster: &v1alpha1.HostMaster{
 						Type:      v1alpha1.OVSBridge,
 						OVSBridge: &v1alpha1.OVSBridgeConfig{Name: new("ovsbr0"), AutoCreate: new(false)},
 					},
+					NodeSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"kubernetes.io/hostname": "test-node"}},
 				},
 			},
 		},
 		L3Passthrough: []v1alpha1.L3Passthrough{
 			{
-				TypeMeta:   metav1.TypeMeta{Kind: "L3Passthrough", APIVersion: "openpe.openperouter.github.io/v1alpha1"},
-				ObjectMeta: metav1.ObjectMeta{Name: "static-l3passthrough"},
+				TypeMeta: metav1.TypeMeta{Kind: "L3Passthrough", APIVersion: "openpe.openperouter.github.io/v1alpha1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "static-test-node-l3passthrough",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						StaticSourceLabel: StaticSourceValue,
+						StaticNodeLabel:   "test-node",
+					},
+				},
 				Spec: v1alpha1.L3PassthroughSpec{
 					HostSession: v1alpha1.HostSession{
 						ASN: 64514, HostASN: new(int64(64517)),
 						LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.169.100.0/24"), IPv6: new("2001:db8:100::/64")},
 					},
+					NodeSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"kubernetes.io/hostname": "test-node"}},
 				},
 			},
 		},
@@ -379,7 +428,7 @@ l2vnis:
         autoCreate: true
 `)
 
-	_, err := readStaticConfigs(dir)
+	_, err := readStaticConfigs(dir, "test-node", "test-namespace")
 	if err == nil {
 		t.Fatal("expected validation error for L2VNI with bridge name and autoCreate, got nil")
 	}
@@ -424,7 +473,7 @@ l2vnis:
 			dir := t.TempDir()
 			writeYAMLFile(t, dir, "openpe_invalid.yaml", tc.yaml)
 
-			_, err := readStaticConfigs(dir)
+			_, err := readStaticConfigs(dir, "test-node", "test-namespace")
 			if err == nil {
 				t.Fatal("expected validation error, got nil")
 			}
@@ -457,7 +506,7 @@ l2vnis:
         autoCreate: true
 `)
 
-	_, err := readStaticConfigs(dir)
+	_, err := readStaticConfigs(dir, "test-node", "test-namespace")
 	if err == nil {
 		t.Fatal("expected validation errors for invalid underlay AND invalid L2VNI, got nil")
 	}
@@ -495,7 +544,7 @@ l2vnis:
         autoCreate: true
 `)
 
-	_, err := readStaticConfigs(dir)
+	_, err := readStaticConfigs(dir, "test-node", "test-namespace")
 	if err == nil {
 		t.Fatal("expected error for config with 1 valid underlay and 1 invalid L2VNI, got nil -- partial result should not be returned")
 	}
@@ -511,5 +560,237 @@ func writeYAMLFile(t *testing.T, dir, filename, content string) {
 	path := filepath.Join(dir, filename)
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatalf("failed to write YAML file %s: %v", path, err)
+	}
+}
+
+func TestStaticConfigToAPIConfig_WithNodeName(t *testing.T) {
+	cfg := &static.PERouterConfig{
+		Underlays: []v1alpha1.UnderlaySpec{
+			{
+				ASN:  64514,
+				Nics: []string{"eth0"},
+				Neighbors: []v1alpha1.Neighbor{
+					{ASN: new(int64(64512)), Address: new("192.168.11.2")},
+				},
+			},
+			{
+				ASN:  64515,
+				Nics: []string{"eth1"},
+				Neighbors: []v1alpha1.Neighbor{
+					{ASN: new(int64(64513)), Address: new("192.168.11.3")},
+				},
+			},
+		},
+		L3VNIs: []v1alpha1.L3VNISpec{
+			{
+				VRF: "red",
+				VNI: 100,
+				HostSession: &v1alpha1.HostSession{
+					ASN:       64514,
+					HostASN:   new(int64(64515)),
+					LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.169.10.0/24")},
+				},
+			},
+			{
+				VRF: "blue",
+				VNI: 200,
+				HostSession: &v1alpha1.HostSession{
+					ASN:       64514,
+					HostASN:   new(int64(64516)),
+					LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.169.11.0/24")},
+				},
+			},
+		},
+		L2VNIs: []v1alpha1.L2VNISpec{
+			{VNI: 300},
+		},
+		BGPPassthrough: v1alpha1.L3PassthroughSpec{
+			HostSession: v1alpha1.HostSession{
+				ASN:       64514,
+				HostASN:   new(int64(64517)),
+				LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.169.100.0/24")},
+			},
+		},
+		RawFRRConfigs: []v1alpha1.RawFRRConfigSpec{
+			{RawConfig: "test config"},
+		},
+	}
+
+	result, err := staticConfigToAPIConfig(cfg, "worker-1", "openperouter-system")
+	if err != nil {
+		t.Fatalf("staticConfigToAPIConfig() unexpected error: %v", err)
+	}
+
+	// Verify naming convention
+	tests := []struct {
+		desc     string
+		got      string
+		expected string
+	}{
+		{"underlay 0", result.Underlays[0].Name, "static-worker-1-underlay-0"},
+		{"underlay 1", result.Underlays[1].Name, "static-worker-1-underlay-1"},
+		{"l3vni 0", result.L3VNIs[0].Name, "static-worker-1-l3vni-0"},
+		{"l3vni 1", result.L3VNIs[1].Name, "static-worker-1-l3vni-1"},
+		{"l2vni 0", result.L2VNIs[0].Name, "static-worker-1-l2vni-0"},
+		{"l3passthrough", result.L3Passthrough[0].Name, "static-worker-1-l3passthrough"},
+		{"rawfrrconfig 0", result.RawFRRConfigs[0].Name, "static-worker-1-rawfrrconfig-0"},
+	}
+	for _, tt := range tests {
+		if tt.got != tt.expected {
+			t.Errorf("%s: expected name %s, got %s", tt.desc, tt.expected, tt.got)
+		}
+	}
+
+	// Verify labels on all resource types
+	allResources := []metav1.ObjectMeta{
+		result.Underlays[0].ObjectMeta,
+		result.Underlays[1].ObjectMeta,
+		result.L3VNIs[0].ObjectMeta,
+		result.L3VNIs[1].ObjectMeta,
+		result.L2VNIs[0].ObjectMeta,
+		result.L3Passthrough[0].ObjectMeta,
+		result.RawFRRConfigs[0].ObjectMeta,
+	}
+	for _, meta := range allResources {
+		if meta.Labels[StaticSourceLabel] != StaticSourceValue {
+			t.Errorf("resource %s: expected label %s=%s, got %v", meta.Name, StaticSourceLabel, StaticSourceValue, meta.Labels)
+		}
+	}
+
+	// Verify namespace on all resource types
+	for _, meta := range allResources {
+		if meta.Namespace != "openperouter-system" {
+			t.Errorf("resource %s: expected namespace openperouter-system, got %s", meta.Name, meta.Namespace)
+		}
+	}
+
+	// Verify NodeSelector on all resource types
+	checkNodeSelector := func(name string, got *metav1.LabelSelector) {
+		t.Helper()
+		if got == nil {
+			t.Errorf("resource %s: expected non-nil NodeSelector", name)
+			return
+		}
+		if got.MatchLabels["kubernetes.io/hostname"] != "worker-1" {
+			t.Errorf("resource %s: expected NodeSelector hostname=worker-1, got %v", name, got.MatchLabels)
+		}
+	}
+
+	checkNodeSelector("underlay-0", result.Underlays[0].Spec.NodeSelector)
+	checkNodeSelector("underlay-1", result.Underlays[1].Spec.NodeSelector)
+	checkNodeSelector("l3vni-0", result.L3VNIs[0].Spec.NodeSelector)
+	checkNodeSelector("l3vni-1", result.L3VNIs[1].Spec.NodeSelector)
+	checkNodeSelector("l2vni-0", result.L2VNIs[0].Spec.NodeSelector)
+	checkNodeSelector("l3passthrough", result.L3Passthrough[0].Spec.NodeSelector)
+	checkNodeSelector("rawfrrconfig-0", result.RawFRRConfigs[0].Spec.NodeSelector)
+
+	if result.L2VNIs[0].Spec.VRF != nil {
+		t.Errorf("expected L2VNI VRF to be nil when not set, got %s", *result.L2VNIs[0].Spec.VRF)
+	}
+}
+
+func TestStaticConfigToAPIConfig_L3PassthroughSkippedWhenZeroASN(t *testing.T) {
+	cfg := &static.PERouterConfig{
+		BGPPassthrough: v1alpha1.L3PassthroughSpec{
+			HostSession: v1alpha1.HostSession{
+				ASN: 0,
+			},
+		},
+	}
+
+	result, err := staticConfigToAPIConfig(cfg, "worker-1", "ns")
+	if err != nil {
+		t.Fatalf("staticConfigToAPIConfig() unexpected error: %v", err)
+	}
+	if len(result.L3Passthrough) != 0 {
+		t.Errorf("expected no l3passthrough when ASN is 0, got %d", len(result.L3Passthrough))
+	}
+}
+
+func TestStaticConfigToAPIConfig_PreservesSpecFields(t *testing.T) {
+	cfg := &static.PERouterConfig{
+		Underlays: []v1alpha1.UnderlaySpec{
+			{
+				ASN:          64514,
+				RouterIDCIDR: new("10.0.0.0/24"),
+				Nics:         []string{"eth0"},
+				Neighbors: []v1alpha1.Neighbor{
+					{ASN: new(int64(64512)), Address: new("192.168.11.2")},
+				},
+			},
+		},
+		L3VNIs: []v1alpha1.L3VNISpec{
+			{VRF: "red", VNI: 100, VXLanPort: new(int32(4789))},
+		},
+	}
+
+	result, err := staticConfigToAPIConfig(cfg, "node-a", "test-ns")
+	if err != nil {
+		t.Fatalf("staticConfigToAPIConfig() unexpected error: %v", err)
+	}
+
+	if result.Underlays[0].Spec.ASN != 64514 {
+		t.Errorf("expected ASN 64514, got %d", result.Underlays[0].Spec.ASN)
+	}
+	if ptr.Deref(result.Underlays[0].Spec.RouterIDCIDR, "") != "10.0.0.0/24" {
+		t.Errorf("expected RouterIDCIDR 10.0.0.0/24, got %s", ptr.Deref(result.Underlays[0].Spec.RouterIDCIDR, ""))
+	}
+	if len(result.Underlays[0].Spec.Neighbors) != 1 {
+		t.Fatalf("expected 1 neighbor, got %d", len(result.Underlays[0].Spec.Neighbors))
+	}
+	if ptr.Deref(result.Underlays[0].Spec.Neighbors[0].Address, "") != "192.168.11.2" {
+		t.Errorf("expected neighbor address 192.168.11.2, got %s", ptr.Deref(result.Underlays[0].Spec.Neighbors[0].Address, ""))
+	}
+	if result.L3VNIs[0].Spec.VRF != "red" {
+		t.Errorf("expected VRF red, got %s", result.L3VNIs[0].Spec.VRF)
+	}
+	if result.L3VNIs[0].Spec.VNI != 100 {
+		t.Errorf("expected VNI 100, got %d", result.L3VNIs[0].Spec.VNI)
+	}
+}
+
+func TestStaticConfigToAPIConfig_L2VNIPreservesExplicitVRF(t *testing.T) {
+	explicitVRF := "my-vrf"
+	cfg := &static.PERouterConfig{
+		L2VNIs: []v1alpha1.L2VNISpec{
+			{VNI: 500, VRF: &explicitVRF},
+		},
+	}
+
+	result, err := staticConfigToAPIConfig(cfg, "worker-1", "ns")
+	if err != nil {
+		t.Fatalf("staticConfigToAPIConfig() unexpected error: %v", err)
+	}
+
+	if result.L2VNIs[0].Spec.VRF == nil {
+		t.Fatal("expected VRF to be set, got nil")
+	}
+	if *result.L2VNIs[0].Spec.VRF != "my-vrf" {
+		t.Errorf("expected VRF my-vrf, got %s", *result.L2VNIs[0].Spec.VRF)
+	}
+}
+
+func TestStaticConfigToAPIConfig_EmptyConfig(t *testing.T) {
+	cfg := &static.PERouterConfig{}
+
+	result, err := staticConfigToAPIConfig(cfg, "worker-1", "ns")
+	if err != nil {
+		t.Fatalf("staticConfigToAPIConfig() unexpected error: %v", err)
+	}
+
+	if len(result.Underlays) != 0 {
+		t.Errorf("expected 0 underlays, got %d", len(result.Underlays))
+	}
+	if len(result.L3VNIs) != 0 {
+		t.Errorf("expected 0 l3vnis, got %d", len(result.L3VNIs))
+	}
+	if len(result.L2VNIs) != 0 {
+		t.Errorf("expected 0 l2vnis, got %d", len(result.L2VNIs))
+	}
+	if len(result.L3Passthrough) != 0 {
+		t.Errorf("expected 0 l3passthrough, got %d", len(result.L3Passthrough))
+	}
+	if len(result.RawFRRConfigs) != 0 {
+		t.Errorf("expected 0 rawfrrconfigs, got %d", len(result.RawFRRConfigs))
 	}
 }

--- a/internal/controller/routerconfiguration/underlay_vni_controller.go
+++ b/internal/controller/routerconfiguration/underlay_vni_controller.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -56,6 +57,10 @@ type PERouterReconciler struct {
 
 	// TriggerChan receives events from FileWatcher (in host mode)
 	TriggerChan chan event.GenericEvent
+
+	// notStaticConfigsListOpts filters out mirrored resources (source=static) when listing CRDs.
+	// Built once in SetupWithManager since the label is const.
+	notStaticConfigsListOpts *client.ListOptions
 }
 
 type requestKey string
@@ -74,8 +79,9 @@ type requestKey string
 // +kubebuilder:rbac:groups=openpe.openperouter.github.io,resources=l3passthroughs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=openpe.openperouter.github.io,resources=l3passthroughs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=openpe.openperouter.github.io,resources=l3passthroughs/finalizers,verbs=update
-// +kubebuilder:rbac:groups=openpe.openperouter.github.io,resources=rawfrrconfigs,verbs=get;list;watch
-// +kubebuilder:rbac:groups=openpe.openperouter.github.io,resources=rawfrrconfigs/status,verbs=get
+// +kubebuilder:rbac:groups=openpe.openperouter.github.io,resources=rawfrrconfigs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=openpe.openperouter.github.io,resources=rawfrrconfigs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=openpe.openperouter.github.io,resources=rawfrrconfigs/finalizers,verbs=update
 // +kubebuilder:rbac:groups=openpe.openperouter.github.io,resources=routernodeconfigurationstatuses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=openpe.openperouter.github.io,resources=routernodeconfigurationstatuses/status,verbs=get;update;patch
 
@@ -117,7 +123,7 @@ func (r *PERouterReconciler) reconcile(ctx context.Context, logger *slog.Logger)
 	}
 
 	if r.StaticConfigDir != "" {
-		config, err = mergeStaticConfig(r.StaticConfigDir, config, logger)
+		config, err = mergeStaticConfig(r.StaticConfigDir, r.MyNode, r.MyNamespace, config, logger)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to merge static config: %w", err)
 		}
@@ -167,9 +173,9 @@ func (r *PERouterReconciler) reconcile(ctx context.Context, logger *slog.Logger)
 	return ctrl.Result{}, nil
 }
 
-func mergeStaticConfig(staticConfigDir string, config conversion.APIConfigData, logger *slog.Logger) (conversion.APIConfigData, error) {
+func mergeStaticConfig(staticConfigDir, nodeName, namespace string, config conversion.APIConfigData, logger *slog.Logger) (conversion.APIConfigData, error) {
 	var noConfigErr *staticconfiguration.NoConfigAvailable
-	staticConfig, err := readStaticConfigs(staticConfigDir)
+	staticConfig, err := readStaticConfigs(staticConfigDir, nodeName, namespace)
 	// if we don't have a static configuration is fair to continue and use only the dynamic one
 	if errors.As(err, &noConfigErr) {
 		logger.Info("no static configuration available", "dir", staticConfigDir, "reason", noConfigErr.Error())
@@ -191,32 +197,36 @@ func mergeStaticConfig(staticConfigDir string, config conversion.APIConfigData, 
 }
 
 func (r *PERouterReconciler) getConfigFromAPI(ctx context.Context, logger *slog.Logger) (conversion.APIConfigData, error) {
+	// Exclude mirrored resources (source=static) at query time.
+	// These are handled from static files via mergeStaticConfig(); including them
+	// here would cause double-processing.
+
 	var underlays v1alpha1.UnderlayList
-	if err := r.List(ctx, &underlays); err != nil {
+	if err := r.List(ctx, &underlays, r.notStaticConfigsListOpts); err != nil {
 		slog.Error("failed to list underlays", "error", err)
 		return conversion.APIConfigData{}, err
 	}
 
 	var l3vnis v1alpha1.L3VNIList
-	if err := r.List(ctx, &l3vnis); err != nil {
+	if err := r.List(ctx, &l3vnis, r.notStaticConfigsListOpts); err != nil {
 		slog.Error("failed to list l3vnis", "error", err)
 		return conversion.APIConfigData{}, err
 	}
 
 	var l2vnis v1alpha1.L2VNIList
-	if err := r.List(ctx, &l2vnis); err != nil {
+	if err := r.List(ctx, &l2vnis, r.notStaticConfigsListOpts); err != nil {
 		slog.Error("failed to list l2vnis", "error", err)
 		return conversion.APIConfigData{}, err
 	}
 
 	var l3passthrough v1alpha1.L3PassthroughList
-	if err := r.List(ctx, &l3passthrough); err != nil {
+	if err := r.List(ctx, &l3passthrough, r.notStaticConfigsListOpts); err != nil {
 		slog.Error("failed to list l3passthrough", "error", err)
 		return conversion.APIConfigData{}, err
 	}
 
 	var rawFRRConfigs v1alpha1.RawFRRConfigList
-	if err := r.List(ctx, &rawFRRConfigs); err != nil {
+	if err := r.List(ctx, &rawFRRConfigs, r.notStaticConfigsListOpts); err != nil {
 		slog.Error("failed to list rawfrrconfigs", "error", err)
 		return conversion.APIConfigData{}, err
 	}
@@ -283,6 +293,12 @@ func (r *PERouterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}
 		return true
 	})
+	// Build the not-mirrored list options once (the label is const).
+	notMirrored, err := labels.NewRequirement(StaticSourceLabel, selection.DoesNotExist, nil)
+	if err != nil {
+		return fmt.Errorf("failed to build label requirement: %w", err)
+	}
+	r.notStaticConfigsListOpts = &client.ListOptions{LabelSelector: labels.NewSelector().Add(*notMirrored)}
 
 	filterNonRouterPods := predicate.NewPredicateFuncs(func(object client.Object) bool {
 		switch o := object.(type) {

--- a/internal/crdschema/crdschema_test.go
+++ b/internal/crdschema/crdschema_test.go
@@ -268,12 +268,12 @@ func TestValidateSuccessful(t *testing.T) {
 		obj  *unstructured.Unstructured
 	}{
 		{
-			name: "Underlay EVPN with only vtepCIDR",
+			name: "Underlay with tunnel endpoint",
 			gvk:  underlayGVK,
 			obj: newUnstructured("Underlay", map[string]any{
-				"asn":  int64(65000),
-				"nics": []any{"eth0"},
-				"evpn": map[string]any{"vtepCIDR": "10.10.0.0/24"},
+				"asn":            int64(65000),
+				"nics":           []any{"eth0"},
+				"tunnelEndpoint": map[string]any{"cidrs": []any{"10.10.0.0/24"}},
 				"neighbors": []any{
 					map[string]any{
 						"address": "192.168.1.1",

--- a/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2026-06-17T12:54:16Z"
+    createdAt: "2026-06-18T13:22:54Z"
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: openperouter-operator.v0.0.0
@@ -92,6 +92,7 @@ spec:
           - l2vnis
           - l3passthroughs
           - l3vnis
+          - rawfrrconfigs
           - routernodeconfigurationstatuses
           - underlays
           verbs:
@@ -108,6 +109,7 @@ spec:
           - l2vnis/finalizers
           - l3passthroughs/finalizers
           - l3vnis/finalizers
+          - rawfrrconfigs/finalizers
           - underlays/finalizers
           verbs:
           - update
@@ -117,26 +119,13 @@ spec:
           - l2vnis/status
           - l3passthroughs/status
           - l3vnis/status
+          - rawfrrconfigs/status
           - routernodeconfigurationstatuses/status
           - underlays/status
           verbs:
           - get
           - patch
           - update
-        - apiGroups:
-          - openpe.openperouter.github.io
-          resources:
-          - rawfrrconfigs
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - openpe.openperouter.github.io
-          resources:
-          - rawfrrconfigs/status
-          verbs:
-          - get
         serviceAccountName: controller
       - rules:
         - apiGroups:

--- a/website/content/docs/configuration/systemd-mode.md
+++ b/website/content/docs/configuration/systemd-mode.md
@@ -85,6 +85,19 @@ Depending on the CNI, the network configuration might need to be complete before
 
 Configuration files are watched for changes and dynamically reloaded at runtime. Updating a file triggers a reconciliation cycle without restarting the service.
 
+### Kubernetes Visibility
+
+When a kubeconfig is available, the controller mirrors the static configuration to Kubernetes Custom Resources. Each statically-configured resource (underlay, L3VNI, L2VNI, L3Passthrough, RawFRRConfig) is created as a corresponding CR with a `openperouter.io/static-source` label. This makes the full cluster configuration visible via `kubectl`:
+
+```bash
+kubectl get underlays -n openperouter-system -l openperouter.io/static-source=true
+kubectl get l3vnis -n openperouter-system -l openperouter.io/static-source=true
+```
+
+The mirrored resources also go through webhook validation, ensuring that the static configuration is validated against the same rules as API-managed resources.
+
+The static files remain the source of truth: any external modification to the mirrored CRs is reverted on the next reconciliation cycle, and deleting a mirrored CR causes it to be recreated.
+
 ### Merging with API Server Configuration
 
 When a kubeconfig is available (exported by the hostbridge pod), configuration from the Kubernetes API server is merged with the file-based configuration. This allows managing part of the configuration via Kubernetes CRs while keeping the base overlay setup in static files that are applied at boot time.


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
/kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

When the k8s api is accessible, we might want to mirror and reconcile the static configurations to actual resources.
This gives us visibility and also allows the webhooks to avoid conflicting resources.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Mirror configuration consumed by static files to k8s resources for better visibility.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
