### PR TITLE
Introduce inspect tool for debugging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -703,7 +703,7 @@ grout-docker-build: docker-build
 INSPECT_DIR ?= /tmp/openperouter-inspect
 .PHONY: inspect
 inspect:
-	tools/inspect/inspect --k8s-client=$(KUBECTL) --namespace=$(NAMESPACE) --dest-dir=$(INSPECT_DIR)
+	tools/inspect/inspect --k8s-client=$(KUBECTL) --namespace=$(NAMESPACE) --dest-dir=$(INSPECT_DIR) --since=$(SINCE)
 
 HOST_INSPECT_DIR = /openperouter-inspect-host
 .PHONY: inspect-host

--- a/Makefile
+++ b/Makefile
@@ -705,11 +705,22 @@ INSPECT_DIR ?= /tmp/openperouter-inspect
 inspect:
 	tools/inspect/inspect --k8s-client=$(KUBECTL) --namespace=$(NAMESPACE) --dest-dir=$(INSPECT_DIR) --since=$(SINCE)
 
-HOST_INSPECT_DIR = /openperouter-inspect-host
-.PHONY: inspect-host
-inspect-host:
-	@ ! test -n "$(NODE)" && echo "target node is not set, make sure to pass NODE argument" && exit 1; \
-	NODE_INSPECT_DIR="/tmp/$(NODE)-inspect"; \
-	$(CONTAINER_ENGINE) exec -i $(NODE) bash <<< $$(cat tools/inspect/inspect_host); \
-	$(CONTAINER_ENGINE) cp $(NODE):$(HOST_INSPECT_DIR) $$NODE_INSPECT_DIR; \
-	echo "Inspect node $(NODE) completed. Artifacts are stored at $$NODE_INSPECT_DIR"
+# INSPECT_SYSTEMD_MODE_DIR is the root artifacts directory on the local machine, containing
+# one subdirectory per inspected node.
+INSPECT_SYSTEMD_MODE_DIR ?= /tmp/openperouter-systemd-mode-inspect
+# INSPECT_NODE_DIR is the path inside each node where inspect_host stores its artifacts
+INSPECT_NODE_DIR = /openperouter-inspect-host
+.PHONY: inspect-systemd-mode
+inspect-systemd-mode: kubectl
+	@ nodes="$(NODES)"; \
+	test -z "$$nodes" && nodes=$$($(KUBECTL) get nodes -o jsonpath='{.items[*].metadata.name}'); \
+	test -z "$$nodes" && echo "no node found" && exit 1 ;\
+	mkdir -p $(INSPECT_SYSTEMD_MODE_DIR); \
+	for node in $$nodes ; do \
+		echo "=== Inspecting node $$node ==="; \
+		node_dir="$(INSPECT_SYSTEMD_MODE_DIR)/$$node"; \
+		$(CONTAINER_ENGINE) exec -i $$node bash <<< $$(cat tools/inspect/inspect_host); \
+		$(CONTAINER_ENGINE) cp $$node:$(INSPECT_NODE_DIR) $$node_dir; \
+		echo "Inspect node $$node completed. Artifacts are stored at [$$node_dir]"; \
+	done; \
+	echo "Inspect completed for all nodes. Artifacts are stored at [$(INSPECT_SYSTEMD_MODE_DIR)]"

--- a/Makefile
+++ b/Makefile
@@ -678,7 +678,6 @@ deploy-olm: operator-sdk ## deploys OLM on the cluster
 
 build-and-push-bundle-images: bundle-build bundle-push catalog-build catalog-push
 
-
 .PHONY: grout-deploy
 grout-deploy: IMG_TAG=main-grout
 grout-deploy: export KUSTOMIZE_LAYER=grout
@@ -700,3 +699,8 @@ grout-deploy-helm: helm kind deploy-cluster load-on-kind deploy-helm
 grout-docker-build: IMG_TAG=main-grout
 grout-docker-build: DOCKERFILE=Dockerfile.grout
 grout-docker-build: docker-build
+
+INSPECT_DIR ?= /tmp/openperouter-inspect
+.PHONY: inspect
+inspect:
+	tools/inspect/inspect --k8s-client=$(KUBECTL) --namespace=$(NAMESPACE) --dest-dir=$(INSPECT_DIR)

--- a/Makefile
+++ b/Makefile
@@ -704,3 +704,12 @@ INSPECT_DIR ?= /tmp/openperouter-inspect
 .PHONY: inspect
 inspect:
 	tools/inspect/inspect --k8s-client=$(KUBECTL) --namespace=$(NAMESPACE) --dest-dir=$(INSPECT_DIR)
+
+HOST_INSPECT_DIR = /openperouter-inspect-host
+.PHONY: inspect-host
+inspect-host:
+	@ ! test -n "$(NODE)" && echo "target node is not set, make sure to pass NODE argument" && exit 1; \
+	NODE_INSPECT_DIR="/tmp/$(NODE)-inspect"; \
+	$(CONTAINER_ENGINE) exec -i $(NODE) bash <<< $$(cat tools/inspect/inspect_host); \
+	$(CONTAINER_ENGINE) cp $(NODE):$(HOST_INSPECT_DIR) $$NODE_INSPECT_DIR; \
+	echo "Inspect node $(NODE) completed. Artifacts are stored at $$NODE_INSPECT_DIR"

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,5 @@
+# Tools
+
+| Tool | Description |
+|------|-------------|
+| [inspect/](inspect/) | Collect OpenPERouter deployment state for debugging (`make inspect`) |

--- a/tools/README.md
+++ b/tools/README.md
@@ -2,4 +2,4 @@
 
 | Tool | Description |
 |------|-------------|
-| [inspect/](inspect/) | Collect OpenPERouter deployment state for debugging (`make inspect`) |
+| [inspect/](inspect/) | Collect OpenPERouter deployment state for debugging (`make inspect`, `make inspect-host`) |

--- a/tools/inspect/README.md
+++ b/tools/inspect/README.md
@@ -18,6 +18,16 @@ $ ./inspect --dest-dir=mydir --k8s-client=oc
 
 # override openperouter namespace
 $ ./inspect --dest-dir=mydir --namespace=myns --k8s-client=oc
+
+# via global Make target
+$ make inspect
+
+# override parameters
+$ KUBECONFIG_PATH=$KUBECONFIG \
+    make inspect \
+      NAMESPACE=myns \
+      KUBECTL=oc \
+      INSPECT_DIR=./art
 ```
 **Note:** Options must be specified with `=`.
 

--- a/tools/inspect/README.md
+++ b/tools/inspect/README.md
@@ -19,6 +19,9 @@ $ ./inspect --dest-dir=mydir --k8s-client=oc
 # override openperouter namespace
 $ ./inspect --dest-dir=mydir --namespace=myns --k8s-client=oc
 
+# collect logs since relative time duration
+$ ./inspect --since=3m
+
 # via global Make target
 $ make inspect
 
@@ -27,7 +30,8 @@ $ KUBECONFIG_PATH=$KUBECONFIG \
     make inspect \
       NAMESPACE=myns \
       KUBECTL=oc \
-      INSPECT_DIR=./art
+      INSPECT_DIR=./art \
+      SINCE=3m
 ```
 **Note:** Options must be specified with `=`.
 
