### PR TITLE
Auto report nightly flakes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -279,6 +279,15 @@ jobs:
             make e2etests
           fi
 
+      - name: Upload e2e test reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          retention-days: 1
+          name: e2e-reports-${{ matrix.deployment }}
+          path: /tmp/kind_logs/e2e-report*.json
+          if-no-files-found: ignore
+
       - name: Export kind logs
         if: ${{ failure() }}
         run:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -8,3 +8,30 @@ on:
 jobs:
   ci:
     uses: ./.github/workflows/ci.yaml
+
+  report-flakes:
+    runs-on: ubuntu-22.04
+    needs: ci
+    if: ${{ always() && needs.ci.result == 'failure' }}
+    permissions:
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: hack/report-flakes.py
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Download e2e reports
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: e2e-reports-*
+          path: reports/
+
+      - name: Report flakes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 hack/report-flakes.py reports/

--- a/Makefile
+++ b/Makefile
@@ -339,16 +339,16 @@ $(APIDOCSGEN): $(LOCALBIN)
 
 .PHONY: e2etests
 e2etests: ginkgo kubectl build-validator create-export-logs
-	$(GINKGO) -v $(GINKGO_ARGS) --timeout=3h ./e2etests/suite -- --kubectl=$(KUBECTL) $(TEST_ARGS) --hostvalidator $(VALIDATOR_PATH) --reporterpath=${KIND_EXPORT_LOGS}
+	$(GINKGO) -v $(GINKGO_ARGS) --json-report=e2e-report.json --output-dir=${KIND_EXPORT_LOGS} --timeout=3h ./e2etests/suite -- --kubectl=$(KUBECTL) $(TEST_ARGS) --hostvalidator $(VALIDATOR_PATH) --reporterpath=${KIND_EXPORT_LOGS}
 
 .PHONY: e2etests-hostmode-boot
 e2etests-hostmode-boot: ginkgo kubectl build-validator create-export-logs ## Run e2e tests for hostmode boot scenario (static config first, then K8s API).
 	@echo "=== Running systemd_static_suite tests (static config only) ==="
-	$(GINKGO) -v $(GINKGO_ARGS) --timeout=3h ./e2etests/systemd_static_suite -- --kubectl=$(KUBECTL) $(TEST_ARGS)
+	$(GINKGO) -v $(GINKGO_ARGS) --json-report=e2e-report-systemd.json --output-dir=${KIND_EXPORT_LOGS} --timeout=3h ./e2etests/systemd_static_suite -- --kubectl=$(KUBECTL) $(TEST_ARGS)
 	@echo "=== Deploying controller to enable K8s API ==="
 	$(MAKE) deploy-controller KUSTOMIZE_LAYER=hostmode
 	@echo "=== Running passthrough tests (with K8s API available) ==="
-	$(GINKGO) -v $(GINKGO_ARGS) --label-filter="passthrough" --timeout=3h ./e2etests/suite -- --kubectl=$(KUBECTL) $(TEST_ARGS) --skip-underlay-passthrough --systemdmode --hostvalidator $(VALIDATOR_PATH) --reporterpath=${KIND_EXPORT_LOGS}
+	$(GINKGO) -v $(GINKGO_ARGS) --json-report=e2e-report-passthrough.json --output-dir=${KIND_EXPORT_LOGS} --label-filter="passthrough" --timeout=3h ./e2etests/suite -- --kubectl=$(KUBECTL) $(TEST_ARGS) --skip-underlay-passthrough --systemdmode --hostvalidator $(VALIDATOR_PATH) --reporterpath=${KIND_EXPORT_LOGS}
 
 .PHONY: scale-tests
 scale-tests: ginkgo kubectl create-export-logs ## Run VNI scale tests

