### PR TITLE
Systemd mode: let's have the controller monitor the status of frr

### DIFF
--- a/cmd/hostcontroller/main.go
+++ b/cmd/hostcontroller/main.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -286,6 +287,24 @@ func runK8sConfigReconcilerHostMode(ctx context.Context,
 		return fmt.Errorf("unable to create controller: %w", err)
 	}
 
+	if err := routerProvider.StartFRRRestartWatcher(ctx, func() {
+		select {
+		case triggerChan <- event.GenericEvent{
+			Object: &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "restart-trigger",
+					Namespace: "default",
+				},
+			},
+		}:
+			slog.Info("triggered reconciliation after router restart")
+		default:
+			slog.Debug("reconciliation already queued, skipping restart trigger")
+		}
+	}); err != nil {
+		return fmt.Errorf("unable to start FRR restart watcher: %w", err)
+	}
+
 	// Setup file watcher to trigger API reconciler on static file changes
 	fw, err := filewatcher.New(hostModeParams.configurationDir, triggerChan, logger)
 	if err != nil {
@@ -384,6 +403,12 @@ func runStaticConfigReconciler(ctx context.Context,
 	}
 	if err = staticReconciler.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller: %w", err)
+	}
+
+	if err := staticRouterProvider.StartFRRRestartWatcher(ctx, func() {
+		staticReconciler.TriggerReconcile()
+	}); err != nil {
+		return fmt.Errorf("unable to start FRR restart watcher: %w", err)
 	}
 
 	// Setup file watcher for static configuration changes