@@ -37,6 +41,7 @@ $ KUBECONFIG_PATH=$KUBECONFIG \
 | `--namespace`  | OpenPERouter namespace                                            | `openperouter-system`  |
 | `--dest-dir`   | Output directory path                                             | `openperouter-inspect` |
 | `--k8s-client` | Kubernetes client                                                 | `kubectl`              |
+| `--since`      | Collect pod logs newer then relative duration (e.g.: 5s, 10m, 2h) |                        |
 | `-h`, `--help` | Print usage instructions                                          |                        |
 
 ## Output

--- a/tools/inspect/README.md
+++ b/tools/inspect/README.md
@@ -150,8 +150,8 @@ $ scp -r <target node>/openperouter-inspect-host ./<target node>-perouter-inspec
 $ docker exec pe-kind-worker -i bash <<< $(cat inspect_host)
 $ docker cp pe-kind-worker:/openperouter-inspect-host ./pe-kind-worker-inspect-host
 
-# via global make, artifacts stored at /tmp/$NODE-inspect
-$ make inspect-host NODE=pe-kind-worker
+# via global make, each node artifacts stored at /tmp/openperouter-systemd-mode-inspect/<node name>
+$ make inspect-systemd-mode
 ```
 
 ## Output
@@ -167,13 +167,22 @@ NAME                    STATUS   ROLES           AGE     VERSION
 pe-kind-control-plane   Ready    control-plane   3h20m   v1.32.2
 pe-kind-worker          Ready    <none>          3h20m   v1.32.2
 
-$ make inspect-host NODE=pe-kind-worker
+$ make inspect-systemd-mode
 
-$ tree /tmp/pe-kind-worker-inspect/
-pe-kind-worker-inspect/
-├── config_files.log
-├── root_netns_info.log
-├── router_info_podman_quadlet.log
-└── configs
-    └── node-config.yaml
+$ tree /tmp/openperouter-systemd-mode-inspect/ 
+├── pe-kind-control-plane
+│   ├── node_infoconfig_files.log
+│   ├── root_netns_info.log
+│   ├── router_info_podman_quadlet.log
+│   └── configs
+│        └── node-config.yaml
+└── pe-kind-worker
+    ├── node_infoconfig_files.log
+    ├── root_netns_info.log
+    ├── router_info_podman_quadlet.log
+    └── configs
+        └── node-config.yaml
+     
+# inspect a specific node     
+$ make inspect-systemd-mode NODES=pe-kind-worker
 ```

--- a/tools/inspect/README.md
+++ b/tools/inspect/README.md
@@ -144,6 +144,9 @@ $ scp -r <target node>/openperouter-inspect-host ./<target node>-perouter-inspec
 # troubleshooting kind cluster node running OpenPERouter on host mode
 $ docker exec pe-kind-worker -i bash <<< $(cat inspect_host)
 $ docker cp pe-kind-worker:/openperouter-inspect-host ./pe-kind-worker-inspect-host
+
+# via global make, artifacts stored at /tmp/$NODE-inspect
+$ make inspect-host NODE=pe-kind-worker
 ```
 
 ## Output

--- a/tools/inspect/README.md
+++ b/tools/inspect/README.md
@@ -150,7 +150,8 @@ $ make inspect-systemd-mode
 ```
 
 ### Output
-- `router_info_podman_quadlet.log` - router infrastructure information collected via the router Podman Quadlet container
+- `router_info_podman.log` - router infrastructure information collected from podman (for Podman Quadlet containers)
+- `router_info_crictl.log` - router infrastructure information collected using crictl (e.g.: from CRI-O, containerd)
 - `root_netns_info.log` - Root network namespace information
 - `configs/` - Contains collected static config resources in YAML form
 - `config_files.log` - Static config resources collection log
@@ -168,13 +169,13 @@ $ tree /tmp/openperouter-systemd-mode-inspect/
 ├── pe-kind-control-plane
 │   ├── config_files.log
 │   ├── root_netns_info.log
-│   ├── router_info_podman_quadlet.log
+│   ├── router_info_podman.log
 │   └── configs
 │       └── node-config.yaml
 └── pe-kind-worker
     ├── config_files.log
     ├── root_netns_info.log
-    ├── router_info_podman_quadlet.log
+    ├── router_info_podman.log
     └── configs
         └── node-config.yaml
      

