### PR TITLE
fix: replace hardcoded kind/docker and fix make test/clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: fmt vet envtest $(LOCALBIN) ## Run tests.
+test: fmt vet envtest $(LOCALBIN) kind-node-image-build ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v e2etest) -coverprofile cover.out
 	@RUNASROOT_TESTS=""; \
 	for pkg in $$(grep -rl "//go:build runasroot" --include="*_test.go" $$(go list -f '{{.Dir}}' ./...) | xargs -I{} dirname {} | sort -u); do \

--- a/Makefile
+++ b/Makefile
@@ -461,7 +461,7 @@ generate-all-in-one: manifests kustomize ## Create manifests
 
 .PHONY: helm-docs
 helm-docs:
-	docker run --rm -v $$(pwd):/app -w /app jnorwood/helm-docs:$(HELM_DOCS_VERSION) helm-docs
+	$(CONTAINER_ENGINE) run --rm -v $$(pwd):/app -w /app jnorwood/helm-docs:$(HELM_DOCS_VERSION) helm-docs
 
 .PHONY: api-docs
 api-docs: crd-ref-docs

--- a/clab/calico/apply_calico.sh
+++ b/clab/calico/apply_calico.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source "$(dirname $(readlink -f $0))/../common.sh"
+
 timeout=600
 start_time=$(date +%s)
 
@@ -17,7 +19,7 @@ while true; do
     sleep 5
     check_timeout
     echo "Apply calico."
-    if ! kind get kubeconfig --name pe-kind > kubeconfig; then
+    if ! ${KIND_COMMAND} get kubeconfig --name pe-kind > kubeconfig; then
 	    continue
     fi
     export KUBECONFIG=./kubeconfig

--- a/clab/clean.sh
+++ b/clab/clean.sh
@@ -21,6 +21,13 @@ echo "CLAB_TOPOLOGY: $CLAB_TOPOLOGY"
 echo "CONTAINER_ENGINE: $CONTAINER_ENGINE"
 echo "CLUSTER_NAMES: ${CLUSTER_ARRAY[*]}"
 
+echo "=== Stop check_veths monitoring ==="
+pid=$(cat "${PID_FILE}" 2>/dev/null || true)
+if ps -q "${pid}" >/dev/null 2>&1; then
+    echo "Found process ID ${pid} for check_veths, killing the process"
+    sudo kill "${pid}"
+fi
+
 echo "=== Destroying containerlab topology ==="
 if [[ $CONTAINER_ENGINE == "docker" ]]; then
     docker run --rm --privileged \
@@ -65,12 +72,5 @@ ${CONTAINER_ENGINE_CLI} rm kind-registry 2>/dev/null || true
 
 echo "=== cluster cleanup completed ==="
 echo "All resources have been cleaned up"
-
-echo "=== Stop check_veths monitoring ==="
-pid=$(cat "${PID_FILE}" 2>/dev/null || true)
-if ps -q "${pid}" >/dev/null 2>&1; then
-    echo "Found process ID ${pid} for check_veths, killing the process"
-    sudo kill "${pid}"
-fi
 
 popd

--- a/examples/evpn/metallb/prepare.sh
+++ b/examples/evpn/metallb/prepare.sh
@@ -26,7 +26,7 @@ helm install metallb metallb/metallb --namespace metallb-system --set frrk8s.ext
 
 wait_for_pods metallb-system app.kubernetes.io/name=metallb
 
-docker image pull nginx:1.25
+${CONTAINER_ENGINE:-docker} image pull nginx:1.25
 ${KIND_BIN} --name pe-kind load docker-image nginx:1.25
 
 apply_manifests_with_retries metallb.yaml openpe.yaml workload.yaml

--- a/systemdmode/deploy.sh
+++ b/systemdmode/deploy.sh
@@ -70,10 +70,10 @@ fi
 
 CLUSTER_NAME="$1"
 
-NODES=$(kind get nodes --name "$CLUSTER_NAME" 2>/dev/null)
+NODES=$(${KIND_COMMAND} get nodes --name "$CLUSTER_NAME" 2>/dev/null)
 if [[ -z "$NODES" ]]; then
     log_error "No nodes found for kind cluster: $CLUSTER_NAME"
-    log_error "Please check that the cluster exists with: kind get clusters"
+    log_error "Please check that the cluster exists with: ${KIND_COMMAND} get clusters"
     exit 1
 fi
 

--- a/systemdmode/setup_node_config.sh
+++ b/systemdmode/setup_node_config.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../clab/common.sh"
+
 log_info() {
     echo "[INFO] $*"
 }
@@ -27,10 +30,10 @@ if [[ -n "${NODE_CONFIG_DIR:-}" ]]; then
     log_info "Will copy files from $NODE_CONFIG_DIR to each node"
 fi
 
-NODES=$(kind get nodes --name "$CLUSTER_NAME" 2>/dev/null)
+NODES=$(${KIND_COMMAND} get nodes --name "$CLUSTER_NAME" 2>/dev/null)
 if [[ -z "$NODES" ]]; then
     log_error "No nodes found for kind cluster: $CLUSTER_NAME"
-    log_error "Please check that the cluster exists with: kind get clusters"
+    log_error "Please check that the cluster exists with: ${KIND_COMMAND} get clusters"
     exit 1
 fi
 
@@ -38,9 +41,9 @@ NODE_INDEX=0
 for NODE in $NODES; do
     log_info "Creating configuration file for node $NODE with nodeIndex=$NODE_INDEX..."
 
-    docker exec "$NODE" mkdir -p /var/lib/openperouter/configs
+    $CONTAINER_ENGINE_CLI exec "$NODE" mkdir -p /var/lib/openperouter/configs
 
-    docker exec "$NODE" bash -c "cat > /var/lib/openperouter/node-config.yaml <<EOF
+    $CONTAINER_ENGINE_CLI exec "$NODE" bash -c "cat > /var/lib/openperouter/node-config.yaml <<EOF
 nodeIndex: $NODE_INDEX
 logLevel: debug
 EOF"
@@ -54,7 +57,7 @@ EOF"
                 filename=$(basename "$file")
                 # Copy openpe_*.yaml files to configs subdirectory
                 if [[ "$filename" == openpe_*.yaml ]]; then
-                    docker cp "$file" "$NODE:/var/lib/openperouter/configs/$filename"
+                    $CONTAINER_ENGINE_CLI cp "$file" "$NODE:/var/lib/openperouter/configs/$filename"
                     log_info "    Copied router config: $filename -> configs/"
                 fi
             fi


### PR DESCRIPTION
- Add kind-node-image-build as prerequisite for make test
- Use KIND_COMMAND and CONTAINER_ENGINE_CLI from common.sh instead of hardcoded kind and docker commands
- Kill check_veths before teardown in clean.sh to avoid recreating veths during cleanup

/kind cleanup

**What this PR does / why we need it**:
closes some corners when deploying on environment without kind and docker

**Special notes for your reviewer**:
all paths have been checked

```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
