### PR TITLE
Move errors to errors

### DIFF
--- a/internal/controller/routerconfiguration/frr.go
+++ b/internal/controller/routerconfiguration/frr.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 
 	"github.com/openperouter/openperouter/internal/conversion"
+	openpeerrors "github.com/openperouter/openperouter/internal/errors"
 	"github.com/openperouter/openperouter/internal/frr"
 )
 
@@ -23,7 +24,7 @@ type frrConfigData struct {
 func configureFRR(ctx context.Context, data frrConfigData) error {
 	slog.DebugContext(ctx, "reloading FRR config", "config", data)
 	frrConfig, err := conversion.APItoFRR(data.APIConfigData, data.nodeIndex, data.logLevel)
-	emptyConfig := conversion.FRREmptyConfigError("")
+	emptyConfig := openpeerrors.FRREmptyConfig("")
 	if errors.As(err, &emptyConfig) {
 		slog.InfoContext(ctx, "reloading FRR config", "empty config", data, "event", "cleaning the frr configuration")
 		frrConfig = frr.Config{}

--- a/internal/controller/routerconfiguration/host_config.go
+++ b/internal/controller/routerconfiguration/host_config.go
@@ -161,10 +161,3 @@ func configureInterfaces(ctx context.Context, config interfacesConfiguration) er
 	}
 	return errors.Join(resourceErrors...)
 }
-
-// nonRecoverableHostError tells whether the router pod
-// should be restarted instead of being reconfigured.
-func nonRecoverableHostError(e error) bool {
-	underlayExistsError := hostnetwork.UnderlayExistsError("")
-	return errors.As(e, &underlayExistsError)
-}

--- a/internal/controller/routerconfiguration/static_configuration_controller.go
+++ b/internal/controller/routerconfiguration/static_configuration_controller.go
@@ -79,7 +79,7 @@ func (r *StaticConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	for _, f := range openpeerrors.CollectFailures(err) {
 		logger.Warn("resource skipped", "kind", f.Kind, "name", f.Name, "reason", f.Reason, "message", f.Message)
 	}
-	if nonRecoverableHostError(err) {
+	if openpeerrors.NonRecoverableHost(err) {
 		logger.Error("non recoverable error", "error", err)
 		if err := router.HandleNonRecoverableError(ctx); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to handle non recoverable error: %w", err)

--- a/internal/controller/routerconfiguration/underlay_vni_controller.go
+++ b/internal/controller/routerconfiguration/underlay_vni_controller.go
@@ -90,7 +90,7 @@ func (r *PERouterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	// Best-effort status write: non-recoverable errors must never requeue,
 	// so we ignore any status update failure here.
-	if nonRecoverableHostError(err) {
+	if openpeerrors.NonRecoverableHost(err) {
 		_ = r.reconcileNodeStatus(ctx, err)
 		return ctrl.Result{}, nil
 	}
@@ -150,7 +150,7 @@ func (r *PERouterReconciler) reconcile(ctx context.Context, logger *slog.Logger)
 	}
 
 	err = Reconcile(ctx, config, nodeIndex, r.LogLevel, r.FRRConfigPath, targetNS, updater, configureInterfaces)
-	if nonRecoverableHostError(err) {
+	if openpeerrors.NonRecoverableHost(err) {
 		logger.Error("non recoverable error", "error", err)
 		if err := router.HandleNonRecoverableError(ctx); err != nil {
 			slog.Error("failed to handle non recoverable error", "error", err)

--- a/internal/conversion/frr_conversion.go
+++ b/internal/conversion/frr_conversion.go
@@ -10,17 +10,12 @@ import (
 	"sort"
 
 	"github.com/openperouter/openperouter/api/v1alpha1"
+	openpeerrors "github.com/openperouter/openperouter/internal/errors"
 	"github.com/openperouter/openperouter/internal/frr"
 	"github.com/openperouter/openperouter/internal/ipam"
 	"github.com/openperouter/openperouter/internal/ipfamily"
 	"k8s.io/utils/ptr"
 )
-
-type FRREmptyConfigError string
-
-func (e FRREmptyConfigError) Error() string {
-	return string(e)
-}
 
 type L3VNIOption func(*frr.L3VNIConfig) error
 
@@ -61,7 +56,7 @@ func APItoFRR(config APIConfigData, nodeIndex int, logLevel string) (frr.Config,
 	}
 
 	if len(config.Underlays) == 0 {
-		return frr.Config{}, FRREmptyConfigError("no underlays provided")
+		return frr.Config{}, openpeerrors.FRREmptyConfig("no underlays provided")
 	}
 
 	underlay := config.Underlays[0]

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -52,6 +52,23 @@ func HasUnderlayFailure(err error) bool {
 	return false
 }
 
+type UnderlayExists string
+
+func (e UnderlayExists) Error() string {
+	return string(e)
+}
+
+func NonRecoverableHost(e error) bool {
+	underlayExistsError := UnderlayExists("")
+	return errors.As(e, &underlayExistsError)
+}
+
+type FRREmptyConfig string
+
+func (e FRREmptyConfig) Error() string {
+	return string(e)
+}
+
 // unwrapAll flattens a (possibly nested) error tree into its leaf errors.
 // It handles both errors.Join trees (Unwrap() []error) and single-wrapped
 // errors (Unwrap() error), using an iterative stack to avoid recursion.

--- a/internal/hostnetwork/underlay.go
+++ b/internal/hostnetwork/underlay.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"slices"
 
+	openpeerrors "github.com/openperouter/openperouter/internal/errors"
 	"github.com/openperouter/openperouter/internal/netnamespace"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
@@ -56,7 +57,7 @@ func SetupUnderlay(ctx context.Context, params UnderlayParams) error {
 	}
 	for _, name := range existingIfaces {
 		if !slices.Contains(params.UnderlayInterfaces, name) {
-			return UnderlayExistsError(fmt.Sprintf(
+			return openpeerrors.UnderlayExists(fmt.Sprintf(
 				"existing underlay found: %s, new interfaces are %v", name, params.UnderlayInterfaces))
 		}
 	}
@@ -101,12 +102,6 @@ func SetupUnderlay(ctx context.Context, params UnderlayParams) error {
 	}
 
 	return nil
-}
-
-type UnderlayExistsError string
-
-func (e UnderlayExistsError) Error() string {
-	return string(e)
 }
 
 func ensureLoopback(ctx context.Context, ns netns.NsHandle, vtepIPs ...string) error {

--- a/internal/hostnetwork/underlay_test.go
+++ b/internal/hostnetwork/underlay_test.go
@@ -14,6 +14,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	openpeerrors "github.com/openperouter/openperouter/internal/errors"
 	"github.com/openperouter/openperouter/internal/netnamespace"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
@@ -117,7 +118,7 @@ var _ = Describe("Underlay configuration should work when", func() {
 		params.UnderlayInterfaces = []string{underlayTestInterfaceEdit}
 
 		err = SetupUnderlay(context.Background(), params)
-		u := UnderlayExistsError("")
+		u := openpeerrors.UnderlayExists("")
 		Expect(errors.As(err, &u)).To(BeTrue())
 	})
 


### PR DESCRIPTION
Move error types that are checked by the controller layer for control flow decisions into `internal/errors/` (openpeerrors):

- `UnderlayExistsError` (from `internal/hostnetwork/underlay.go`)
- `FRREmptyConfigError` (from `internal/conversion/frr_conversion.go`)
- `NonRecoverableHostError` (promoted from a private helper in `host_config.go`)

This eliminates the cross-package type dependency where upper layers import lower-level packages just for error types.

Closes: https://github.com/openperouter/openperouter/issues/488

**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:

Moves `UnderlayExistsError` and `FRREmptyConfigError` to the `openpeerrors` package. Both were defined in lower-level packages (`hostnetwork`, `conversion`) but checked by `internal/controller/routerconfiguration/` for control flow (retry vs skip vs restart). The private `nonRecoverableHostError` helper is promoted to a public `NonRecoverableHostError` function in the same package.

**Special notes for your reviewer**:

Pure refactor, no behavior change. Split into two commits: one per error type moved.

**Release note**:

```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.