### PR TITLE
Rm IPFamily from passthr/l3vni frr_test.go, fix local_passthrough.tmpl

### DIFF
--- a/internal/frr/frr_test.go
+++ b/internal/frr/frr_test.go
@@ -48,10 +48,9 @@ func TestBasic(t *testing.T) {
 				VNI:      100,
 				RouterID: "10.0.0.1",
 				LocalNeighbor: &NeighborConfig{
-					ASN:      mustNewPeerASNFromNumber(64513),
-					Addr:     "192.168.1.2",
-					ID:       "192.168.1.2",
-					IPFamily: ipfamily.IPv4,
+					ASN:  mustNewPeerASNFromNumber(64513),
+					Addr: "192.168.1.2",
+					ID:   "192.168.1.2",
 				},
 				ToAdvertiseIPv4: []string{
 					"192.169.10.2/24",
@@ -140,10 +139,9 @@ func TestBasicWithIPRT(t *testing.T) {
 				VNI:      100,
 				RouterID: "10.0.0.1",
 				LocalNeighbor: &NeighborConfig{
-					ASN:      mustNewPeerASNFromNumber(64513),
-					Addr:     "192.168.1.2",
-					ID:       "192.168.1.2",
-					IPFamily: ipfamily.IPv4,
+					ASN:  mustNewPeerASNFromNumber(64513),
+					Addr: "192.168.1.2",
+					ID:   "192.168.1.2",
 				},
 				ToAdvertiseIPv4: []string{
 					"192.169.10.2/24",
@@ -187,10 +185,9 @@ func TestExternal(t *testing.T) {
 				VNI:      100,
 				RouterID: "10.0.0.1",
 				LocalNeighbor: &NeighborConfig{
-					ASN:      mustNewPeerASNFromType("external"),
-					Addr:     "192.168.1.2",
-					ID:       "192.168.1.2",
-					IPFamily: ipfamily.IPv4,
+					ASN:  mustNewPeerASNFromType("external"),
+					Addr: "192.168.1.2",
+					ID:   "192.168.1.2",
 				},
 				ToAdvertiseIPv4: []string{
 					"192.169.10.2/24",
@@ -232,10 +229,9 @@ func TestInternal(t *testing.T) {
 				VNI:      100,
 				RouterID: "10.0.0.1",
 				LocalNeighbor: &NeighborConfig{
-					ASN:      mustNewPeerASNFromNumber(64512),
-					Addr:     "192.168.1.3",
-					ID:       "192.168.1.3",
-					IPFamily: ipfamily.IPv4,
+					ASN:  mustNewPeerASNFromNumber(64512),
+					Addr: "192.168.1.3",
+					ID:   "192.168.1.3",
 				},
 				ToAdvertiseIPv4: []string{
 					"192.169.10.2/24",
@@ -277,10 +273,9 @@ func TestDualStack(t *testing.T) {
 				VNI:      100,
 				RouterID: "10.0.0.1",
 				LocalNeighbor: &NeighborConfig{
-					ASN:      mustNewPeerASNFromNumber(64513),
-					Addr:     "192.168.1.2",
-					ID:       "192.168.1.2",
-					IPFamily: ipfamily.IPv4,
+					ASN:  mustNewPeerASNFromNumber(64513),
+					Addr: "192.168.1.2",
+					ID:   "192.168.1.2",
 				},
 				ToAdvertiseIPv4: []string{
 					"192.169.10.2/24",
@@ -325,10 +320,9 @@ func TestDualStackWithRT(t *testing.T) {
 				VNI:      100,
 				RouterID: "10.0.0.1",
 				LocalNeighbor: &NeighborConfig{
-					ASN:      mustNewPeerASNFromNumber(64513),
-					Addr:     "192.168.1.2",
-					ID:       "192.168.1.2",
-					IPFamily: ipfamily.IPv4,
+					ASN:  mustNewPeerASNFromNumber(64513),
+					Addr: "192.168.1.2",
+					ID:   "192.168.1.2",
 				},
 				ToAdvertiseIPv4: []string{
 					"192.169.10.2/24",
@@ -376,10 +370,9 @@ func TestIPv6Only(t *testing.T) {
 				VNI:      100,
 				RouterID: "10.0.0.1",
 				LocalNeighbor: &NeighborConfig{
-					ASN:      mustNewPeerASNFromNumber(64513),
-					Addr:     "2001:db8::2",
-					ID:       "2001:db8::2",
-					IPFamily: ipfamily.IPv6,
+					ASN:  mustNewPeerASNFromNumber(64513),
+					Addr: "2001:db8::2",
+					ID:   "2001:db8::2",
 				},
 				ToAdvertiseIPv6: []string{
 					"2001:db8::2/64",
@@ -422,10 +415,9 @@ func TestBGPUnnumbered(t *testing.T) {
 				VNI:      100,
 				RouterID: "10.0.0.1",
 				LocalNeighbor: &NeighborConfig{
-					ASN:      mustNewPeerASNFromNumber(64512),
-					Addr:     "2001:db8::2",
-					ID:       "2001:db8::2",
-					IPFamily: ipfamily.IPv6,
+					ASN:  mustNewPeerASNFromNumber(64512),
+					Addr: "2001:db8::2",
+					ID:   "2001:db8::2",
 				},
 				ToAdvertiseIPv6: []string{
 					"2001:db8::2/64",
@@ -467,10 +459,9 @@ func TestIPv6OnlyWithRT(t *testing.T) {
 				VNI:      100,
 				RouterID: "10.0.0.1",
 				LocalNeighbor: &NeighborConfig{
-					ASN:      mustNewPeerASNFromNumber(64513),
-					Addr:     "2001:db8::2",
-					ID:       "2001:db8::2",
-					IPFamily: ipfamily.IPv6,
+					ASN:  mustNewPeerASNFromNumber(64513),
+					Addr: "2001:db8::2",
+					ID:   "2001:db8::2",
 				},
 				ToAdvertiseIPv6: []string{
 					"2001:db8::2/64",
@@ -655,10 +646,9 @@ func TestL3VNIWithLocalNeighborAndRedistributeConnected(t *testing.T) {
 				VNI:      100,
 				RouterID: "10.0.0.1",
 				LocalNeighbor: &NeighborConfig{
-					ASN:      mustNewPeerASNFromNumber(64513),
-					Addr:     "192.168.1.2",
-					ID:       "192.168.1.2",
-					IPFamily: ipfamily.IPv4,
+					ASN:  mustNewPeerASNFromNumber(64513),
+					Addr: "192.168.1.2",
+					ID:   "192.168.1.2",
 				},
 				ToAdvertiseIPv4: []string{
 					"192.169.10.2/24",
@@ -692,10 +682,9 @@ func TestPassthroughNoEVPN(t *testing.T) {
 		},
 		Passthrough: &PassthroughConfig{
 			LocalNeighborV4: &NeighborConfig{
-				ASN:      mustNewPeerASNFromNumber(64513),
-				Addr:     "192.168.1.3",
-				ID:       "192.168.1.3",
-				IPFamily: ipfamily.IPv4,
+				ASN:  mustNewPeerASNFromNumber(64513),
+				Addr: "192.168.1.3",
+				ID:   "192.168.1.3",
 			},
 			ToAdvertiseIPv4: []string{
 				"192.169.20.0/24",
@@ -729,10 +718,9 @@ func TestPassthroughExternal(t *testing.T) {
 		},
 		Passthrough: &PassthroughConfig{
 			LocalNeighborV4: &NeighborConfig{
-				ASN:      mustNewPeerASNFromType("external"),
-				Addr:     "192.168.1.3",
-				ID:       "192.168.1.3",
-				IPFamily: ipfamily.IPv4,
+				ASN:  mustNewPeerASNFromType("external"),
+				Addr: "192.168.1.3",
+				ID:   "192.168.1.3",
 			},
 			ToAdvertiseIPv4: []string{
 				"192.169.20.0/24",
@@ -769,10 +757,9 @@ func TestPassthroughV4(t *testing.T) {
 		},
 		Passthrough: &PassthroughConfig{
 			LocalNeighborV4: &NeighborConfig{
-				ASN:      mustNewPeerASNFromNumber(64513),
-				Addr:     "192.168.1.3",
-				ID:       "192.168.1.3",
-				IPFamily: ipfamily.IPv4,
+				ASN:  mustNewPeerASNFromNumber(64513),
+				Addr: "192.168.1.3",
+				ID:   "192.168.1.3",
 			},
 			ToAdvertiseIPv4: []string{
 				"192.169.20.0/24",
@@ -815,16 +802,14 @@ func TestPassthroughDual(t *testing.T) {
 		},
 		Passthrough: &PassthroughConfig{
 			LocalNeighborV4: &NeighborConfig{
-				ASN:      mustNewPeerASNFromNumber(64513),
-				Addr:     "192.168.1.3",
-				ID:       "192.168.1.3",
-				IPFamily: ipfamily.IPv4,
+				ASN:  mustNewPeerASNFromNumber(64513),
+				Addr: "192.168.1.3",
+				ID:   "192.168.1.3",
 			},
 			LocalNeighborV6: &NeighborConfig{
-				ASN:      mustNewPeerASNFromNumber(64513),
-				Addr:     "2001:db8:20::2",
-				ID:       "2001:db8:20::2",
-				IPFamily: ipfamily.IPv6,
+				ASN:  mustNewPeerASNFromNumber(64513),
+				Addr: "2001:db8:20::2",
+				ID:   "2001:db8:20::2",
 			},
 			ToAdvertiseIPv4: []string{
 				"192.169.20.0/24",

--- a/internal/frr/templates/local_passthrough.tmpl
+++ b/internal/frr/templates/local_passthrough.tmpl
@@ -16,8 +16,6 @@
     neighbor {{ .Passthrough.LocalNeighborV4.ID }} next-hop-self force
   {{- end }}
   exit-address-family
-
-{{- template "neighborenableipfamily" dict "neighbor" .Passthrough.LocalNeighborV4 "routerASN" .Underlay.MyASN -}}
 {{- end -}}
 
 {{- if .Passthrough.LocalNeighborV6 }}
@@ -36,7 +34,6 @@
     neighbor {{ .Passthrough.LocalNeighborV6.ID }} next-hop-self force
   {{- end }}
   exit-address-family
-{{- template "neighborenableipfamily" dict "neighbor" .Passthrough.LocalNeighborV6 "routerASN" .Underlay.MyASN -}}
 {{- end -}}
 {{- end }}
 

--- a/internal/frr/testdata/TestPassthroughDual.golden
+++ b/internal/frr/testdata/TestPassthroughDual.golden
@@ -44,11 +44,6 @@ router bgp 64512
     neighbor 192.168.1.3 route-map allowall out
   exit-address-family
 
-  address-family ipv4 unicast
-    neighbor 192.168.1.3 activate
-    neighbor 192.168.1.3 allowas-in
-  exit-address-family
-
   neighbor 2001:db8:20::2 remote-as 64513
 
   address-family ipv6 unicast
@@ -58,11 +53,6 @@ router bgp 64512
     neighbor 2001:db8:20::2 activate
     neighbor 2001:db8:20::2 route-map allowall in
     neighbor 2001:db8:20::2 route-map allowall out
-  exit-address-family
-
-  address-family ipv6 unicast
-    neighbor 2001:db8:20::2 activate
-    neighbor 2001:db8:20::2 allowas-in
   exit-address-family
   address-family ipv4 unicast
     network 100.64.0.1/32

--- a/internal/frr/testdata/TestPassthroughExternal.golden
+++ b/internal/frr/testdata/TestPassthroughExternal.golden
@@ -30,10 +30,5 @@ router bgp 64512
     neighbor 192.168.1.3 route-map allowall in
     neighbor 192.168.1.3 route-map allowall out
   exit-address-family
-
-  address-family ipv4 unicast
-    neighbor 192.168.1.3 activate
-    neighbor 192.168.1.3 allowas-in
-  exit-address-family
 exit
 !

--- a/internal/frr/testdata/TestPassthroughNoEVPN.golden
+++ b/internal/frr/testdata/TestPassthroughNoEVPN.golden
@@ -30,10 +30,5 @@ router bgp 64512
     neighbor 192.168.1.3 route-map allowall in
     neighbor 192.168.1.3 route-map allowall out
   exit-address-family
-
-  address-family ipv4 unicast
-    neighbor 192.168.1.3 activate
-    neighbor 192.168.1.3 allowas-in
-  exit-address-family
 exit
 !

--- a/internal/frr/testdata/TestPassthroughV4.golden
+++ b/internal/frr/testdata/TestPassthroughV4.golden
@@ -30,11 +30,6 @@ router bgp 64512
     neighbor 192.168.1.3 route-map allowall in
     neighbor 192.168.1.3 route-map allowall out
   exit-address-family
-
-  address-family ipv4 unicast
-    neighbor 192.168.1.3 activate
-    neighbor 192.168.1.3 allowas-in
-  exit-address-family
   address-family ipv4 unicast
     network 100.64.0.1/32
   exit-address-family


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:

The IPFamily field for passthrough LocalNeighborV4/V6 and L3VNI
LocalNeighbor is never set by production code. For passthrough,
the underlay address family already has a one-to-one mapping to
the BGP address family (LocalNeighborV4 -> AF IPv4, LocalNeighborV6
-> AF IPv6), so the neighborenableipfamily template invocation is
a) redundant and b) its logic is actually never executed.

Remove the neighborenableipfamily template calls from
local_passthrough.tmpl and drop the IPFamily field from tests to
match production behavior. Adjust testdata accordingly.

**Special notes for your reviewer**:

The `neighborenableipfamily` template is still used for global sessions in `frr.tmpl` - only the passthrough usage is removed and tests are fixed for passthrough and l3vni.

**Release note**:

```release-note
Fix duplicate address-family blocks in FRR passthrough configuration by removing unused neighborenableipfamily template calls. Remove IPFamily from frr_test.go for l3vni and passthrough input as it is never set by production code.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.