--- a/tools/inspect/README.md
+++ b/tools/inspect/README.md
@@ -1,0 +1,117 @@
+# Inspect OpenPERouter deployment
+
+The `inspect` tool makes debugging OpenPERouter deployments easier by collecting related objects and logs.
+
+## Prerequisites
+- Cluster API client set for the target cluster.
+- Read access to the OpenPERouter namespace; exec access to router pods for node logs.
+
+## How to use:
+```bash
+$ ./inspect
+
+# overriding output directory path
+$ ./inspect --dest-dir=/tmp/perouter-logs
+
+# use a different Kubernetes client
+$ ./inspect --dest-dir=mydir --k8s-client=oc
+
+# override openperouter namespace
+$ ./inspect --dest-dir=mydir --namespace=myns --k8s-client=oc
+```
+**Note:** Options must be specified with `=`.
+
+### Options
+| Option         | Description                                                       | Default                |
+|----------------|-------------------------------------------------------------------|------------------------|
+| `--namespace`  | OpenPERouter namespace                                            | `openperouter-system`  |
+| `--dest-dir`   | Output directory path                                             | `openperouter-inspect` |
+| `--k8s-client` | Kubernetes client                                                 | `kubectl`              |
+| `-h`, `--help` | Print usage instructions                                          |                        |
+
+## Output
+The output root directory contains the following:
+- `timestamp` - Execution timestamp
+- `inspect.log` - Execution log
+- `node_info/` - Per node network and routing infrastructure information
+- `<openperouter namesapce>/` - OpenPERouter namespace objects and workloads logs (defaults is `openperouter-system`)
+- `<namespace name>/` - Per namespaces containing config resources directory (Underlay, L3VNI, L2VNI, etc.)
+
+The OpenPERouter namespace directory structure:
+- `overview/all.log` - Existing resources in summary
+- `pod_logs/` - Pod logs
+- `namespace.yaml` - Namespace state
+- `events.yaml` - Events
+- `<resource-name>/` - Per resource directory (CRDs, workloads)
+
+### Example:
+```bash
+$ tree /tmp/openperouter-inspect/
+├── inspect.log
+├── timestamp
+├── blue
+│   ├── l2vnis
+│   │   └── blue-111.yaml
+│   └── l3vnis
+│       └── blue-101.yaml
+├── node_info
+│   ├── pe-kind-control-plane
+│   │   ├── root_netns_info.log
+│   │   ├── router_info.log
+│   │   └── router_netns_info.log
+│   └── pe-kind-worker
+│       ├── root_netns_info.log
+│       ├── router_info.log
+│       └── router_netns_info.log
+└── openperouter-system
+    ├── events.yaml
+    ├── namespace.yaml
+    ├── configmaps
+    │   ├── frr-startup.yaml
+    │   └── kube-root-ca.crt.yaml
+    ├── daemonsets
+    │   ├── controller.yaml
+    │   └── router.yaml
+    ├── deployments
+    │   └── nodemarker.yaml
+    ├── l2vnis
+    │   └── layer2.yaml
+    ├── l3vnis
+    │   └── red.yaml
+    ├── overview
+    │   └── all.log
+    ├── pod_logs
+    │   ├── controller-cdkqz_controller.log
+    │   ├── controller-j8tgb_controller.log
+    │   ├── nodemarker-7cf554c5b8-8sq72_nodemarker.log
+    │   ├── nodemarker-7cf554c5b8-8sq72_nodemarker_previous.log
+    │   ├── router-w5d2t_frr.log
+    │   ├── router-w5d2t_cp-frr-files.log
+    │   ├── router-w5d2t_reloader.log
+    │   ├── router-w8pz6_frr.log
+    │   ├── router-w8pz6_cp-frr-files.log
+    │   └── router-w8pz6_reloader.log
+    ├── pods
+    │   ├── controller-cdkqz.yaml
+    │   ├── controller-j8tgb.yaml
+    │   ├── nodemarker-7cf554c5b8-8sq72.yaml
+    │   ├── router-w5d2t.yaml
+    │   └── router-w8pz6.yaml
+    ├── rolebindings
+    │   ├── controller-rolebinding.yaml
+    │   └── perouter-rolebinding.yaml
+    ├── roles
+    │   ├── controller-role.yaml
+    │   └── perouter-role.yaml
+    ├── routernodeconfigurationstatuses
+    │   ├── pe-kind-control-plane.yaml
+    │   └── pe-kind-worker.yaml
+    ├── serviceaccounts
+    │   ├── controller.yaml
+    │   ├── default.yaml
+    │   └── perouter.yaml
+    ├── services
+    │   └── openpe-webhook-service.yaml
+    └── underlays
+        └── underlay.yaml
+```

--- a/tools/inspect/README.md
+++ b/tools/inspect/README.md
@@ -7,33 +7,6 @@ The `inspect` tool makes debugging OpenPERouter deployments easier by collecting
 - Read access to the OpenPERouter namespace; exec access to router pods for node logs.
 
 ## How to use:
-```bash
-$ ./inspect
-
-# overriding output directory path
-$ ./inspect --dest-dir=/tmp/perouter-logs
-
-# use a different Kubernetes client
-$ ./inspect --dest-dir=mydir --k8s-client=oc
-
-# override openperouter namespace
-$ ./inspect --dest-dir=mydir --namespace=myns --k8s-client=oc
-
-# collect logs since relative time duration
-$ ./inspect --since=3m
-
-# via global Make target
-$ make inspect
-
-# override parameters
-$ KUBECONFIG_PATH=$KUBECONFIG \
-    make inspect \
-      NAMESPACE=myns \
-      KUBECTL=oc \
-      INSPECT_DIR=./art \
-      SINCE=3m
-```
-**Note:** Options must be specified with `=`.
 
 ### Options
 | Option         | Description                                                       | Default                |
@@ -43,6 +16,28 @@ $ KUBECONFIG_PATH=$KUBECONFIG \
 | `--k8s-client` | Kubernetes client                                                 | `kubectl`              |
 | `--since`      | Collect pod logs newer then relative duration (e.g.: 5s, 10m, 2h) |                        |
 | `-h`, `--help` | Print usage instructions                                          |                        |
+
+**Note:** Options must be specified with `=`.
+
+### Example:
+```bash 
+$ cd tools/inspect     
+$ ./inspect
+
+# override parameters
+$ ./inspect --dest-dir=mydir --namespace=myns --k8s-client=oc --since=3m
+
+# via repository make target, artifacts stored at /tmp/openperouter-inspect
+$ make inspect
+
+# override parameters
+$ KUBECONFIG_PATH=$KUBECONFIG \
+    make inspect \
+      NAMESPACE=my-namespace \
+      KUBECTL=oc \
+      INSPECT_DIR=./art \
+      SINCE=3m
+```
 
 ## Output
 The output root directory contains the following:
@@ -64,11 +59,6 @@ The OpenPERouter namespace directory structure:
 $ tree /tmp/openperouter-inspect/
 ├── inspect.log
 ├── timestamp
-├── blue
-│   ├── l2vnis
-│   │   └── blue-111.yaml
-│   └── l3vnis
-│       └── blue-101.yaml
 ├── node_info
 │   ├── pe-kind-control-plane
 │   │   ├── root_netns_info.log
@@ -90,9 +80,9 @@ $ tree /tmp/openperouter-inspect/
     ├── deployments
     │   └── nodemarker.yaml
     ├── l2vnis
-    │   └── layer2.yaml
+    │   └── red-110.yaml
     ├── l3vnis
-    │   └── red.yaml
+    │   └── red-100.yaml
     ├── overview
     │   └── all.log
     ├── pod_logs
@@ -128,7 +118,7 @@ $ tree /tmp/openperouter-inspect/
     ├── services
     │   └── openpe-webhook-service.yaml
     └── underlays
-        └── underlay.yaml
+       └── underlay.yaml
 ```
 
 ## Inspect OpenPERouter nodes when running on systemd mode
@@ -140,27 +130,32 @@ managed by the cluster.
 
 Artifacts are stored at the host (default is `/openperouter-inspect-host`), and can be copied to base station for inspection.
 
-How to use:
+### Prerequisites
+- SSH access to the target node.How to use:
+
+### How to use:
+
+#### Example:
 ```bash
 # via ssh
-$ ssh <target node> -- bash <<< $(cat inspect_host)
+$ ssh <target node> -- bash <<< $(cat tools/inspect/inspect_host)
 $ scp -r <target node>/openperouter-inspect-host ./<target node>-perouter-inspect
 
 # troubleshooting kind cluster node running OpenPERouter on host mode
-$ docker exec pe-kind-worker -i bash <<< $(cat inspect_host)
+$ docker exec pe-kind-worker -i bash <<< $(cat tools/inspect/inspect_host)
 $ docker cp pe-kind-worker:/openperouter-inspect-host ./pe-kind-worker-inspect-host
 