--- a/hack/report-flakes.py
+++ b/hack/report-flakes.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+LANE_GROUPS = {
+    "manifests": "e2e",
+    "helm": "e2e",
+    "operator": "e2e",
+    "systemdmode": "e2e",
+    "grout": "grout",
+    "helm-grout": "grout",
+    "operator-grout": "grout",
+}
+
+def env_required(name):
+    val = os.environ.get(name)
+    if not val:
+        print(f"Error: {name} must be set", file=sys.stderr)
+        sys.exit(1)
+    return val
+
+GH_TIMEOUT_SECONDS = 60
+
+def run_gh(*args):
+    cmd = " ".join(["gh"] + list(args))
+    try:
+        result = subprocess.run(
+            ["gh"] + list(args),
+            capture_output=True, text=True,
+            timeout=GH_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(f"{cmd} timed out after {GH_TIMEOUT_SECONDS}s")
+    if result.returncode != 0:
+        raise RuntimeError(f"{cmd} failed:\n{result.stderr.strip()}")
+    return result.stdout.strip()
+
+def collect_failures(reports_dir):
+    failures = {}
+    report_files_seen = 0
+    for artifact_dir in sorted(reports_dir.glob("e2e-reports-*/")):
+        deployment = artifact_dir.name.removeprefix("e2e-reports-")
+
+        for report_path in sorted(artifact_dir.glob("e2e-report*.json")):
+            report_files_seen += 1
+            try:
+                data = json.loads(report_path.read_text())
+            except (json.JSONDecodeError, OSError) as e:
+                print(f"Warning: {report_path} is invalid JSON, skipping: {e}", file=sys.stderr)
+                continue
+
+            if isinstance(data, dict):
+                suites = [data]
+            elif isinstance(data, list):
+                suites = data
+            else:
+                print(f"Warning: {report_path} has unexpected JSON shape, skipping", file=sys.stderr)
+                continue
+
+            for suite in suites:
+                if not isinstance(suite, dict):
+                    continue
+                for spec in suite.get("SpecReports", []):
+                    if not isinstance(spec, dict):
+                        continue
+                    if spec.get("State") not in ("failed", "panicked", "timedout", "interrupted", "aborted"):
+                        continue
+
+                    hierarchy = spec.get("ContainerHierarchyTexts") or []
+                    leaf = spec.get("LeafNodeText", "")
+                    parts = hierarchy + [leaf]
+                    full_path = " ".join(parts).strip()
+                    if not full_path:
+                        continue
+
+                    if len(hierarchy) > 0:
+                        short_title = f"{hierarchy[-1]} / {leaf}"
+                    else:
+                        short_title = leaf
+
+                    group = LANE_GROUPS.get(deployment)
+                    if group:
+                        flake_id = f"flake-id: [{group}] {full_path}"
+                    else:
+                        flake_id = f"flake-id: [{deployment}] {full_path}"
+
+                    state = spec.get("State", "failed")
+
+                    if flake_id not in failures:
+                        failures[flake_id] = {
+                            "full_path": full_path,
+                            "short_title": short_title,
+                            "deployments": set(),
+                            "states": set(),
+                        }
+                    failures[flake_id]["deployments"].add(deployment)
+                    failures[flake_id]["states"].add(state)
+
+    if report_files_seen == 0:
+        print(f"Warning: no e2e-report*.json files found under {reports_dir}", file=sys.stderr)
+
+    return failures
+
+def fetch_existing_issues(repo):
+    output = run_gh(
+        "api", "--paginate",
+        "--method", "GET",
+        f"repos/{repo}/issues",
+        "-f", "labels=kind/flake",
+        "-f", "state=open",
+        "-f", "per_page=100",
+    )
+    if not output:
+        return []
+    issues = []
+    for line in output.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        page = json.loads(line)
+        if not isinstance(page, list):
+            raise RuntimeError(f"unexpected GitHub issues API response: {line[:200]}")
+        issues.extend(issue for issue in page if "pull_request" not in issue)
+    return issues
+
+def find_existing_issue(issues, flake_id):
+    for issue in issues:
+        body = (issue.get("body") or "").replace("\r", "")
+        if flake_id in body.split("\n"):
+            return issue["number"]
+    return None
+
+def comment_on_issue(repo, issue_number, deployments, full_path, states, run_url, date):
+    body = (
+        f"Nightly flake recurrence ({date})\n\n"
+        f"| Field | Value |\n"
+        f"|-------|-------|\n"
+        f"| Run | {run_url} |\n"
+        f"| Deployment(s) | {deployments} |\n"
+        f"| Failure state(s) | {states} |\n\n"
+        f"**Test path:**\n"
+        f"```\n{full_path}\n```"
+    )
+    run_gh("issue", "comment", str(issue_number), "--repo", repo, "--body", body)
+    print(f"Commented on issue #{issue_number} for [{deployments}]: {full_path}")
+
+def create_issue(repo, title, flake_id, full_path, deployments, states, run_url, date):
+    body = (
+        f"Flaky test detected by nightly CI.\n\n"
+        f"**Test path:**\n"
+        f"```\n{full_path}\n```\n\n"
+        f"**Deployment(s):** {deployments}\n"
+        f"**Failure state(s):** {states}\n"
+        f"**First seen:** {date}\n"
+        f"**Run:** {run_url}\n\n"
+        f"---\n"
+        f"{flake_id}"
+    )
+    run_gh("issue", "create", "--repo", repo, "--title", title, "--label", "kind/flake", "--body", body)
+    print(f"Created issue for [{deployments}]: {full_path}")
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: report-flakes.py <reports-dir>", file=sys.stderr)
+        sys.exit(1)
+
+    reports_dir = Path(sys.argv[1])
+    if not reports_dir.is_dir():
+        print(f"No reports dir found ({reports_dir}); nothing to report.")
+        return
+    repo = env_required("GITHUB_REPOSITORY")
+    server_url = env_required("GITHUB_SERVER_URL")
+    run_id = env_required("GITHUB_RUN_ID")
+    run_url = f"{server_url}/{repo}/actions/runs/{run_id}"
+    date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    failures = collect_failures(reports_dir)
+    if not failures:
+        print("No test failures found.")
+        return
+
+    existing_issues = fetch_existing_issues(repo)
+
+    had_errors = False
+    for flake_id, info in sorted(failures.items()):
+        deployments = ", ".join(sorted(info["deployments"]))
+        states = ", ".join(sorted(info["states"]))
+        title = f"Flake: {info['short_title']}"
+        if len(title) > 80:
+            title = title[:77] + "..."
+
+        try:
+            issue_number = find_existing_issue(existing_issues, flake_id)
+            if issue_number:
+                comment_on_issue(repo, issue_number, deployments, info["full_path"], states, run_url, date)
+            else:
+                create_issue(repo, title, flake_id, info["full_path"], deployments, states, run_url, date)
+        except RuntimeError as e:
+            had_errors = True
+            print(f"Error updating flake_id {flake_id!r}: {e}", file=sys.stderr)
+
+    if had_errors:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:

Adds automated flake tracking to the nightly CI workflow. When e2e tests fail, a new `report-flakes` job parses Ginkgo JSON reports and, for each failed test, either opens a new GitHub issue labeled `kind/flake` or comments on an existing one with the run link.

The matching key (`flake-id`) is the full Ginkgo spec path embedded in the issue body. The `manifests`, `helm`, and `operator` lanes are grouped together (same test suite, different deployment), while `systemdmode` and `hostmode-boot` are tracked separately.

**Special notes for your reviewer**:

- Commit 1 adds `--json-report` to the Makefile e2e targets and uploads reports as CI artifacts
- Commit 2 adds the `report-flakes` job and `hack/report-flakes.sh` script
- The job only runs when `ci` fails (`always() && needs.ci.result == 'failure'`)
- `continue-on-error: true` on the artifact download handles the case where CI fails before producing e2e reports

**Release note**:
```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added nightly flaky end-to-end test detection that aggregates JSON results and automatically comments or creates issues for recurring failures.
* **Test Improvements**
  * Updated end-to-end and host-mode boot test runs to emit structured JSON reports into export logs (separate reports for each phase).
* **CI / Reporting**
  * CI now uploads end-to-end test report artifacts even when jobs fail, ensuring reports are available for follow-up analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->