--- a/e2etests/tests/systemd_resiliency.go
+++ b/e2etests/tests/systemd_resiliency.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openperouter/openperouter/api/v1alpha1"
+
+	"github.com/openperouter/openperouter/e2etests/pkg/config"
+	"github.com/openperouter/openperouter/e2etests/pkg/executor"
+	"github.com/openperouter/openperouter/e2etests/pkg/infra"
+	"github.com/openperouter/openperouter/e2etests/pkg/k8sclient"
+	"github.com/openperouter/openperouter/e2etests/pkg/openperouter"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+var _ = Describe("Systemd Router Restart Resiliency", Label("systemdmode"), Ordered, func() {
+	var cs clientset.Interface
+	nodes := []corev1.Node{}
+
+	BeforeAll(func() {
+		err := Updater.CleanAll()
+		Expect(err).NotTo(HaveOccurred())
+
+		cs = k8sclient.New()
+		_, err = openperouter.Get(cs, HostMode)
+		Expect(err).NotTo(HaveOccurred())
+		nodesItems, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		nodes = nodesItems.Items
+
+		err = Updater.Update(config.Resources{
+			Underlays: []v1alpha1.Underlay{
+				infra.Underlay,
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(infra.LeafKind1Config.UpdateConfig(nodes, infra.LeafKindConfiguration{})).To(Succeed())
+		Expect(infra.LeafKind2Config.UpdateConfig(nodes, infra.LeafKindConfiguration{})).To(Succeed())
+	})
+
+	AfterAll(func() {
+		err := Updater.CleanAll()
+		Expect(err).NotTo(HaveOccurred())
+		By("waiting for the underlay to be removed from all nodes")
+		for _, node := range nodes {
+			Eventually(func(g Gomega) {
+				isConfigured, err := openperouter.UnderlayConfigured(node.Name)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(isConfigured).To(BeFalse())
+			}, 2*time.Minute, time.Second).Should(Succeed())
+		}
+	})
+
+	AfterEach(func() {
+		dumpIfFails(cs)
+	})
+
+	validateTORSessions := func() {
+		leaves := []string{infra.KindLeaf, infra.KindLeaf2}
+		for _, leaf := range leaves {
+			exec := executor.ForContainer(leaf)
+			Eventually(func() error {
+				for _, node := range nodes {
+					neighborIP, err := infra.NeighborIP(leaf, node.Name)
+					Expect(err).NotTo(HaveOccurred())
+					validateSessionWithNeighbor(exec, validationParameters{
+						fromName:    leaf,
+						toName:      node.Name,
+						neighborIP:  neighborIP,
+						established: Established,
+					})
+				}
+				return nil
+			}, time.Minute, time.Second).ShouldNot(HaveOccurred())
+		}
+	}
+
+	restartRouterOnNode := func(node corev1.Node) {
+		By("restarting FRR container via systemd on node " + node.Name)
+		nodeExec := executor.ForContainer(node.Name)
+
+		pidBefore, err := nodeExec.Exec("systemctl", "show", "--property=MainPID", "--value", "routerpod-pod.service")
+		Expect(err).NotTo(HaveOccurred())
+		pidBefore = strings.TrimSpace(pidBefore)
+
+		_, err = nodeExec.Exec("systemctl", "restart", "routerpod-pod.service")
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() error {
+			output, err := nodeExec.Exec("systemctl", "is-active", "routerpod-pod.service")
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(output) != "active" {
+				return fmt.Errorf("service is not active: %s", output)
+			}
+			pidAfter, err := nodeExec.Exec("systemctl", "show", "--property=MainPID", "--value", "routerpod-pod.service")
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(pidAfter) == pidBefore {
+				return fmt.Errorf("PID has not changed, still %s", pidBefore)
+			}
+			return nil
+		}, 30*time.Second, time.Second).Should(Succeed())
+	}
+
+	It("recovers BGP sessions after FRR restart", func() {
+		By("validating initial sessions with TOR switches")
+		validateTORSessions()
+
+		By("restarting FRR on all nodes")
+		for _, node := range nodes {
+			restartRouterOnNode(node)
+		}
+
+		By("validating sessions re-established after restart")
+		validateTORSessions()
+	})
+
+})

--- a/internal/controller/routerconfiguration/router_host.go
+++ b/internal/controller/routerconfiguration/router_host.go
@@ -8,10 +8,12 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/openperouter/openperouter/internal/netnamespace"
 	"github.com/openperouter/openperouter/internal/systemdctl"
 	"github.com/vishvananda/netns"
@@ -151,4 +153,61 @@ func (r *RouterHostContainer) CanReconcile(ctx context.Context) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// StartFRRRestartWatcher watches the router PID file for changes via inotify.
+// When the PID file is rewritten (container restart), onRestart is called.
+// The goroutine stops when ctx is cancelled.
+// Safe to call multiple times — only the first call starts the watcher.
+func (r *RouterHostProvider) StartFRRRestartWatcher(ctx context.Context, onRestart func()) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("failed to create fsnotify watcher: %w", err)
+	}
+
+	pidDir := filepath.Dir(r.RouterPidFilePath)
+	pidFile := filepath.Base(r.RouterPidFilePath)
+
+	if err := watcher.Add(pidDir); err != nil {
+		if closeErr := watcher.Close(); closeErr != nil {
+			slog.Error("failed to close watcher", "error", closeErr)
+		}
+		return fmt.Errorf("failed to watch PID directory %s: %w", pidDir, err)
+	}
+
+	slog.Info("restart watcher: watching PID file", "path", r.RouterPidFilePath)
+
+	go func() {
+		defer func() {
+			if err := watcher.Close(); err != nil {
+				slog.Error("failed to close watcher", "error", err)
+			}
+		}()
+		for {
+			select {
+			case <-ctx.Done():
+				slog.Info("restart watcher: stopping")
+				return
+			case ev, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+				if filepath.Base(ev.Name) != pidFile {
+					continue
+				}
+				if ev.Op&(fsnotify.Write|fsnotify.Create) == 0 {
+					continue
+				}
+				slog.Info("restart watcher: PID file changed, router restart detected", "event", ev.Op.String())
+				onRestart()
+			case err, ok := <-watcher.Errors:
+				if !ok {
+					return
+				}
+				slog.Error("restart watcher: fsnotify error", "error", err)
+			}
+		}
+	}()
+
+	return nil
 }

--- a/internal/controller/routerconfiguration/underlay_vni_controller.go
+++ b/internal/controller/routerconfiguration/underlay_vni_controller.go
@@ -344,7 +344,6 @@ func (r *PERouterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		WithEventFilter(filterUpdates).
 		Named("routercontroller")
 
-	// In host mode, watch for file system events via TriggerChan
 	if r.TriggerChan != nil {
 		builder = builder.WatchesRawSource(source.Channel(r.TriggerChan, &handler.EnqueueRequestForObject{}))
 	}


### PR DESCRIPTION
In case of restart of the frr container, the frr configuration is lost. Because of this, we must retrigger a reconcile loop. Here we monitor the pid file and if changed, we trigger a reconciliation of the controller.

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

 In systemd mode, if the frr container restarts the configuration is lost

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Monitor the frr container in systemd mode, if it restarts we reconfigure it.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