-# via global make, each node artifacts stored at /tmp/openperouter-systemd-mode-inspect/<node name>
+# via repository make target, artifacts stored at /tmp/openperouter-systemd-mode-inspect
 $ make inspect-systemd-mode
 ```
 
-## Output
+### Output
 - `router_info_podman_quadlet.log` - router infrastructure information collected via the router Podman Quadlet container
 - `root_netns_info.log` - Root network namespace information
 - `configs/` - Contains collected static config resources in YAML form
 - `config_files.log` - Static config resources collection log
 
-### Example:
+#### Example:
 ```bash
 $ kubectl get no
 NAME                    STATUS   ROLES           AGE     VERSION
@@ -171,13 +166,13 @@ $ make inspect-systemd-mode
 
 $ tree /tmp/openperouter-systemd-mode-inspect/ 
 ├── pe-kind-control-plane
-│   ├── node_infoconfig_files.log
+│   ├── config_files.log
 │   ├── root_netns_info.log
 │   ├── router_info_podman_quadlet.log
 │   └── configs
-│        └── node-config.yaml
+│       └── node-config.yaml
 └── pe-kind-worker
-    ├── node_infoconfig_files.log
+    ├── config_files.log
     ├── root_netns_info.log
     ├── router_info_podman_quadlet.log
     └── configs

