### PR TITLE
cleanup: stop updating CSV createdAt timestamp

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,7 +163,7 @@ jobs:
       - name: Verify bundle manifests
         run: |
           make bundle
-          git diff --exit-code -I'^    createdAt: ' operator/bundle
+          git diff --exit-code operator/bundle
 
   build-test-images:
     runs-on: ubuntu-22.04

--- a/Makefile
+++ b/Makefile
@@ -426,8 +426,7 @@ bumplicense:
 .PHONY: checkuncommitted
 CSV_FILE = operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
 checkuncommitted:
-	git diff --exit-code -I'^    createdAt: ' -- $(CSV_FILE)
-	git diff --exit-code -- ':!$(CSV_FILE)'
+	git diff --exit-code
 
 .PHONY: bumpall
 bumpall: bumplicense manifests
@@ -591,6 +590,7 @@ bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metada
 	cd operator/config/pods && $(KUSTOMIZE) edit set image controller=$(IMG)
 	cd operator/config/webhook/backend && $(KUSTOMIZE) edit set image controller=$(IMG)
 	cd operator && $(KUSTOMIZE) build config/default | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS) --extra-service-accounts "controller,perouter" --package openperouter-operator
+	hack/restore-csv-timestamp.sh $(CSV_FILE)
 	cd operator && $(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-build

--- a/hack/restore-csv-timestamp.sh
+++ b/hack/restore-csv-timestamp.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+# restore-csv-timestamp.sh
+# Restores the committed createdAt timestamp in the CSV file if it's the only change.
+# This prevents spurious diffs when operator-sdk regenerates the bundle.
+
+CSV_FILE="${1:-}"
+
+if [ ! -f "$CSV_FILE" ]; then
+    echo "Error: CSV file not found: $CSV_FILE" >&2
+    exit 1
+fi
+
+if git diff --quiet HEAD -- "$CSV_FILE"; then
+    exit 0
+fi
+
+if ! git diff --exit-code -I'^    createdAt: ' HEAD -- "$CSV_FILE" >/dev/null 2>&1; then
+    exit 0
+fi
+
+echo "Restoring createdAt timestamp from HEAD in $CSV_FILE"
+git restore --source=HEAD --worktree "$CSV_FILE"


### PR DESCRIPTION
operator-sdk regenerates the createdAt annotation with the current timestamp on every `make bundle` run, causing spurious diffs and merge conflicts. Restore the committed timestamp after generation so only real content changes produce a diff, and remove the workarounds in the Makefile and CI that were hiding the problem.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