--- a/tools/inspect/README.md
+++ b/tools/inspect/README.md
@@ -125,3 +125,47 @@ $ tree /tmp/openperouter-inspect/
     └── underlays
         └── underlay.yaml
 ```
+
+## Inspect OpenPERouter nodes when running on systemd mode
+
+When OpenPERouter runs on systemd mode, related info cannot be collected via cluster API as the router container is not
+managed by the cluster.
+
+`inspect_host` can be used for collecting related info by executing the script directly on the target node.
+
+Artifacts are stored at the host (default is `/openperouter-inspect-host`), and can be copied to base station for inspection.
+
+How to use:
+```bash
+# via ssh
+$ ssh <target node> -- bash <<< $(cat inspect_host)
+$ scp -r <target node>/openperouter-inspect-host ./<target node>-perouter-inspect
+
+# troubleshooting kind cluster node running OpenPERouter on host mode
+$ docker exec pe-kind-worker -i bash <<< $(cat inspect_host)
+$ docker cp pe-kind-worker:/openperouter-inspect-host ./pe-kind-worker-inspect-host
+```
+
+## Output
+- `router_info_podman_quadlet.log` - router infrastructure information collected via the router Podman Quadlet container
+- `root_netns_info.log` - Root network namespace information
+- `configs/` - Contains collected static config resources in YAML form
+- `config_files.log` - Static config resources collection log
+
+### Example:
+```bash
+$ kubectl get no
+NAME                    STATUS   ROLES           AGE     VERSION
+pe-kind-control-plane   Ready    control-plane   3h20m   v1.32.2
+pe-kind-worker          Ready    <none>          3h20m   v1.32.2
+
+$ make inspect-host NODE=pe-kind-worker
+
+$ tree /tmp/pe-kind-worker-inspect/
+pe-kind-worker-inspect/
+├── config_files.log
+├── root_netns_info.log
+├── router_info_podman_quadlet.log
+└── configs
+    └── node-config.yaml
+```

--- a/tools/inspect/inspect
+++ b/tools/inspect/inspect
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier:Apache-2.0
+
+set -ueo pipefail
+
+SCRIPT_DIR="$(dirname "$(realpath -s "$0")")"
+
+# script for collecting routing infrastructure information 
+readonly ROUTER_INFO_SCRIPT="${SCRIPT_DIR}/router_info"
+# script for collecting network information
+readonly NET_INFO_SCRIPT="${SCRIPT_DIR}/net_info"
+# router pod's label selector
+readonly ROUTER_LABEL="app=router"
+# router pod's container who has access to perouter netns (used for collecting routing infra info)
+readonly ROUTER_INFRA_CONTAINER="frr"
+# pod's container who has access to node root netns (used for collecting root netns info)
+readonly HOST_NET_CONTAINER="reloader"
+# router infrastructure netns name
+readonly NETNS="perouter"
+# openperouter system resources to collect
+readonly CORE_RESOURCES=(\
+	"daemonsets" \
+	"deployments" \
+	"pods" \
+	"services" \
+	"configmaps" \
+	"roles" \
+	"rolebindings" \
+	"serviceaccounts" \
+	"routernodeconfigurationstatuses" \
+)
+# openperouter config resources to collect
+readonly CONFIG_RESOURCES=(\
+	"underlays" \
+	"l2vnis" \
+	"l3vnis" \
+	"l3passthroughs" \
+	"rawfrrconfigs" \
+)
+
+function dump_overview() {
+	local -r ctl="$1"
+	local -r dir="$2"
+
+	mkdir -p "$dir"
+
+	local -r logfile="${dir}/all.log"
+	local -r all=("${CORE_RESOURCES[@]}" "${CONFIG_RESOURCES[@]}")
+	{
+		for r in "${all[@]}"; do
+			echo "# $r"
+			$ctl get "$r" -o wide
+			echo "" 
+		done
+	} > "$logfile"
+
+	echo "Dumped namespace resources overview to [$logfile]"
+}
+
+function dump_core_resources_from_ns() {
+	local -r ctl="$1"
+	local -r namespace="$2"
+	local -r base_dir="$3"
+
+	local -r ns_dir="${base_dir}/${namespace}"	
+	mkdir -p "$ns_dir"
+
+	local logfile="${ns_dir}/namespace.yaml"
+	$ctl get namespace "$namespace" -o yaml > "$logfile"
+	echo "Dumped namespace [$namespace] manifest to [$logfile]"
+	
+	logfile="${ns_dir}/events.yaml"
+	$ctl get events -n "$namespace" -o yaml > "$logfile"
+	echo "Dumped events to [$logfile]"
+		
+	for r in "${CORE_RESOURCES[@]}"; do
+		dump_resource "${ctl}" "${namespace}" "${r}" "${ns_dir}"
+	done
+}
+
+function dump_config_resources_from_all_ns() {
+	local -r ctl="$1"
+	local -r base_dir="$2"
+
+	local namespaces
+	for r in "${CONFIG_RESOURCES[@]}"; do
+		namespaces="$($ctl get --all-namespaces "$r" -o jsonpath='{.items[*].metadata.namespace}')"
+		if [[ -z $namespaces ]]; then
+			continue
+		fi
+		for namespace in $namespaces; do
+			dump_resource "${ctl}" "${namespace}" "${r}" "${base_dir}/${namespace}"
+		done
+	done
+}
+
+function dump_resource() {
+	local -r ctl="$1"
+	local -r ns="$2"
+	local -r type="$3"
+	local -r base_dir="$4"
+
+	local -r objs="$($ctl get -n "$ns" "$type" -o jsonpath='{.items[*].metadata.name}')"
+	if [[ -z $objs ]]; then
+		return
+	fi
+
+	local -r dir="${base_dir}/${type}"
+	mkdir -p "$dir"
+
+	local logfile
+	for obj in $objs; do
+		logfile="${dir}/${obj}.yaml"
+		$ctl get -n "$ns" "$type" "$obj" -o yaml > "$logfile" 
+		echo "Dumped resource manifest [$type][$ns/$obj] [$logfile]"
+	done
+}
+
+function dump_pod_logs() {
+	local -r ctl="$1"
+	local -r dir="$2"
+
+	mkdir -p "$dir"
+
+	local -r pods="$($ctl get pods -o jsonpath='{.items[*].metadata.name}')"
+	local logfile
+	for p in $pods; do
+		local containers=()
+		containers=("$($ctl get pods "$p" -o jsonpath='{.spec.containers[*].name}')")
+		containers+=("$($ctl get pods "$p" -o jsonpath='{.spec.initContainers[*].name}')")
+		for c in ${containers[@]}; do
+			logfile="${dir}/${p}_${c}.log"
+			$ctl logs "$p" -c "$c" > "$logfile"
+			echo "Dumped logs for [$p/$c] to [$logfile]"
+
+			if $ctl logs "$p" -c "$c" --previous &> /dev/null; then
+				logfile="${dir}/${p}_${c}_previous.log"	
+				$ctl logs "$p" -c "$c" --previous > "$logfile"
+				echo "Dumped previous logs for [$p/$c] to [$logfile]"
+			fi
+		done
+	done
+}
+
+function dump_node_info() {
+	local -r ctl="$1"
+	local -r base_dir="$2"
+
+	local -r router_pods="$($ctl get pods -l "$ROUTER_LABEL" -o jsonpath='{.items[*].metadata.name}')"
+	local node_name logfile
+	for p in $router_pods; do
+		node_name="$($ctl get pods "$p" -o jsonpath='{.spec.nodeName}')"
+		node_dir="${base_dir}/${node_name}"
+				
+		mkdir -p "$node_dir"
+		
+		logfile="${node_dir}/root_netns_info.log"
+		$ctl exec -i "$p" -c "$HOST_NET_CONTAINER" -- bash <<< "$(cat "$NET_INFO_SCRIPT")" &> "$logfile"
+		echo "Dumped root netns info of node [$node_name] pod [$p/$HOST_NET_CONTAINER] to [$logfile]"
+
+		logfile="${node_dir}/router_netns_info.log"
+		$ctl exec -i "$p" -c "$ROUTER_INFRA_CONTAINER" -- bash <<< "NETNS=$NETNS $(cat "$NET_INFO_SCRIPT")" &> "$logfile"
+		echo "Dumped router netns info of node [$node_name] pod [$p/$ROUTER_INFRA_CONTAINER] to [$logfile]"
+
+		logfile="${node_dir}/router_info.log"
+		$ctl exec -i "$p" -c "$ROUTER_INFRA_CONTAINER" -- bash <<< "$(cat "$ROUTER_INFO_SCRIPT")" &> "$logfile"
+		echo "Dumped router info of node [$node_name] pod [$p/$ROUTER_INFRA_CONTAINER] to [$logfile]"
+	done
+}
+
+function help() {
+    cat <<EOF
+Inspect OpenPERouter deployment and export related resources and logs.
+
+Usage: inspect [options]=<value>
+
+Example
+  inspect --dest-dir=/tmp/openperouter-logs --k8s-client=./bin/kubectl --namespace=openperouter-system
+
+Options:
+  --namespace   OpenPERouter system namespace name (default: "openperouter-system")
+  --dest-dir    The directory to store artifacts (default: "openperouter-inspect")
+  --k8s-client  Kubernetes client binary path (default: "kubectl")
+  -h, --help    Show this help message and exit
+EOF
+}
+
+NAMESPACE="openperouter-system"
+ARTIFACTS_DIR="./openperouter-inspect"
+CTL_BIN="kubectl"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --namespace=*)   NAMESPACE="${1#*=}" ;;
+        --dest-dir=*)    ARTIFACTS_DIR="${1#*=}" ;;
+        --k8s-client=*)  CTL_BIN="${1#*=}" ;;
+        -h | --help)     help; exit 0 ;;
+        *) echo "Unknown option: $1"; help; exit 1 ;;
+    esac
+	shift
+done
+
+if ! command -v "${CTL_BIN}" &> /dev/null; then
+	echo "FATAL: '${CTL_BIN}' command not found" && exit 1
+fi
+
+if ! "${CTL_BIN}" get ns "${NAMESPACE}" &> /dev/null; then
+	echo "FATAL: '${NAMESPACE}' namespace not found. Make sure KUBECONFIG is set correctly." && exit 1
+fi
+
+mkdir -p "${ARTIFACTS_DIR}"
+date --rfc-3339=ns > "${ARTIFACTS_DIR}/timestamp"
+
+(
+	readonly CTL="${CTL_BIN} -n ${NAMESPACE}"
+	readonly NS_DIR="${ARTIFACTS_DIR}/${NAMESPACE}"
+	set +e
+	dump_overview  "${CTL}" "${NS_DIR}/overview" 
+	dump_core_resources_from_ns       "${CTL_BIN}" "${NAMESPACE}" "${ARTIFACTS_DIR}"
+	dump_config_resources_from_all_ns "${CTL_BIN}" "${ARTIFACTS_DIR}"
+	dump_pod_logs  "${CTL}" "${NS_DIR}/pod_logs"  
+	dump_node_info "${CTL}" "${ARTIFACTS_DIR}/node_info"
+) 2>&1 | tee -a "${ARTIFACTS_DIR}/inspect.log"
+
+echo "Inspect completed. Artifacts are stored in ${ARTIFACTS_DIR}"

--- a/tools/inspect/inspect
+++ b/tools/inspect/inspect
@@ -120,23 +120,25 @@ function dump_resource() {
 function dump_pod_logs() {
 	local -r ctl="$1"
 	local -r dir="$2"
+	local -r opts="$3"
 
 	mkdir -p "$dir"
 
 	local -r pods="$($ctl get pods -o jsonpath='{.items[*].metadata.name}')"
-	local logfile
+	local logfile ctl_logs
 	for p in $pods; do
 		local containers=()
 		containers=("$($ctl get pods "$p" -o jsonpath='{.spec.containers[*].name}')")
 		containers+=("$($ctl get pods "$p" -o jsonpath='{.spec.initContainers[*].name}')")
 		for c in ${containers[@]}; do
 			logfile="${dir}/${p}_${c}.log"
-			$ctl logs "$p" -c "$c" > "$logfile"
+			ctl_logs="$ctl logs $p -c $c $opts"
+			$ctl_logs > "$logfile"
 			echo "Dumped logs for [$p/$c] to [$logfile]"
 
-			if $ctl logs "$p" -c "$c" --previous &> /dev/null; then
-				logfile="${dir}/${p}_${c}_previous.log"	
-				$ctl logs "$p" -c "$c" --previous > "$logfile"
+			if $ctl_logs --previous &> /dev/null; then
+				logfile="${dir}/${p}_${c}_previous.log"
+				$ctl_logs --previous > "$logfile"
 				echo "Dumped previous logs for [$p/$c] to [$logfile]"
 			fi
 		done
@@ -182,6 +184,7 @@ Options:
   --namespace   OpenPERouter system namespace name (default: "openperouter-system")
   --dest-dir    The directory to store artifacts (default: "openperouter-inspect")
   --k8s-client  Kubernetes client binary path (default: "kubectl")
+  --since       Collect pod logs newer then relative duration, e.g.: 5s, 10m, 2h.
   -h, --help    Show this help message and exit
 EOF
 }
@@ -189,12 +192,14 @@ EOF
 NAMESPACE="openperouter-system"
 ARTIFACTS_DIR="./openperouter-inspect"
 CTL_BIN="kubectl"
+SINCE_DURATION=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --namespace=*)   NAMESPACE="${1#*=}" ;;
         --dest-dir=*)    ARTIFACTS_DIR="${1#*=}" ;;
         --k8s-client=*)  CTL_BIN="${1#*=}" ;;
+        --since=*)       SINCE_DURATION="${1#*=}" ;;
         -h | --help)     help; exit 0 ;;
         *) echo "Unknown option: $1"; help; exit 1 ;;
     esac
@@ -209,6 +214,11 @@ if ! "${CTL_BIN}" get ns "${NAMESPACE}" &> /dev/null; then
 	echo "FATAL: '${NAMESPACE}' namespace not found. Make sure KUBECONFIG is set correctly." && exit 1
 fi
 
+log_opts=""
+if [[ -n $SINCE_DURATION ]]; then
+  log_opts="--since $SINCE_DURATION"
+fi
+
 mkdir -p "${ARTIFACTS_DIR}"
 date --rfc-3339=ns > "${ARTIFACTS_DIR}/timestamp"
 
@@ -216,10 +226,10 @@ date --rfc-3339=ns > "${ARTIFACTS_DIR}/timestamp"
 	readonly CTL="${CTL_BIN} -n ${NAMESPACE}"
 	readonly NS_DIR="${ARTIFACTS_DIR}/${NAMESPACE}"
 	set +e
-	dump_overview  "${CTL}" "${NS_DIR}/overview" 
+	dump_overview  "${CTL}" "${NS_DIR}/overview"
 	dump_core_resources_from_ns       "${CTL_BIN}" "${NAMESPACE}" "${ARTIFACTS_DIR}"
 	dump_config_resources_from_all_ns "${CTL_BIN}" "${ARTIFACTS_DIR}"
-	dump_pod_logs  "${CTL}" "${NS_DIR}/pod_logs"  
+	dump_pod_logs  "${CTL}" "${NS_DIR}/pod_logs" "${log_opts}"
 	dump_node_info "${CTL}" "${ARTIFACTS_DIR}/node_info"
 ) 2>&1 | tee -a "${ARTIFACTS_DIR}/inspect.log"
 

--- a/tools/inspect/inspect_host
+++ b/tools/inspect/inspect_host
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier:Apache-2.0
+
+set -ueo pipefail
+
+readonly NETNS_INFO=(\
+	"ip link" \
+	"ip address" \
+	"ip route" \
+	"ip neigh" \
+	"ip vrf" \
+	"bridge fdb show" \
+)
+readonly FRR_INFO=(\
+	"timeout 10s vtysh -c 'show running-config'" \
+	"timeout 10s vtysh -c 'show bgp ipv4'" \
+	"timeout 10s vtysh -c 'show bgp ipv6'" \
+	"timeout 10s vtysh -c 'show bgp neighbor'" \
+	"timeout 10s vtysh -c 'show bfd peer'" \
+	"timeout 10s vtysh -c 'show bgp l2vpn evpn'" \
+)
+
+function dump_netns_info() {
+	echo "### Network namespace info [root]:"
+	for cmd in "${NETNS_INFO[@]}"; do
+		echo "$ $cmd"
+		$cmd
+		echo ""
+	done
+	printf "###\n\n"
+}
+
+function dump_router_info_via_podman_quadlet() {
+	local -r container_id="$1"
+
+	echo "### Routing infrastructure info from podman quadlets:"
+	for cmd in "${FRR_INFO[@]}"; do
+		echo "$ $cmd"
+		podman exec -i "$container_id" bash <<< "$cmd"
+		echo ""
+	done
+	printf "###\n\n"
+}
+
+function dump_config_files() {
+	local -r conf_dir="$1"
+	local -r base_dir="$2"
+
+	local -r yamls="$(find "$conf_dir" -type f -name '*.yaml')"
+	if [[ -z $yamls ]]; then
+		return
+	fi
+
+	local out_conf_dir="$base_dir/configs"
+	mkdir -p "$out_conf_dir"
+	
+	local f
+	for yaml in $yamls; do	
+		f="$out_conf_dir/$(basename "$yaml")"
+		cat "$yaml" > "$f"
+		echo "Dumped configuration file [$yaml] to [$f]"
+	done
+}
+
+ARTIFACTS_DIR=${ARTIFACTS_DIR:-"/openperouter-inspect-host"}
+ROUTER_CONTAINER=${ROUTER_CONTAINER:-"frr"}
+CONF_DIR=${CONF_DIR:-"/var/lib/openperouter"}
+
+mkdir -p "$ARTIFACTS_DIR"
+
+pushd "$ARTIFACTS_DIR"
+	dump_netns_info > "root_netns_info.log"
+
+	if podman info &> /dev/null; then
+		router_container_id="$(podman ps -q -f name="$ROUTER_CONTAINER" -f status=running)"
+		if [[ -n $router_container_id ]]; then
+			dump_router_info_via_podman_quadlet "$router_container_id" > "router_info_podman_quadlet.log"
+		fi
+	fi
+
+	if [[ -d $CONF_DIR ]]; then
+		dump_config_files "$CONF_DIR" "$ARTIFACTS_DIR" > "config_files.log"
+	fi 
+popd 
+
+echo "Inspect completed. Artifacts are stored in ${ARTIFACTS_DIR}"

--- a/tools/inspect/inspect_host
+++ b/tools/inspect/inspect_host
@@ -31,13 +31,14 @@ function dump_netns_info() {
 	printf "###\n\n"
 }
 
-function dump_router_info_via_podman_quadlet() {
-	local -r container_id="$1"
+function dump_router_info() {
+	local -r oci_ctl="$1"
+	local -r container_id="$2"
 
-	echo "### Routing infrastructure info from podman quadlets:"
+	echo "### Routing infrastructure info via [$oci_ctl]:"
 	for cmd in "${FRR_INFO[@]}"; do
 		echo "$ $cmd"
-		podman exec -i "$container_id" bash <<< "$cmd"
+		$oci_ctl exec -i "$container_id" bash -c "$cmd"
 		echo ""
 	done
 	printf "###\n\n"
@@ -75,7 +76,13 @@ pushd "$ARTIFACTS_DIR"
 	if podman info &> /dev/null; then
 		router_container_id="$(podman ps -q -f name="$ROUTER_CONTAINER" -f status=running)"
 		if [[ -n $router_container_id ]]; then
-			dump_router_info_via_podman_quadlet "$router_container_id" > "router_info_podman_quadlet.log"
+			dump_router_info "podman" "$router_container_id" > "router_info_podman.log"
+		fi
+	fi
+	if crictl info &> /dev/null; then
+		router_container_id="$(crictl ps -q --name frr --state Running)"
+		if [[ -n $router_container_id ]]; then
+			dump_router_info "crictl" "$router_container_id" > "router_info_crictl.log"
 		fi
 	fi
 

--- a/tools/inspect/net_info
+++ b/tools/inspect/net_info
@@ -18,6 +18,34 @@ readonly NETNS_INFO=(\
 "bridge fdb show" \
 )
 
+readonly VRF_SHOW="ip -br link show type vrf"
+readonly VRF_INFO=(\
+"ip link show type vrf"
+"ip route show vrf"
+"ip address show vrf"
+)
+
+function print_vrf_info {
+  local -r netns_name=$1
+  local -r args="$2"
+
+  vrfs=("$($args $VRF_SHOW | awk '{print $1}')")
+  [[ ${#vrfs} -eq 0 ]] && return
+
+  echo "### netns [$netns_name] VRFs:"
+  $args $VRF_SHOW
+
+  for vrf in "${vrfs[@]}"; do
+    echo "### netns [$netns_name] VRF [$vrf]:"
+    for cmd in "${VRF_INFO[@]}"; do
+      c="$args $cmd $vrf"
+      echo "$ $c"
+      $c
+    done
+  done
+  echo "###"
+}
+
 echo "### Networking info:"
 for cmd in "${NETNS_INFO[@]}"; do
 	c="$args $cmd"
@@ -26,3 +54,10 @@ for cmd in "${NETNS_INFO[@]}"; do
 	echo ""
 done
 echo "###"
+echo ""
+
+if [[ -n $NETNS ]]; then
+  print_vrf_info "$NETNS" "$args"
+else
+  print_vrf_info "root" ""
+fi

--- a/tools/inspect/net_info
+++ b/tools/inspect/net_info
@@ -2,13 +2,6 @@
 
 # SPDX-License-Identifier:Apache-2.0
 
-NETNS=${NETNS:-""}
-
-args=""
-if [ -n "$NETNS" ]; then
-	args="ip netns exec $NETNS"
-fi
-
 readonly NETNS_INFO=(\
 "ip link" \
 "ip address" \
@@ -26,19 +19,18 @@ readonly VRF_INFO=(\
 )
 
 function print_vrf_info {
-  local -r netns_name=$1
-  local -r args="$2"
+  local -r cmd_prefix="$1"
 
-  vrfs=("$($args $VRF_SHOW | awk '{print $1}')")
+  local -r vrfs=("$($cmd_prefix $VRF_SHOW | awk '{print $1}')")
   [[ ${#vrfs} -eq 0 ]] && return
 
-  echo "### netns [$netns_name] VRFs:"
-  $args $VRF_SHOW
+  echo "### VRFs:"
+  $cmd_prefix $VRF_SHOW
 
   for vrf in "${vrfs[@]}"; do
-    echo "### netns [$netns_name] VRF [$vrf]:"
+    echo "### VRF [$vrf] info:"
     for cmd in "${VRF_INFO[@]}"; do
-      c="$args $cmd $vrf"
+      c="$cmd_prefix $cmd $vrf"
       echo "$ $c"
       $c
     done
@@ -46,9 +38,18 @@ function print_vrf_info {
   echo "###"
 }
 
+NETNS=${NETNS:-""}
+
+cmd_prefix=""
+dump_vrfs_info=0
+if [ -n "$NETNS" ]; then
+	cmd_prefix="ip netns exec $NETNS"
+	dump_vrfs_info=1
+fi
+
 echo "### Networking info:"
 for cmd in "${NETNS_INFO[@]}"; do
-	c="$args $cmd"
+	c="$cmd_prefix $cmd"
 	echo "$ $c"
 	$c
 	echo ""
@@ -56,8 +57,6 @@ done
 echo "###"
 echo ""
 
-if [[ -n $NETNS ]]; then
-  print_vrf_info "$NETNS" "$args"
-else
-  print_vrf_info "root" ""
+if [[ $dump_vrfs_info -gt 0 ]]; then
+  print_vrf_info "$cmd_prefix"
 fi

--- a/tools/inspect/net_info
+++ b/tools/inspect/net_info
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier:Apache-2.0
+
+NETNS=${NETNS:-""}
+
+args=""
+if [ -n "$NETNS" ]; then
+	args="ip netns exec $NETNS"
+fi
+
+readonly NETNS_INFO=(\
+"ip link" \
+"ip address" \
+"ip route" \
+"ip neigh" \
+"ip vrf" \
+"bridge fdb show" \
+)
+
+echo "### Networking info:"
+for cmd in "${NETNS_INFO[@]}"; do
+	c="$args $cmd"
+	echo "$ $c"
+	$c
+	echo ""
+done
+echo "###"

--- a/tools/inspect/router_info
+++ b/tools/inspect/router_info
@@ -2,14 +2,40 @@
 
 # SPDX-License-Identifier:Apache-2.0
 
+readonly VTYSH_EXEC="timeout 10s vtysh -c"
 readonly FRR_INFO=(\
-"timeout 10s vtysh -c 'show running-config'" \
-"timeout 10s vtysh -c 'show bgp ipv4'" \
-"timeout 10s vtysh -c 'show bgp ipv6'" \
-"timeout 10s vtysh -c 'show bgp neighbor'" \
-"timeout 10s vtysh -c 'show bfd peer'" \
-"timeout 10s vtysh -c 'show bgp l2vpn evpn'" \
+"$VTYSH_EXEC 'show running-config'" \
+"$VTYSH_EXEC 'show bgp ipv4'" \
+"$VTYSH_EXEC 'show bgp ipv6'" \
+"$VTYSH_EXEC 'show bgp neighbor'" \
+"$VTYSH_EXEC 'show bfd peer'" \
+"$VTYSH_EXEC 'show bgp l2vpn evpn'" \
 )
+
+function get_neighbors_addr() {
+	local -r cmd="$1"
+	$VTYSH_EXEC "$cmd" 2>/dev/null \
+		| sed -n 's/^BGP neighbor is \([^,]*\),.*/\1/p'
+}
+
+function print_neighbor_routes() {
+  local -r route_direction=("advertised-routes" "received-routes")
+  declare -A nei_by_afi
+  nei_by_afi["ipv4"]="$(get_neighbors_addr "show bgp ipv4 neighbors")"
+  nei_by_afi["ipv6"]="$(get_neighbors_addr "show bgp ipv6 neighbors")"
+
+  for afi in "${!nei_by_afi[@]}"; do
+    afi_neis=(${nei_by_afi[$afi]})
+    [[ ${#afi_neis[@]} -eq 0 ]] && continue
+    for nei in "${afi_neis[@]}"; do
+      for direction in "${route_direction[@]}"; do
+        echo "### Neighbor [$nei] BGP ${direction}:"
+        $VTYSH_EXEC "show bgp ${afi} neighbors ${nei} ${direction}"
+      done
+      echo ""
+    done
+  done
+}
 
 echo "### Routing infrastructure info:"
 for cmd in "${FRR_INFO[@]}"; do
@@ -17,4 +43,9 @@ for cmd in "${FRR_INFO[@]}"; do
 	eval "$cmd"
 	echo ""
 done
+echo "###"
+echo ""
+
+echo "### Neighbors BGP routes:"
+print_neighbor_routes
 echo "###"

--- a/tools/inspect/router_info
+++ b/tools/inspect/router_info
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier:Apache-2.0
+
+readonly FRR_INFO=(\
+"timeout 10s vtysh -c 'show running-config'" \
+"timeout 10s vtysh -c 'show bgp ipv4'" \
+"timeout 10s vtysh -c 'show bgp ipv6'" \
+"timeout 10s vtysh -c 'show bgp neighbor'" \
+"timeout 10s vtysh -c 'show bfd peer'" \
+"timeout 10s vtysh -c 'show bgp l2vpn evpn'" \
+)
+
+echo "### Routing infrastructure info:"
+for cmd in "${FRR_INFO[@]}"; do
+	echo "$ $cmd"
+	eval "$cmd"
+	echo ""
+done
+echo "###"

--- a/website/content/docs/troubleshoot/_index.md
+++ b/website/content/docs/troubleshoot/_index.md
@@ -1,0 +1,53 @@
+---
+weight: 60
+title: "Troubleshoot"
+description: "How to troubleshoot OpenPERouter"
+icon: "article"
+date: "2026-07-12T10:03:22+02:00"
+lastmod: "2026-07-12T10:03:22+02:00"
+toc: true
+---
+
+This section explains how to troubleshoot OpenPERouter deployments.
+
+## Inspect Tool
+
+The `inspect` tool makes debugging OpenPERouter deployments easier by
+collecting related objects and logs into a single directory, for inspection
+or attached to a bug report.
+
+It can be found at OpenPERouter repository 
+[`tools/inspect`](https://github.com/openperouter/openperouter/tree/main/tools/inspect) 
+
+### Output
+The tool wire all collected info to output directory (default is `openperouter-inspect/`), including:
+- `node_info/` - per-node network and routing infrastructure information (IP link state, VRFs, type 2 and 5 routes, etc.)
+- `<openperouter namespace>/` - namespace objects and workload logs (pod logs, events, CRs, roles, etc.)
+- `<namespace name>/` - per-namespace directory with config resources (Underlay, L3VNI, L2VNI, etc.)
+
+Please refer to the tool 
+[README](https://github.com/openperouter/openperouter/blob/main/tools/inspect/README.md) 
+for more details.
+
+
+### Systemd mode
+When OpenPERouter runs in [systemd mode](../configuration/systemd-mode/),
+the router state can't be collected through the cluster API because the router
+container isn't managed by Kubernetes. 
+
+The `inspect_host` tool can be used for inspecting such nodes.
+
+It can be found at OpenPERouter repository
+[`tools/inspect`](https://github.com/openperouter/openperouter/tree/main/tools/inspect)
+
+#### Output
+The tool store all collected info to output directory (default is `/openperouter-inspect-host`), including: 
+- `router_info_podman_quadlet.log` - router infrastructure information, 
+- collected via the router Podman Quadlet container
+- `root_netns_info.log` - root network namespace information
+- `config_files.log` - static config resources collection log
+- `configs/` - collected static config resources, YAML form
+
+Please see the tool 
+[README](https://github.com/openperouter/openperouter/blob/main/tools/inspect/README.md)
+for more details.

--- a/website/content/docs/troubleshoot/_index.md
+++ b/website/content/docs/troubleshoot/_index.md
@@ -42,8 +42,8 @@ It can be found at OpenPERouter repository
 
 #### Output
 The tool store all collected info to output directory (default is `/openperouter-inspect-host`), including: 
-- `router_info_podman_quadlet.log` - router infrastructure information, 
-- collected via the router Podman Quadlet container
+- `router_info_podman.log` - router infrastructure information collected from podman (for Podman Quadlet containers)
+- `router_info_crictl.log` - router infrastructure information collected using crictl (e.g.: from CRI-O, containerd)
 - `root_netns_info.log` - root network namespace information
 - `config_files.log` - static config resources collection log
 - `configs/` - collected static config resources, YAML form


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup

/kind feature

> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
Debugging k8s controllers is tedious require knowing details how controller is deployed and  usually involve manually dumping multiple objects and logs.
We want to improve debug UX, at least for collecting relevant info for troubleshooting.

Introduce `inspect` tool for collecting OpenPERouter deployment state for easier debugging.

The tool dumps related objects such as pods, pod logs, CRDs, node router 
network and router (frr instance) information.

How to use: 
Inspect openperouter deployment:
```
$ make inspect

# override parameters 
$ KUBECONFIG_PATH=$KUBECONFIG  make inspect \
    NAMESPACE=openshift-openperouter
    KUBECTL=oc \
    INSPECT_DIR=./art \
    SINCE=1d

# run script directly
$ ./tools/inspect/inspect 

# override parameters
$ ./tools/inspect/inspect \
    --namespace=openshift-openperouter \
    --k8s-client=oc \
    --dest-dir=/tmp/openperouter-logs
    --since=1d
```
Inspect nodes running systemd mode:
```bash
# run script directly on node
$ ssh mynode.example.io -- bash <<< $(cat ./tools/inspect/inspect_host)
$ scp -r mynode.example.io:/openperouter-inspect-host ./openperoute-inspect-mynode.example.io

# debug kind cluster node
$ docker exec pe-kind-worker -i bash <<< $(cat ./tools/inspect/inspect_host)
$ docker cp pe-kind-worker:/openperouter-inspect-host ./pe-kind-worker-inspect-host
# via repo make target
$ make inspect-systemd-mode
```

**Special notes for your reviewer**:
Please see the added the README files, it contain more info about usage and output.

Since on systemd mode info cannot be collected via cluster API, a separate script is add to enable collecting info of node running on systemd mode. 
The script is meant to run directly on a target node, output can be copied to base station for inspection.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Introduce tool for inspecting OpenPERouter deployments for easier troubleshooting.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
