### PR TITLE
Enable ipv6 vteps

### DIFF
--- a/API-DOCS.md
+++ b/API-DOCS.md
@@ -189,6 +189,7 @@ _Appears in:_
 | `vrf` _string_ | vrf is the name of the linux VRF to be used inside the PERouter namespace.<br />The field is optional, if not set it the name of the VNI instance will be used. |  | MaxLength: 15 <br />Pattern: `^[a-zA-Z][a-zA-Z0-9_-]*$` <br />Optional: \{\} <br /> |
 | `vni` _integer_ | vni is the VXLan VNI to be used |  | Maximum: 1.6777215e+07 <br />Minimum: 1 <br />Required: \{\} <br /> |
 | `vxlanport` _integer_ | vxlanport is the port to be used for VXLan encapsulation. | 4789 | Optional: \{\} <br /> |
+| `underlayAddressFamily` _string_ | underlayAddressFamily selects which VTEP address family to use for this VNI's<br />VXLAN interface. When omitted, defaults to the available family in the underlay<br />(IPv4 preferred in dual-stack). |  | Enum: [ipv4 ipv6] <br />Optional: \{\} <br /> |
 | `hostmaster` _[HostMaster](#hostmaster)_ | hostmaster is the interface on the host the veth should be enslaved to.<br />If not set, the host veth will not be enslaved to any interface and it must be<br />enslaved manually (or by some other means). This is useful if another controller<br />is leveraging the host interface for the VNI. |  | Optional: \{\} <br /> |
 | `l2gatewayips` _string array_ | l2gatewayips is a list of IP addresses in CIDR notation to be used for the L2 gateway. When this is set, the<br />bridge the veths are enslaved to will be configured with these IP addresses, effectively<br />acting as a distributed gateway for the VNI. This allows for dual-stack (IPv4 and IPv6) support.<br />Maximum of 2 addresses are allowed. If 2 addresses are provided, one must be IPv4 and one must be IPv6. |  | MaxItems: 2 <br />Optional: \{\} <br /> |
 
@@ -293,6 +294,7 @@ _Appears in:_
 | `vrf` _string_ | vrf is the name of the linux VRF to be used inside the PERouter namespace. |  | MaxLength: 15 <br />MinLength: 1 <br />Pattern: `^[a-zA-Z][a-zA-Z0-9_-]*$` <br />Required: \{\} <br /> |
 | `vni` _integer_ | vni is the VXLan VNI to be used |  | Maximum: 1.6777215e+07 <br />Minimum: 1 <br />Required: \{\} <br /> |
 | `vxlanport` _integer_ | vxlanport is the port to be used for VXLan encapsulation. | 4789 | Optional: \{\} <br /> |
+| `underlayAddressFamily` _string_ | underlayAddressFamily selects which VTEP address family to use for this VNI's<br />VXLAN interface. When omitted, defaults to the available family in the underlay<br />(IPv4 preferred in dual-stack). |  | Enum: [ipv4 ipv6] <br />Optional: \{\} <br /> |
 | `hostsession` _[HostSession](#hostsession)_ | hostsession is the configuration for the host session. |  | Optional: \{\} <br /> |
 | `exportRTs` _[RouteTarget](#routetarget) array_ | exportRTs are the Route Targets to be used for exporting routes.<br />RouteTarget defines a BGP Extended Community for route filtering. |  | MaxItems: 100 <br />MaxLength: 21 <br />Optional: \{\} <br /> |
 | `importRTs` _[RouteTarget](#routetarget) array_ | importRTs are the Route Targets to be used for importing routes.<br />RouteTarget defines a BGP Extended Community for route filtering. |  | MaxItems: 100 <br />MaxLength: 21 <br />Optional: \{\} <br /> |
@@ -519,7 +521,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `cidrs` _string array_ | cidrs is a list of CIDRs to be used to assign IPs to the local tunnel endpoint on<br />each node. A loopback interface will be created with IPs derived from<br />these CIDRs. Exactly one IPv4 CIDR is required, and an optional IPv6<br />CIDR may also be specified for dual-stack operation. |  | MaxItems: 2 <br />MinItems: 1 <br />Required: \{\} <br /> |
+| `cidrs` _string array_ | cidrs is a list of CIDRs to be used to assign IPs to the local tunnel endpoint on<br />each node. A loopback interface will be created with IPs derived from<br />these CIDRs. At least one IPv4 or IPv6 CIDR is required. At most one of each family may be specified. |  | MaxItems: 2 <br />MinItems: 1 <br />Required: \{\} <br /> |
 
 
 #### Underlay

--- a/api/v1alpha1/l2vni_types.go
+++ b/api/v1alpha1/l2vni_types.go
@@ -51,6 +51,13 @@ type L2VNISpec struct {
 	// +optional
 	VXLanPort *int32 `json:"vxlanport,omitempty"`
 
+	// underlayAddressFamily selects which VTEP address family to use for this VNI's
+	// VXLAN interface. When omitted, defaults to the available family in the underlay
+	// (IPv4 preferred in dual-stack).
+	// +kubebuilder:validation:Enum=ipv4;ipv6
+	// +optional
+	UnderlayAddressFamily *string `json:"underlayAddressFamily,omitempty"`
+
 	// hostmaster is the interface on the host the veth should be enslaved to.
 	// If not set, the host veth will not be enslaved to any interface and it must be
 	// enslaved manually (or by some other means). This is useful if another controller

--- a/api/v1alpha1/l3vni_types.go
+++ b/api/v1alpha1/l3vni_types.go
@@ -47,6 +47,13 @@ type L3VNISpec struct {
 	// +optional
 	VXLanPort *int32 `json:"vxlanport,omitempty"`
 
+	// underlayAddressFamily selects which VTEP address family to use for this VNI's
+	// VXLAN interface. When omitted, defaults to the available family in the underlay
+	// (IPv4 preferred in dual-stack).
+	// +kubebuilder:validation:Enum=ipv4;ipv6
+	// +optional
+	UnderlayAddressFamily *string `json:"underlayAddressFamily,omitempty"`
+
 	// hostsession is the configuration for the host session.
 	// +optional
 	HostSession *HostSession `json:"hostsession,omitempty"`

--- a/api/v1alpha1/underlay_types.go
+++ b/api/v1alpha1/underlay_types.go
@@ -98,12 +98,11 @@ type GracefulRestartConfig struct {
 type TunnelEndpointConfig struct {
 	// cidrs is a list of CIDRs to be used to assign IPs to the local tunnel endpoint on
 	// each node. A loopback interface will be created with IPs derived from
-	// these CIDRs. Exactly one IPv4 CIDR is required, and an optional IPv6
-	// CIDR may also be specified for dual-stack operation.
+	// these CIDRs. At least one IPv4 or IPv6 CIDR is required. At most one of each family may be specified.
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=2
 	// +kubebuilder:validation:XValidation:rule="self.all(c, isCIDR(c))",message="all entries must be valid CIDRs"
-	// +kubebuilder:validation:XValidation:rule="self.filter(c, isCIDR(c) && cidr(c).ip().family() == 4).size() == 1",message="exactly one IPv4 CIDR is required"
+	// +kubebuilder:validation:XValidation:rule="self.filter(c, isCIDR(c) && cidr(c).ip().family() == 4).size() <= 1",message="at most one IPv4 CIDR is allowed"
 	// +kubebuilder:validation:XValidation:rule="self.filter(c, isCIDR(c) && cidr(c).ip().family() == 6).size() <= 1",message="at most one IPv6 CIDR is allowed"
 	// +listType=atomic
 	// +required

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -247,6 +247,11 @@ func (in *L2VNISpec) DeepCopyInto(out *L2VNISpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.UnderlayAddressFamily != nil {
+		in, out := &in.UnderlayAddressFamily, &out.UnderlayAddressFamily
+		*out = new(string)
+		**out = **in
+	}
 	if in.HostMaster != nil {
 		in, out := &in.HostMaster, &out.HostMaster
 		*out = new(HostMaster)
@@ -457,6 +462,11 @@ func (in *L3VNISpec) DeepCopyInto(out *L3VNISpec) {
 	if in.VXLanPort != nil {
 		in, out := &in.VXLanPort, &out.VXLanPort
 		*out = new(int32)
+		**out = **in
+	}
+	if in.UnderlayAddressFamily != nil {
+		in, out := &in.UnderlayAddressFamily, &out.UnderlayAddressFamily
+		*out = new(string)
 		**out = **in
 	}
 	if in.HostSession != nil {

--- a/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_l2vnis.yaml
+++ b/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_l2vnis.yaml
@@ -166,6 +166,15 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              underlayAddressFamily:
+                description: |-
+                  underlayAddressFamily selects which VTEP address family to use for this VNI's
+                  VXLAN interface. When omitted, defaults to the available family in the underlay
+                  (IPv4 preferred in dual-stack).
+                enum:
+                - ipv4
+                - ipv6
+                type: string
               vni:
                 description: vni is the VXLan VNI to be used
                 format: int32

--- a/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_l3vnis.yaml
+++ b/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_l3vnis.yaml
@@ -175,6 +175,15 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              underlayAddressFamily:
+                description: |-
+                  underlayAddressFamily selects which VTEP address family to use for this VNI's
+                  VXLAN interface. When omitted, defaults to the available family in the underlay
+                  (IPv4 preferred in dual-stack).
+                enum:
+                - ipv4
+                - ipv6
+                type: string
               vni:
                 description: vni is the VXLan VNI to be used
                 format: int32

--- a/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_underlays.yaml
+++ b/charts/openperouter/charts/crds/templates/openpe.openperouter.github.io_underlays.yaml
@@ -362,8 +362,7 @@ spec:
                     description: |-
                       cidrs is a list of CIDRs to be used to assign IPs to the local tunnel endpoint on
                       each node. A loopback interface will be created with IPs derived from
-                      these CIDRs. Exactly one IPv4 CIDR is required, and an optional IPv6
-                      CIDR may also be specified for dual-stack operation.
+                      these CIDRs. At least one IPv4 or IPv6 CIDR is required. At most one of each family may be specified.
                     items:
                       type: string
                     maxItems: 2
@@ -373,9 +372,9 @@ spec:
                     x-kubernetes-validations:
                     - message: all entries must be valid CIDRs
                       rule: self.all(c, isCIDR(c))
-                    - message: exactly one IPv4 CIDR is required
+                    - message: at most one IPv4 CIDR is allowed
                       rule: self.filter(c, isCIDR(c) && cidr(c).ip().family() == 4).size()
-                        == 1
+                        <= 1
                     - message: at most one IPv6 CIDR is allowed
                       rule: self.filter(c, isCIDR(c) && cidr(c).ip().family() == 6).size()
                         <= 1

--- a/clab/leafA/setup.sh
+++ b/clab/leafA/setup.sh
@@ -40,3 +40,19 @@ ip link set vni200 type bridge_slave neigh_suppress on learning off
 ip link set vni200 up
 ip link set br200 up
 
+# IPv6 VTEP IP
+ip addr add fd00:64::1/128 dev lo
+
+# L3 VRF (no host leg -- used for IPv6 VTEP testing only)
+ip link add green type vrf table 1102
+
+ip link set green up
+ip link add br300 type bridge
+ip link set br300 master green addrgenmode none
+ip link set br300 addr aa:bb:cc:00:00:69
+ip link add vni300 type vxlan local fd00:64::1 dstport 4789 id 300 nolearning
+ip link set vni300 master br300 addrgenmode none
+ip link set vni300 type bridge_slave neigh_suppress on learning off
+ip link set vni300 up
+ip link set br300 up
+

--- a/clab/leafB/setup.sh
+++ b/clab/leafB/setup.sh
@@ -38,3 +38,19 @@ ip link set vni200 master br200 addrgenmode none
 ip link set vni200 type bridge_slave neigh_suppress on learning off
 ip link set vni200 up
 ip link set br200 up
+
+# IPv6 VTEP IP
+ip addr add fd00:64::2/128 dev lo
+
+# L3 VRF (no host leg -- used for IPv6 VTEP testing only)
+ip link add green type vrf table 1102
+
+ip link set green up
+ip link add br300 type bridge
+ip link set br300 master green addrgenmode none
+ip link set br300 addr aa:bb:cc:00:00:6a
+ip link add vni300 type vxlan local fd00:64::2 dstport 4789 id 300 nolearning
+ip link set vni300 master br300 addrgenmode none
+ip link set vni300 type bridge_slave neigh_suppress on learning off
+ip link set vni300 up
+ip link set br300 up

--- a/clab/singlecluster/leafkind1/frr.conf
+++ b/clab/singlecluster/leafkind1/frr.conf
@@ -1,0 +1,49 @@
+log file /etc/frr/frr.log debug
+ipv6 forwarding
+
+debug zebra events
+debug zebra vxlan
+debug zebra nht
+debug zebra kernel
+debug zebra rib
+debug zebra nexthop
+debug bgp neighbor-events
+debug bgp updates
+debug bgp keepalives
+debug bgp nht
+debug bgp zebra
+debug bfd network
+debug bfd peer
+debug bfd zebra
+
+router bgp 64512
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ no bgp default ipv4-unicast
+
+ neighbor 192.168.1.4 remote-as 64612
+
+ neighbor kind-nodes peer-group
+ neighbor kind-nodes remote-as 64514
+
+ bgp listen range 192.168.11.0/24 peer-group kind-nodes
+ bgp listen range 2001:db8:11::/64 peer-group kind-nodes
+
+ !
+ address-family ipv4 unicast
+  neighbor kind-nodes activate
+  neighbor 192.168.1.4 activate
+ exit-address-family
+ !
+ address-family ipv6 unicast
+  neighbor kind-nodes activate
+ exit-address-family
+ !
+ address-family l2vpn evpn
+  neighbor 192.168.1.4 activate
+  neighbor kind-nodes activate
+  advertise-all-vni
+  advertise-svi-ip
+ exit-address-family
+exit
+!

--- a/clab/singlecluster/leafkind2/frr.conf
+++ b/clab/singlecluster/leafkind2/frr.conf
@@ -1,0 +1,49 @@
+log file /etc/frr/frr.log debug
+ipv6 forwarding
+
+debug zebra events
+debug zebra vxlan
+debug zebra nht
+debug zebra kernel
+debug zebra rib
+debug zebra nexthop
+debug bgp neighbor-events
+debug bgp updates
+debug bgp keepalives
+debug bgp nht
+debug bgp zebra
+debug bfd network
+debug bfd peer
+debug bfd zebra
+
+router bgp 64513
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ no bgp default ipv4-unicast
+
+ neighbor 192.168.1.6 remote-as 64612
+
+ neighbor kind-nodes peer-group
+ neighbor kind-nodes remote-as 64514
+
+ bgp listen range 192.168.12.0/24 peer-group kind-nodes
+ bgp listen range 2001:db8:12::/64 peer-group kind-nodes
+
+ !
+ address-family ipv4 unicast
+  neighbor kind-nodes activate
+  neighbor 192.168.1.6 activate
+ exit-address-family
+ !
+ address-family ipv6 unicast
+  neighbor kind-nodes activate
+ exit-address-family
+ !
+ address-family l2vpn evpn
+  neighbor 192.168.1.6 activate
+  neighbor kind-nodes activate
+  advertise-all-vni
+  advertise-svi-ip
+ exit-address-family
+exit
+!

--- a/clab/singlecluster/spine/frr.conf
+++ b/clab/singlecluster/spine/frr.conf
@@ -34,6 +34,13 @@ router bgp 64612
   neighbor 192.168.1.7 activate
  exit-address-family
  !
+ address-family ipv6 unicast
+  neighbor 192.168.1.1 activate
+  neighbor 192.168.1.3 activate
+  neighbor 192.168.1.5 activate
+  neighbor 192.168.1.7 activate
+ exit-address-family
+ !
  address-family l2vpn evpn
   neighbor 192.168.1.1 activate
   neighbor 192.168.1.3 activate

--- a/config/all-in-one/crio.yaml
+++ b/config/all-in-one/crio.yaml
@@ -175,6 +175,15 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              underlayAddressFamily:
+                description: |-
+                  underlayAddressFamily selects which VTEP address family to use for this VNI's
+                  VXLAN interface. When omitted, defaults to the available family in the underlay
+                  (IPv4 preferred in dual-stack).
+                enum:
+                - ipv4
+                - ipv6
+                type: string
               vni:
                 description: vni is the VXLan VNI to be used
                 format: int32
@@ -549,6 +558,15 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              underlayAddressFamily:
+                description: |-
+                  underlayAddressFamily selects which VTEP address family to use for this VNI's
+                  VXLAN interface. When omitted, defaults to the available family in the underlay
+                  (IPv4 preferred in dual-stack).
+                enum:
+                - ipv4
+                - ipv6
+                type: string
               vni:
                 description: vni is the VXLan VNI to be used
                 format: int32
@@ -1228,8 +1246,7 @@ spec:
                     description: |-
                       cidrs is a list of CIDRs to be used to assign IPs to the local tunnel endpoint on
                       each node. A loopback interface will be created with IPs derived from
-                      these CIDRs. Exactly one IPv4 CIDR is required, and an optional IPv6
-                      CIDR may also be specified for dual-stack operation.
+                      these CIDRs. At least one IPv4 or IPv6 CIDR is required. At most one of each family may be specified.
                     items:
                       type: string
                     maxItems: 2
@@ -1239,9 +1256,9 @@ spec:
                     x-kubernetes-validations:
                     - message: all entries must be valid CIDRs
                       rule: self.all(c, isCIDR(c))
-                    - message: exactly one IPv4 CIDR is required
+                    - message: at most one IPv4 CIDR is allowed
                       rule: self.filter(c, isCIDR(c) && cidr(c).ip().family() == 4).size()
-                        == 1
+                        <= 1
                     - message: at most one IPv6 CIDR is allowed
                       rule: self.filter(c, isCIDR(c) && cidr(c).ip().family() == 6).size()
                         <= 1

--- a/config/all-in-one/openpe.yaml
+++ b/config/all-in-one/openpe.yaml
@@ -175,6 +175,15 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              underlayAddressFamily:
+                description: |-
+                  underlayAddressFamily selects which VTEP address family to use for this VNI's
+                  VXLAN interface. When omitted, defaults to the available family in the underlay
+                  (IPv4 preferred in dual-stack).
+                enum:
+                - ipv4
+                - ipv6
+                type: string
               vni:
                 description: vni is the VXLan VNI to be used
                 format: int32
@@ -549,6 +558,15 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              underlayAddressFamily:
+                description: |-
+                  underlayAddressFamily selects which VTEP address family to use for this VNI's
+                  VXLAN interface. When omitted, defaults to the available family in the underlay
+                  (IPv4 preferred in dual-stack).
+                enum:
+                - ipv4
+                - ipv6
+                type: string
               vni:
                 description: vni is the VXLan VNI to be used
                 format: int32
@@ -1228,8 +1246,7 @@ spec:
                     description: |-
                       cidrs is a list of CIDRs to be used to assign IPs to the local tunnel endpoint on
                       each node. A loopback interface will be created with IPs derived from
-                      these CIDRs. Exactly one IPv4 CIDR is required, and an optional IPv6
-                      CIDR may also be specified for dual-stack operation.
+                      these CIDRs. At least one IPv4 or IPv6 CIDR is required. At most one of each family may be specified.
                     items:
                       type: string
                     maxItems: 2
@@ -1239,9 +1256,9 @@ spec:
                     x-kubernetes-validations:
                     - message: all entries must be valid CIDRs
                       rule: self.all(c, isCIDR(c))
-                    - message: exactly one IPv4 CIDR is required
+                    - message: at most one IPv4 CIDR is allowed
                       rule: self.filter(c, isCIDR(c) && cidr(c).ip().family() == 4).size()
-                        == 1
+                        <= 1
                     - message: at most one IPv6 CIDR is allowed
                       rule: self.filter(c, isCIDR(c) && cidr(c).ip().family() == 6).size()
                         <= 1

--- a/config/crd/bases/openpe.openperouter.github.io_l2vnis.yaml
+++ b/config/crd/bases/openpe.openperouter.github.io_l2vnis.yaml
@@ -166,6 +166,15 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              underlayAddressFamily:
+                description: |-
+                  underlayAddressFamily selects which VTEP address family to use for this VNI's
+                  VXLAN interface. When omitted, defaults to the available family in the underlay
+                  (IPv4 preferred in dual-stack).
+                enum:
+                - ipv4
+                - ipv6
+                type: string
               vni:
                 description: vni is the VXLan VNI to be used
                 format: int32

--- a/config/crd/bases/openpe.openperouter.github.io_l3vnis.yaml
+++ b/config/crd/bases/openpe.openperouter.github.io_l3vnis.yaml
@@ -175,6 +175,15 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              underlayAddressFamily:
+                description: |-
+                  underlayAddressFamily selects which VTEP address family to use for this VNI's
+                  VXLAN interface. When omitted, defaults to the available family in the underlay
+                  (IPv4 preferred in dual-stack).
+                enum:
+                - ipv4
+                - ipv6
+                type: string
               vni:
                 description: vni is the VXLan VNI to be used
                 format: int32

--- a/config/crd/bases/openpe.openperouter.github.io_underlays.yaml
+++ b/config/crd/bases/openpe.openperouter.github.io_underlays.yaml
@@ -362,8 +362,7 @@ spec:
                     description: |-
                       cidrs is a list of CIDRs to be used to assign IPs to the local tunnel endpoint on
                       each node. A loopback interface will be created with IPs derived from
-                      these CIDRs. Exactly one IPv4 CIDR is required, and an optional IPv6
-                      CIDR may also be specified for dual-stack operation.
+                      these CIDRs. At least one IPv4 or IPv6 CIDR is required. At most one of each family may be specified.
                     items:
                       type: string
                     maxItems: 2
@@ -373,9 +372,9 @@ spec:
                     x-kubernetes-validations:
                     - message: all entries must be valid CIDRs
                       rule: self.all(c, isCIDR(c))
-                    - message: exactly one IPv4 CIDR is required
+                    - message: at most one IPv4 CIDR is allowed
                       rule: self.filter(c, isCIDR(c) && cidr(c).ip().family() == 4).size()
-                        == 1
+                        <= 1
                     - message: at most one IPv6 CIDR is allowed
                       rule: self.filter(c, isCIDR(c) && cidr(c).ip().family() == 6).size()
                         <= 1

--- a/e2etests/pkg/infra/testdata/leafkind.tmpl
+++ b/e2etests/pkg/infra/testdata/leafkind.tmpl
@@ -1,4 +1,5 @@
 log file /etc/frr/frr.log debug
+ipv6 forwarding
 
 debug zebra events
 debug zebra vxlan

--- a/e2etests/pkg/ipfamily/ipfamily.go
+++ b/e2etests/pkg/ipfamily/ipfamily.go
@@ -83,6 +83,17 @@ func ForAddress(ip net.IP) Family {
 	return IPv4
 }
 
+// CIDRsForFamily returns all CIDRs matching the given address family.
+func CIDRsForFamily(cidrs []string, family Family) []string {
+	var res []string
+	for _, c := range cidrs {
+		if ForCIDRString(c) == family {
+			res = append(res, c)
+		}
+	}
+	return res
+}
+
 // ForService returns the address family of a given service.
 func ForService(svc *v1.Service) (Family, error) {
 	if len(svc.Spec.ClusterIPs) > 0 {

--- a/e2etests/pkg/openperouter/vtep.go
+++ b/e2etests/pkg/openperouter/vtep.go
@@ -15,43 +15,57 @@ import (
 
 const nodeIndexAnnotation = "openpe.io/nodeindex"
 
-func GetVtepIPv4ForNode(tunnelEndpoint *v1alpha1.TunnelEndpointConfig, node *corev1.Node) (string, error) {
-	if node.Annotations == nil ||
-		node.Annotations[nodeIndexAnnotation] == "" {
-		return "", fmt.Errorf("no index for node %s", node.Name)
-	}
-	nodeIndex, err := strconv.Atoi(node.Annotations[nodeIndexAnnotation])
+func GetVtepIPForNode(tunnelEndpoint *v1alpha1.TunnelEndpointConfig, node *corev1.Node, family ipfamily.Family) (string, error) {
+	nodeIndex, err := nodeIndexFromAnnotation(node)
 	if err != nil {
-		return "", fmt.Errorf("non int index %s for node %s", node.Annotations[nodeIndexAnnotation], node.Name)
+		return "", err
 	}
-
 	if tunnelEndpoint == nil {
 		return "", fmt.Errorf("invalid nil tunnel endpoint")
 	}
-	cidr := ""
-	for _, c := range tunnelEndpoint.CIDRs {
-		if ipfamily.ForCIDRString(c) != ipfamily.IPv4 {
-			continue
-		}
-		cidr = c
-		break
+
+	matching := ipfamily.CIDRsForFamily(tunnelEndpoint.CIDRs, family)
+	if len(matching) == 0 {
+		return "", fmt.Errorf("no %s CIDR found in %v", family, tunnelEndpoint.CIDRs)
 	}
-	if cidr == "" {
-		return "", fmt.Errorf("GetVtepIPv4ForNode: no IPv4 CIDR found in %v", tunnelEndpoint.CIDRs)
+	if len(matching) > 1 {
+		return "", fmt.Errorf("multiple %s CIDRs found in %v", family, tunnelEndpoint.CIDRs)
 	}
 
-	_, vtepCIDR, err := net.ParseCIDR(cidr)
+	_, vtepCIDR, err := net.ParseCIDR(matching[0])
 	if err != nil {
-		return "", fmt.Errorf("failed to parse cidr %s: %w", cidr, err)
+		return "", fmt.Errorf("failed to parse cidr %s: %w", matching[0], err)
 	}
 
 	ip, err := gocidr.Host(vtepCIDR, nodeIndex)
 	if err != nil {
-		return "", fmt.Errorf("failed to get index %d from cidr %s", nodeIndex, vtepCIDR)
+		return "", fmt.Errorf("failed to get index %d from cidr %s: %w", nodeIndex, vtepCIDR, err)
+	}
+
+	maskSize := 32
+	maskBits := 32
+	if family == ipfamily.IPv6 {
+		maskSize = 128
+		maskBits = 128
 	}
 	netip := net.IPNet{
 		IP:   ip,
-		Mask: net.CIDRMask(32, 32),
+		Mask: net.CIDRMask(maskSize, maskBits),
 	}
 	return netip.String(), nil
+}
+
+func GetVtepIPv4ForNode(tunnelEndpoint *v1alpha1.TunnelEndpointConfig, node *corev1.Node) (string, error) {
+	return GetVtepIPForNode(tunnelEndpoint, node, ipfamily.IPv4)
+}
+
+func nodeIndexFromAnnotation(node *corev1.Node) (int, error) {
+	if node.Annotations == nil || node.Annotations[nodeIndexAnnotation] == "" {
+		return 0, fmt.Errorf("no index for node %s", node.Name)
+	}
+	nodeIndex, err := strconv.Atoi(node.Annotations[nodeIndexAnnotation])
+	if err != nil {
+		return 0, fmt.Errorf("non int index %s for node %s: %w", node.Annotations[nodeIndexAnnotation], node.Name, err)
+	}
+	return nodeIndex, nil
 }

--- a/e2etests/tests/ipv6_vtep.go
+++ b/e2etests/tests/ipv6_vtep.go
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package tests
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openperouter/openperouter/api/v1alpha1"
+	"github.com/openperouter/openperouter/e2etests/pkg/config"
+	"github.com/openperouter/openperouter/e2etests/pkg/executor"
+	"github.com/openperouter/openperouter/e2etests/pkg/infra"
+	"github.com/openperouter/openperouter/e2etests/pkg/k8s"
+	"github.com/openperouter/openperouter/e2etests/pkg/k8sclient"
+	"github.com/openperouter/openperouter/e2etests/pkg/networklayerprotocol"
+	"github.com/openperouter/openperouter/e2etests/pkg/openperouter"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
+)
+
+var _ = Describe("IPv6 VTEP", Ordered, func() {
+	const (
+		testNamespace             = "test-ipv6-vtep"
+		linuxBridgeHostAttachment = "linux-bridge"
+	)
+
+	var (
+		cs      clientset.Interface
+		routers openperouter.Routers
+		nodes   []corev1.Node
+	)
+
+	dualStackUnderlay := v1alpha1.Underlay{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "underlay",
+			Namespace: openperouter.Namespace,
+		},
+		Spec: v1alpha1.UnderlaySpec{
+			ASN:  64514,
+			Nics: []string{"toswitch1", "toswitch2"},
+			Neighbors: []v1alpha1.Neighbor{
+				{
+					ASN:     ptr.To(int64(64512)),
+					Address: ptr.To("192.168.11.2"),
+				},
+				{
+					ASN:     ptr.To(int64(64513)),
+					Address: ptr.To("192.168.12.2"),
+				},
+			},
+			TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+				CIDRs: []string{"100.65.0.0/24", "fd00:64::/120"},
+			},
+		},
+	}
+
+	l3VniV4 := v1alpha1.L3VNI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "red-v4",
+			Namespace: openperouter.Namespace,
+		},
+		Spec: v1alpha1.L3VNISpec{
+			VRF: "red",
+			VNI: 100,
+		},
+	}
+
+	l2VniV4 := v1alpha1.L2VNI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "red-v4-110",
+			Namespace: openperouter.Namespace,
+		},
+		Spec: v1alpha1.L2VNISpec{
+			VRF:          ptr.To("red"),
+			VNI:          110,
+			L2GatewayIPs: []string{"192.171.24.1/24"},
+			HostMaster: &v1alpha1.HostMaster{
+				Type: linuxBridgeHostAttachment,
+				LinuxBridge: &v1alpha1.LinuxBridgeConfig{
+					AutoCreate: ptr.To(true),
+				},
+			},
+		},
+	}
+
+	l3VniV6 := v1alpha1.L3VNI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "green-v6",
+			Namespace: openperouter.Namespace,
+		},
+		Spec: v1alpha1.L3VNISpec{
+			VRF:                   "green",
+			VNI:                   300,
+			UnderlayAddressFamily: ptr.To("ipv6"),
+		},
+	}
+
+	l2VniV6 := v1alpha1.L2VNI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "green-v6-310",
+			Namespace: openperouter.Namespace,
+		},
+		Spec: v1alpha1.L2VNISpec{
+			VRF:                   ptr.To("green"),
+			VNI:                   310,
+			UnderlayAddressFamily: ptr.To("ipv6"),
+			L2GatewayIPs:          []string{"192.173.24.1/24"},
+			HostMaster: &v1alpha1.HostMaster{
+				Type: linuxBridgeHostAttachment,
+				LinuxBridge: &v1alpha1.LinuxBridgeConfig{
+					AutoCreate: ptr.To(true),
+				},
+			},
+		},
+	}
+
+	BeforeAll(func() {
+		err := Updater.CleanAll()
+		Expect(err).NotTo(HaveOccurred())
+
+		cs = k8sclient.New()
+		routers, err = openperouter.Get(cs, HostMode)
+		Expect(err).NotTo(HaveOccurred())
+		routers.Dump(ginkgo.GinkgoWriter)
+
+		err = Updater.Update(config.Resources{
+			Underlays: []v1alpha1.Underlay{dualStackUnderlay},
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterAll(func() {
+		err := Updater.CleanAll()
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(func() error {
+			routers, err := openperouter.Get(cs, HostMode)
+			if err != nil {
+				return err
+			}
+			return openperouter.AreReady(routers)
+		}, 2*time.Minute, time.Second).ShouldNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		dumpIfFails(cs, testNamespace)
+		Expect(infra.LeafAConfig.Reset()).To(Succeed())
+		Expect(infra.LeafBConfig.Reset()).To(Succeed())
+		err := Updater.CleanButUnderlay()
+		Expect(err).NotTo(HaveOccurred())
+		err = k8s.DeleteNamespace(cs, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	BeforeEach(func() {
+		var err error
+		nodes, err = k8s.GetNodes(cs)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("setting redistribute connected on leaves")
+		Expect(infra.LeafAConfig.RedistributeConnected()).To(Succeed())
+		Expect(infra.LeafBConfig.RedistributeConnected()).To(Succeed())
+
+		By("configuring leafkind switches with IPv6 unicast address family")
+		leafKindConfig := infra.LeafKindConfiguration{
+			BGPAddressFamilies: []networklayerprotocol.NLP{
+				{AFI: networklayerprotocol.IPv4, SAFI: networklayerprotocol.Unicast},
+				{AFI: networklayerprotocol.IPv6, SAFI: networklayerprotocol.Unicast},
+			},
+		}
+		Expect(infra.LeafKind1Config.UpdateConfig(nodes, leafKindConfig)).To(Succeed())
+		Expect(infra.LeafKind2Config.UpdateConfig(nodes, leafKindConfig)).To(Succeed())
+	})
+
+	setupOverlay := func(l3vnis []v1alpha1.L3VNI, l2vnis []v1alpha1.L2VNI) {
+		GinkgoHelper()
+
+		err := Updater.Update(config.Resources{
+			L3VNIs: l3vnis,
+			L2VNIs: l2vnis,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = k8s.CreateNamespace(cs, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	waitForBGPSessions := func() {
+		GinkgoHelper()
+		leafExec := executor.ForContainer(infra.KindLeaf)
+		for _, node := range nodes {
+			neighborIP, err := infra.NeighborIP(infra.KindLeaf, node.Name)
+			Expect(err).NotTo(HaveOccurred())
+			validateSessionWithNeighbor(
+				leafExec,
+				validationParameters{
+					fromName:    infra.KindLeaf,
+					toName:      node.Name,
+					neighborIP:  neighborIP,
+					established: Established,
+				},
+			)
+		}
+	}
+
+	createPodsOnVNI := func(l2vni v1alpha1.L2VNI, firstName, secondName string, firstPodIPs, secondPodIPs []string) (*corev1.Pod, *corev1.Pod) {
+		GinkgoHelper()
+
+		nadMaster := fmt.Sprintf("br-hs-%d", l2vni.Spec.VNI)
+		nad, err := k8s.CreateMacvlanNad(fmt.Sprintf("%d", l2vni.Spec.VNI), testNamespace, nadMaster, l2vni.Spec.L2GatewayIPs)
+		Expect(err).NotTo(HaveOccurred())
+
+		firstPod, err := k8s.CreateAgnhostPod(cs, firstName, testNamespace,
+			k8s.WithNad(nad.Name, testNamespace, firstPodIPs),
+			k8s.OnNode(nodes[0].Name))
+		Expect(err).NotTo(HaveOccurred())
+		secondPod, err := k8s.CreateAgnhostPod(cs, secondName, testNamespace,
+			k8s.WithNad(nad.Name, testNamespace, secondPodIPs),
+			k8s.OnNode(nodes[1].Name))
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(removeGatewayFromPod(firstPod)).To(Succeed())
+		Expect(removeGatewayFromPod(secondPod)).To(Succeed())
+
+		return firstPod, secondPod
+	}
+
+	verifyPodToPod := func(l2vni v1alpha1.L2VNI, firstPodIPs, secondPodIPs []string) {
+		GinkgoHelper()
+
+		firstPod, secondPod := createPodsOnVNI(l2vni, "pod1", "pod2", firstPodIPs, secondPodIPs)
+
+		waitForBGPSessions()
+
+		firstPodExec := executor.ForPod(firstPod.Namespace, firstPod.Name, "agnhost")
+		secondPodExec := executor.ForPod(secondPod.Namespace, secondPod.Name, "agnhost")
+
+		By(fmt.Sprintf("trying to hit %s from %s", discardAddressLength(secondPodIPs[0]), discardAddressLength(firstPodIPs[0])))
+		checkPodIsReachable(firstPodExec, discardAddressLength(firstPodIPs[0]), discardAddressLength(secondPodIPs[0]))
+
+		By("checking reachability from secondPod to firstPod")
+		checkPodIsReachable(secondPodExec, discardAddressLength(secondPodIPs[0]), discardAddressLength(firstPodIPs[0]))
+	}
+
+	Context("should establish pod-to-pod connectivity over L2VNI", func() {
+		It("with IPv4 VTEP", func() {
+			setupOverlay([]v1alpha1.L3VNI{l3VniV4}, []v1alpha1.L2VNI{l2VniV4})
+			verifyPodToPod(l2VniV4, []string{"192.171.24.2/24"}, []string{"192.171.24.3/24"})
+		})
+
+		It("with IPv6 VTEP", func() {
+			setupOverlay([]v1alpha1.L3VNI{l3VniV6}, []v1alpha1.L2VNI{l2VniV6})
+			verifyPodToPod(l2VniV6, []string{"192.173.24.2/24"}, []string{"192.173.24.3/24"})
+		})
+	})
+
+	It("should not affect IPv4 VNI traffic when IPv6 VNI is active", func() {
+		setupOverlay(
+			[]v1alpha1.L3VNI{l3VniV4, l3VniV6},
+			[]v1alpha1.L2VNI{l2VniV4, l2VniV6},
+		)
+
+		v4FirstPodIPs := []string{"192.171.24.2/24"}
+		v4SecondPodIPs := []string{"192.171.24.3/24"}
+		v6FirstPodIPs := []string{"192.173.24.2/24"}
+		v6SecondPodIPs := []string{"192.173.24.3/24"}
+
+		By("creating pods for IPv4 VTEP VNI")
+		v4Pod1, v4Pod2 := createPodsOnVNI(l2VniV4, "v4-pod1", "v4-pod2", v4FirstPodIPs, v4SecondPodIPs)
+
+		By("creating pods for IPv6 VTEP VNI")
+		v6Pod1, v6Pod2 := createPodsOnVNI(l2VniV6, "v6-pod1", "v6-pod2", v6FirstPodIPs, v6SecondPodIPs)
+
+		waitForBGPSessions()
+
+		By("verifying IPv4 VTEP pod-to-pod reachability")
+		v4Pod1Exec := executor.ForPod(v4Pod1.Namespace, v4Pod1.Name, "agnhost")
+		v4Pod2Exec := executor.ForPod(v4Pod2.Namespace, v4Pod2.Name, "agnhost")
+		checkPodIsReachable(v4Pod1Exec, discardAddressLength(v4FirstPodIPs[0]), discardAddressLength(v4SecondPodIPs[0]))
+		checkPodIsReachable(v4Pod2Exec, discardAddressLength(v4SecondPodIPs[0]), discardAddressLength(v4FirstPodIPs[0]))
+
+		By("verifying IPv6 VTEP pod-to-pod reachability")
+		v6Pod1Exec := executor.ForPod(v6Pod1.Namespace, v6Pod1.Name, "agnhost")
+		v6Pod2Exec := executor.ForPod(v6Pod2.Namespace, v6Pod2.Name, "agnhost")
+		checkPodIsReachable(v6Pod1Exec, discardAddressLength(v6FirstPodIPs[0]), discardAddressLength(v6SecondPodIPs[0]))
+		checkPodIsReachable(v6Pod2Exec, discardAddressLength(v6SecondPodIPs[0]), discardAddressLength(v6FirstPodIPs[0]))
+
+		By("verifying IPv4 VTEP pod-to-host reachability")
+		hostAExec := executor.ForContainer("clab-kind-hostA_red")
+		checkPodIsReachable(v4Pod1Exec, discardAddressLength(v4FirstPodIPs[0]), infra.HostARedIPv4)
+		checkPodIsReachable(v4Pod1Exec, discardAddressLength(v4FirstPodIPs[0]), infra.HostBRedIPv4)
+		checkPodIsReachable(hostAExec, infra.HostARedIPv4, discardAddressLength(v4FirstPodIPs[0]))
+	})
+})

--- a/internal/conversion/frr_conversion.go
+++ b/internal/conversion/frr_conversion.go
@@ -82,6 +82,7 @@ func APItoFRR(config APIConfigData, nodeIndex int, logLevel string) (frr.Config,
 		config.L2VNIs,
 		config.L3VNIs,
 		config.L3Passthrough,
+		underlay.Spec.TunnelEndpoint,
 	)
 	if err != nil {
 		return frr.Config{}, err
@@ -121,10 +122,11 @@ func APItoFRR(config APIConfigData, nodeIndex int, logLevel string) (frr.Config,
 
 func neighborsToFRR(apiNeighbors []v1alpha1.Neighbor,
 	l2vnis []v1alpha1.L2VNI, l3vnis []v1alpha1.L3VNI, l3passthroughs []v1alpha1.L3Passthrough,
+	tunnelEndpoint *v1alpha1.TunnelEndpointConfig,
 ) ([]frr.NeighborConfig, error) {
 	neighbors := make([]frr.NeighborConfig, 0, len(apiNeighbors))
 	for _, n := range apiNeighbors {
-		frrNeigh, err := neighborToFRR(n, l2vnis, l3vnis, l3passthroughs)
+		frrNeigh, err := neighborToFRR(n, l2vnis, l3vnis, l3passthroughs, tunnelEndpoint)
 		if err != nil {
 			return nil, fmt.Errorf("failed to translate underlay neighbor to frr, err: %w", err)
 		}
@@ -181,14 +183,20 @@ func tunnelEndpointToFRR(underlay v1alpha1.Underlay, nodeIndex int) (*frr.Tunnel
 		}
 		tunnelEndpoint.IPv6CIDR = ip.String()
 	}
-	if tunnelEndpoint.IPv4CIDR == "" {
-		return nil, fmt.Errorf("no IPv4 CIDR found after conversion from tunnel endpoint CIDRs: %v",
+	if tunnelEndpoint.IPv4CIDR == "" && tunnelEndpoint.IPv6CIDR == "" {
+		return nil, fmt.Errorf("no VTEP IP available after conversion from tunnel endpoint CIDRs: %v",
 			underlay.Spec.TunnelEndpoint.CIDRs)
 	}
 	return tunnelEndpoint, nil
 }
 
-func vniConfigsToFRR(l3vnis []v1alpha1.L3VNI, l2vnis []v1alpha1.L2VNI, routerID string, underlayASN int64, nodeIndex int) ([]frr.L3VNIConfig, error) {
+func vniConfigsToFRR(
+	l3vnis []v1alpha1.L3VNI,
+	l2vnis []v1alpha1.L2VNI,
+	routerID string,
+	underlayASN int64,
+	nodeIndex int,
+) ([]frr.L3VNIConfig, error) {
 	vrfsWithL2Gateway := vrfsWithL2Gateways(l2vnis)
 	configs := []frr.L3VNIConfig{}
 	for _, vni := range l3vnis {
@@ -365,6 +373,7 @@ func convertRTsToSliceOfStrings(routeTargets []v1alpha1.RouteTarget) []string {
 
 func neighborToFRR(n v1alpha1.Neighbor,
 	l2vnis []v1alpha1.L2VNI, l3vnis []v1alpha1.L3VNI, l3passthroughs []v1alpha1.L3Passthrough,
+	tunnelEndpoint *v1alpha1.TunnelEndpointConfig,
 ) (*frr.NeighborConfig, error) {
 	asn, err := frr.NewPeerASN(n.ASN, n.Type)
 	if err != nil {
@@ -375,7 +384,7 @@ func neighborToFRR(n v1alpha1.Neighbor,
 
 	var nlps []networklayerprotocol.NLP
 	if len(n.AddressFamilies) == 0 {
-		nlps, err = defaultNLPsForNeighbor(n, l2vnis, l3vnis, l3passthroughs)
+		nlps, err = defaultNLPsForNeighbor(n, l2vnis, l3vnis, l3passthroughs, tunnelEndpoint)
 	} else {
 		nlps, err = nlpsForNeighbor(n)
 	}
@@ -504,6 +513,7 @@ func nlpsForNeighbor(n v1alpha1.Neighbor) ([]networklayerprotocol.NLP, error) {
 // - evpn if L2VNIs or L3VNIs are present
 func defaultNLPsForNeighbor(n v1alpha1.Neighbor,
 	l2vnis []v1alpha1.L2VNI, l3vnis []v1alpha1.L3VNI, l3passthroughs []v1alpha1.L3Passthrough,
+	tunnelEndpoint *v1alpha1.TunnelEndpointConfig,
 ) ([]networklayerprotocol.NLP, error) {
 	addIPv4Unicast := false
 	addIPv6Unicast := false
@@ -536,6 +546,17 @@ func defaultNLPsForNeighbor(n v1alpha1.Neighbor,
 	if len(l2vnis) > 0 || len(l3vnis) > 0 {
 		addIPv4Unicast = true
 		addEVPN = true
+	}
+
+	if tunnelEndpoint != nil {
+		for _, cidr := range tunnelEndpoint.CIDRs {
+			switch ipfamily.ForCIDRString(cidr) {
+			case ipfamily.IPv4:
+				addIPv4Unicast = true
+			case ipfamily.IPv6:
+				addIPv6Unicast = true
+			}
+		}
 	}
 
 	defaultNLPs := []networklayerprotocol.NLP{}
@@ -613,7 +634,11 @@ func vrfsWithL2Gateways(l2vnis []v1alpha1.L2VNI) map[string][]string {
 	res := make(map[string][]string)
 	for _, l2vni := range l2vnis {
 		if len(l2vni.Spec.L2GatewayIPs) > 0 {
-			res[*l2vni.Spec.VRF] = l2vni.Spec.L2GatewayIPs
+			vrf := l2vni.Name
+			if l2vni.Spec.VRF != nil {
+				vrf = *l2vni.Spec.VRF
+			}
+			res[vrf] = l2vni.Spec.L2GatewayIPs
 		}
 	}
 	return res

--- a/internal/conversion/frr_conversion_test.go
+++ b/internal/conversion/frr_conversion_test.go
@@ -1802,7 +1802,7 @@ func TestAPItoFRR(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:      "underlay with IPv6 tunnel endpoints only is not supported",
+			name:      "underlay with IPv6 tunnel endpoints only",
 			nodeIndex: 0,
 			underlays: []v1alpha1.Underlay{
 				{
@@ -1815,7 +1815,21 @@ func TestAPItoFRR(t *testing.T) {
 						},
 					}},
 			},
-			wantErr: true,
+			vnis:          []v1alpha1.L3VNI{},
+			l2vnis:        []v1alpha1.L2VNI{},
+			l3Passthrough: []v1alpha1.L3Passthrough{},
+			want: frr.Config{
+				Underlay: frr.UnderlayConfig{
+					Neighbors: []frr.NeighborConfig{},
+					TunnelEndpoint: &frr.TunnelEndpoint{
+						IPv6CIDR: "2001:db8:192:168::/128",
+					},
+					RouterID: "10.0.0.1",
+				},
+				VNIs:        []frr.L3VNIConfig{},
+				BFDProfiles: []frr.BFDProfile{},
+			},
+			wantErr: false,
 		},
 	}
 
@@ -2108,6 +2122,66 @@ func TestAPItoFRRGracefulRestart(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestTunnelEndpointToFRRIPv6Only(t *testing.T) {
+	const (
+		ipv6TestCIDR = "2001:db8::/64"
+		ipv6TestVTEP = "2001:db8::/128"
+	)
+
+	underlay := v1alpha1.Underlay{
+		Spec: v1alpha1.UnderlaySpec{
+			TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+				CIDRs: []string{ipv6TestCIDR},
+			},
+		},
+	}
+
+	got, err := tunnelEndpointToFRR(underlay, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil tunnel endpoint")
+	}
+	if got.IPv4CIDR != "" {
+		t.Errorf("IPv4CIDR = %q, want empty", got.IPv4CIDR)
+	}
+	if got.IPv6CIDR != ipv6TestVTEP {
+		t.Errorf("IPv6CIDR = %q, want %q", got.IPv6CIDR, ipv6TestVTEP)
+	}
+}
+
+func TestTunnelEndpointToFRRDualStack(t *testing.T) {
+	const (
+		ipv4TestCIDR = "10.0.0.0/24"
+		ipv4TestVTEP = "10.0.0.0/32"
+		ipv6TestCIDR = "2001:db8::/64"
+		ipv6TestVTEP = "2001:db8::/128"
+	)
+
+	underlay := v1alpha1.Underlay{
+		Spec: v1alpha1.UnderlaySpec{
+			TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+				CIDRs: []string{ipv4TestCIDR, ipv6TestCIDR},
+			},
+		},
+	}
+
+	got, err := tunnelEndpointToFRR(underlay, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil tunnel endpoint")
+	}
+	if got.IPv4CIDR != ipv4TestVTEP {
+		t.Errorf("IPv4CIDR = %q, want %q", got.IPv4CIDR, ipv4TestVTEP)
+	}
+	if got.IPv6CIDR != ipv6TestVTEP {
+		t.Errorf("IPv6CIDR = %q, want %q", got.IPv6CIDR, ipv6TestVTEP)
 	}
 }
 

--- a/internal/conversion/host_conversion.go
+++ b/internal/conversion/host_conversion.go
@@ -75,11 +75,15 @@ func APItoHostConfig(nodeIndex int, targetNS string, apiConfig APIConfigData) (H
 	res.Underlay.TunnelEndpoint = &underlayConfigTunnelEndpoint
 
 	for _, vni := range apiConfig.L3VNIs {
+		vtepIP, err := resolveVTEPIP(vni.Spec.UnderlayAddressFamily, res.Underlay.TunnelEndpoint)
+		if err != nil {
+			return HostConfigData{}, fmt.Errorf("L3VNI %s: %w", vni.Name, err)
+		}
 		v := hostnetwork.L3VNIParams{
 			VNIParams: hostnetwork.VNIParams{
 				VRF:       vni.Spec.VRF,
 				TargetNS:  targetNS,
-				VTEPIP:    res.Underlay.TunnelEndpoint.IPv4CIDR,
+				VTEPIP:    vtepIP,
 				VNI:       vni.Spec.VNI,
 				VXLanPort: vni.Spec.VXLanPort,
 			},
@@ -107,7 +111,7 @@ func APItoHostConfig(nodeIndex int, targetNS string, apiConfig APIConfigData) (H
 
 	res.L2VNIs = []hostnetwork.L2VNIParams{}
 	for _, l2vni := range apiConfig.L2VNIs {
-		vni, err := convertL2VNI(l2vni, targetNS, res.Underlay.TunnelEndpoint.IPv4CIDR)
+		vni, err := convertL2VNI(l2vni, targetNS, res.Underlay.TunnelEndpoint)
 		if err != nil {
 			return HostConfigData{}, err
 		}
@@ -138,15 +142,19 @@ func tunnelEndpointToHost(underlay v1alpha1.Underlay, nodeIndex int) (hostnetwor
 		}
 		tunnelEndpoint.IPv6CIDR = ip.String()
 	}
-	if tunnelEndpoint.IPv4CIDR == "" {
+	if tunnelEndpoint.IPv4CIDR == "" && tunnelEndpoint.IPv6CIDR == "" {
 		return hostnetwork.UnderlayTunnelEndpointParams{},
-			fmt.Errorf("no IPv4 CIDR found after conversion from tunnel endpoint CIDRS: %v",
+			fmt.Errorf("no VTEP IP available after conversion from tunnel endpoint CIDRs: %v",
 				underlay.Spec.TunnelEndpoint.CIDRs)
 	}
 	return tunnelEndpoint, nil
 }
 
-func convertL2VNI(l2vni v1alpha1.L2VNI, targetNS string, vtepIP string) (hostnetwork.L2VNIParams, error) {
+func convertL2VNI(l2vni v1alpha1.L2VNI, targetNS string, tunnelEndpoint *hostnetwork.UnderlayTunnelEndpointParams) (hostnetwork.L2VNIParams, error) {
+	vtepIP, err := resolveVTEPIP(l2vni.Spec.UnderlayAddressFamily, tunnelEndpoint)
+	if err != nil {
+		return hostnetwork.L2VNIParams{}, fmt.Errorf("L2VNI %s: %w", l2vni.Name, err)
+	}
 	vni := hostnetwork.L2VNIParams{
 		Name: l2vni.Name,
 		VNIParams: hostnetwork.VNIParams{
@@ -206,7 +214,39 @@ func convertHostMaster(l2vni *v1alpha1.L2VNI) (*hostnetwork.HostMaster, error) {
 	)
 }
 
-// ipNetToString returns the string representation of the IPNet, or empty string if IP is nil
+func resolveVTEPIP(
+	underlayAddressFamily *string,
+	tunnelEndpoint *hostnetwork.UnderlayTunnelEndpointParams,
+) (string, error) {
+	af := ""
+	if underlayAddressFamily != nil {
+		af = *underlayAddressFamily
+	}
+
+	switch af {
+	case "":
+		if tunnelEndpoint.IPv4CIDR != "" {
+			return tunnelEndpoint.IPv4CIDR, nil
+		}
+		if tunnelEndpoint.IPv6CIDR != "" {
+			return tunnelEndpoint.IPv6CIDR, nil
+		}
+		return "", fmt.Errorf("no VTEP IP available")
+	case "ipv4":
+		if tunnelEndpoint.IPv4CIDR != "" {
+			return tunnelEndpoint.IPv4CIDR, nil
+		}
+		return "", fmt.Errorf("ipv4 address family requested but no IPv4 VTEP IP available")
+	case "ipv6":
+		if tunnelEndpoint.IPv6CIDR != "" {
+			return tunnelEndpoint.IPv6CIDR, nil
+		}
+		return "", fmt.Errorf("ipv6 address family requested but no IPv6 VTEP IP available")
+	default:
+		return "", fmt.Errorf("unsupported address family %q", af)
+	}
+}
+
 func ipNetToString(ipNet net.IPNet) string {
 	if ipNet.IP == nil {
 		return ""

--- a/internal/conversion/host_conversion_test.go
+++ b/internal/conversion/host_conversion_test.go
@@ -4,6 +4,7 @@ package conversion
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/openperouter/openperouter/api/v1alpha1"
@@ -465,7 +466,7 @@ func TestAPItoHostConfig(t *testing.T) {
 			wantErr:         false,
 		},
 		{
-			name:      "underlay with IPv6 tunnel endpoints only is not supported",
+			name:      "underlay with IPv6 tunnel endpoints only",
 			nodeIndex: 0,
 			targetNS:  "namespace",
 			underlays: []v1alpha1.Underlay{
@@ -479,14 +480,18 @@ func TestAPItoHostConfig(t *testing.T) {
 						},
 					}},
 			},
-			vnis:            []v1alpha1.L3VNI{},
-			l2vnis:          []v1alpha1.L2VNI{},
-			l3Passthrough:   []v1alpha1.L3Passthrough{},
-			wantUnderlay:    hostnetwork.UnderlayParams{},
-			wantL3VNIParams: nil,
-			wantL2VNIParams: nil,
-			wantPassthrough: nil,
-			wantErr:         true,
+			vnis:   []v1alpha1.L3VNI{},
+			l2vnis: []v1alpha1.L2VNI{},
+			wantUnderlay: hostnetwork.UnderlayParams{
+				TargetNS:           "namespace",
+				UnderlayInterfaces: []string{"eth0"},
+				TunnelEndpoint: &hostnetwork.UnderlayTunnelEndpointParams{
+					IPv6CIDR: "2001:db8:192:168::/128",
+				},
+			},
+			wantL3VNIParams: []hostnetwork.L3VNIParams{},
+			wantL2VNIParams: []hostnetwork.L2VNIParams{},
+			wantErr:         false,
 		},
 	}
 
@@ -517,5 +522,268 @@ func TestAPItoHostConfig(t *testing.T) {
 				t.Errorf("APItoHostConfig() gotPassthrough = %+v, want %+v", gotHostConfig.L3Passthrough, tt.wantPassthrough)
 			}
 		})
+	}
+}
+
+func TestResolveVTEPIP(t *testing.T) {
+	tests := []struct {
+		name           string
+		addressFamily  *string
+		tunnelEndpoint *hostnetwork.UnderlayTunnelEndpointParams
+		want           string
+		wantErr        string
+	}{
+		{
+			name:          "ipv4 only, no field set, returns ipv4",
+			addressFamily: nil,
+			tunnelEndpoint: &hostnetwork.UnderlayTunnelEndpointParams{
+				IPv4CIDR: "10.0.0.1/32",
+			},
+			want: "10.0.0.1/32",
+		},
+		{
+			name:          "ipv6 only, no field set, returns ipv6",
+			addressFamily: nil,
+			tunnelEndpoint: &hostnetwork.UnderlayTunnelEndpointParams{
+				IPv6CIDR: "2001:db8::1/128",
+			},
+			want: "2001:db8::1/128",
+		},
+		{
+			name:          "dual-stack, no field set, defaults to ipv4",
+			addressFamily: nil,
+			tunnelEndpoint: &hostnetwork.UnderlayTunnelEndpointParams{
+				IPv4CIDR: "10.0.0.1/32",
+				IPv6CIDR: "2001:db8::1/128",
+			},
+			want: "10.0.0.1/32",
+		},
+		{
+			name:          "dual-stack, field=ipv6, returns ipv6",
+			addressFamily: new("ipv6"),
+			tunnelEndpoint: &hostnetwork.UnderlayTunnelEndpointParams{
+				IPv4CIDR: "10.0.0.1/32",
+				IPv6CIDR: "2001:db8::1/128",
+			},
+			want: "2001:db8::1/128",
+		},
+		{
+			name:          "dual-stack, field=ipv4, returns ipv4",
+			addressFamily: new("ipv4"),
+			tunnelEndpoint: &hostnetwork.UnderlayTunnelEndpointParams{
+				IPv4CIDR: "10.0.0.1/32",
+				IPv6CIDR: "2001:db8::1/128",
+			},
+			want: "10.0.0.1/32",
+		},
+		{
+			name:          "ipv4 only, field=ipv6, error",
+			addressFamily: new("ipv6"),
+			tunnelEndpoint: &hostnetwork.UnderlayTunnelEndpointParams{
+				IPv4CIDR: "10.0.0.1/32",
+			},
+			wantErr: "ipv6 address family requested but no IPv6 VTEP IP available",
+		},
+		{
+			name:          "ipv6 only, field=ipv4, error",
+			addressFamily: new("ipv4"),
+			tunnelEndpoint: &hostnetwork.UnderlayTunnelEndpointParams{
+				IPv6CIDR: "2001:db8::1/128",
+			},
+			wantErr: "ipv4 address family requested but no IPv4 VTEP IP available",
+		},
+		{
+			name:           "empty tunnel endpoint, no field set, error",
+			addressFamily:  nil,
+			tunnelEndpoint: &hostnetwork.UnderlayTunnelEndpointParams{},
+			wantErr:        "no VTEP IP available",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveVTEPIP(tt.addressFamily, tt.tunnelEndpoint)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("resolveVTEPIP() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTunnelEndpointToHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		cidrs    []string
+		wantIPv4 string
+		wantIPv6 string
+		wantErr  string
+	}{
+		{
+			name:     "ipv6 only",
+			cidrs:    []string{"2001:db8::/64"},
+			wantIPv6: "2001:db8::/128",
+		},
+		{
+			name:     "ipv4 only",
+			cidrs:    []string{"10.0.0.0/24"},
+			wantIPv4: "10.0.0.0/32",
+		},
+		{
+			name:     "dual-stack",
+			cidrs:    []string{"10.0.0.0/24", "2001:db8::/64"},
+			wantIPv4: "10.0.0.0/32",
+			wantIPv6: "2001:db8::/128",
+		},
+		{
+			name:    "empty cidrs",
+			cidrs:   []string{},
+			wantErr: "no VTEP IP available",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			underlay := v1alpha1.Underlay{
+				Spec: v1alpha1.UnderlaySpec{
+					TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{CIDRs: tt.cidrs},
+				},
+			}
+			got, err := tunnelEndpointToHost(underlay, 0)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.IPv4CIDR != tt.wantIPv4 {
+				t.Errorf("IPv4CIDR = %q, want %q", got.IPv4CIDR, tt.wantIPv4)
+			}
+			if got.IPv6CIDR != tt.wantIPv6 {
+				t.Errorf("IPv6CIDR = %q, want %q", got.IPv6CIDR, tt.wantIPv6)
+			}
+		})
+	}
+}
+
+func TestAPItoHostConfigAddressFamily(t *testing.T) {
+	tests := []struct {
+		name       string
+		cidrs      []string
+		l3VNI      *v1alpha1.L3VNI
+		l2VNI      *v1alpha1.L2VNI
+		wantVTEPIP string
+		wantErr    string
+	}{
+		{
+			name:  "dual-stack underlay with ipv6 L3VNI",
+			cidrs: []string{"10.0.0.0/24", "2001:db8::/64"},
+			l3VNI: &v1alpha1.L3VNI{
+				ObjectMeta: metav1.ObjectMeta{Name: "vni-ipv6"},
+				Spec: v1alpha1.L3VNISpec{
+					VRF: "red", VNI: 100, VXLanPort: new(int32(4789)),
+					UnderlayAddressFamily: new("ipv6"),
+				},
+			},
+			wantVTEPIP: "2001:db8::/128",
+		},
+		{
+			name:  "ipv6-only underlay with L2VNI defaults to ipv6",
+			cidrs: []string{"2001:db8::/64"},
+			l2VNI: &v1alpha1.L2VNI{
+				ObjectMeta: metav1.ObjectMeta{Name: "l2-ipv6"},
+				Spec:       v1alpha1.L2VNISpec{VNI: 200, VXLanPort: new(int32(4789))},
+			},
+			wantVTEPIP: "2001:db8::/128",
+		},
+		{
+			name:  "ipv4-only underlay with ipv6 L3VNI errors",
+			cidrs: []string{"10.0.0.0/24"},
+			l3VNI: &v1alpha1.L3VNI{
+				ObjectMeta: metav1.ObjectMeta{Name: "vni-mismatch"},
+				Spec: v1alpha1.L3VNISpec{
+					VRF: "red", VNI: 100,
+					UnderlayAddressFamily: new("ipv6"),
+				},
+			},
+			wantErr: "L3VNI vni-mismatch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var l3VNIs []v1alpha1.L3VNI
+			var l2VNIs []v1alpha1.L2VNI
+			if tt.l3VNI != nil {
+				l3VNIs = []v1alpha1.L3VNI{*tt.l3VNI}
+			}
+			if tt.l2VNI != nil {
+				l2VNIs = []v1alpha1.L2VNI{*tt.l2VNI}
+			}
+
+			apiConfig := APIConfigData{
+				Underlays: []v1alpha1.Underlay{{
+					Spec: v1alpha1.UnderlaySpec{
+						Nics:           []string{"eth0"},
+						TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{CIDRs: tt.cidrs},
+					},
+				}},
+				L3VNIs: l3VNIs,
+				L2VNIs: l2VNIs,
+			}
+
+			got, err := APItoHostConfig(0, "namespace", apiConfig)
+			checkAddressFamilyResult(t, got, err, tt.wantErr, tt.wantVTEPIP, tt.l3VNI != nil, tt.l2VNI != nil)
+		})
+	}
+}
+
+func checkAddressFamilyResult(t *testing.T, got HostConfigData, err error, wantErr, wantVTEPIP string, hasL3VNIs, hasL2VNIs bool) {
+	t.Helper()
+	if wantErr != "" {
+		if err == nil {
+			t.Fatalf("expected error containing %q, got nil", wantErr)
+		}
+		if !strings.Contains(err.Error(), wantErr) {
+			t.Errorf("expected error containing %q, got %q", wantErr, err.Error())
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if hasL3VNIs {
+		if len(got.L3VNIs) != 1 {
+			t.Fatalf("expected 1 L3VNI, got %d", len(got.L3VNIs))
+		}
+		if got.L3VNIs[0].VTEPIP != wantVTEPIP {
+			t.Errorf("L3VNI VTEPIP = %q, want %q", got.L3VNIs[0].VTEPIP, wantVTEPIP)
+		}
+	}
+	if hasL2VNIs {
+		if len(got.L2VNIs) != 1 {
+			t.Fatalf("expected 1 L2VNI, got %d", len(got.L2VNIs))
+		}
+		if got.L2VNIs[0].VTEPIP != wantVTEPIP {
+			t.Errorf("L2VNI VTEPIP = %q, want %q", got.L2VNIs[0].VTEPIP, wantVTEPIP)
+		}
 	}
 }

--- a/internal/conversion/validate_underlay.go
+++ b/internal/conversion/validate_underlay.go
@@ -96,14 +96,10 @@ func validateUnderlayTunnelEndpoint(underlay *v1alpha1.Underlay) error {
 		return fmt.Errorf("underlay %s: tunnel endpoint CIDRs must be specified", underlay.Name)
 	}
 
-	af, err := ipfamily.ForCIDRStrings(cidrs...)
+	_, err := ipfamily.ForCIDRStrings(cidrs...)
 	if err != nil {
 		return fmt.Errorf("invalid tunnel endpoint CIDRs for underlay %s: %v - %w",
 			underlay.Name, cidrs, err)
-	}
-	if af != ipfamily.IPv4 && af != ipfamily.DualStack {
-		return fmt.Errorf("invalid tunnel endpoint CIDRs for underlay %s, no IPv4 CIDR found: %v",
-			underlay.Name, cidrs)
 	}
 	return nil
 }

--- a/internal/conversion/validate_underlay_test.go
+++ b/internal/conversion/validate_underlay_test.go
@@ -238,6 +238,44 @@ func TestValidateUnderlay(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "valid IPv6-only tunnel endpoint",
+			underlay: v1alpha1.Underlay{
+				Spec: v1alpha1.UnderlaySpec{
+					TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+						CIDRs: []string{"2001:db8::1/128"},
+					},
+					Nics: []string{"eth0"},
+					ASN:  65001,
+					Neighbors: []v1alpha1.Neighbor{
+						{
+							ASN:     new(int64(65002)),
+							Address: new("2001:db8::2"),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid dual-stack tunnel endpoint",
+			underlay: v1alpha1.Underlay{
+				Spec: v1alpha1.UnderlaySpec{
+					TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+						CIDRs: []string{"192.168.1.0/24", "2001:db8::1/128"},
+					},
+					Nics: []string{"eth0"},
+					ASN:  65001,
+					Neighbors: []v1alpha1.Neighbor{
+						{
+							ASN:     new(int64(65002)),
+							Address: new("192.168.1.1"),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/operator/bundle/manifests/openpe.openperouter.github.io_l2vnis.yaml
+++ b/operator/bundle/manifests/openpe.openperouter.github.io_l2vnis.yaml
@@ -166,6 +166,15 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              underlayAddressFamily:
+                description: |-
+                  underlayAddressFamily selects which VTEP address family to use for this VNI's
+                  VXLAN interface. When omitted, defaults to the available family in the underlay
+                  (IPv4 preferred in dual-stack).
+                enum:
+                - ipv4
+                - ipv6
+                type: string
               vni:
                 description: vni is the VXLan VNI to be used
                 format: int32

--- a/operator/bundle/manifests/openpe.openperouter.github.io_l3vnis.yaml
+++ b/operator/bundle/manifests/openpe.openperouter.github.io_l3vnis.yaml
@@ -175,6 +175,15 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              underlayAddressFamily:
+                description: |-
+                  underlayAddressFamily selects which VTEP address family to use for this VNI's
+                  VXLAN interface. When omitted, defaults to the available family in the underlay
+                  (IPv4 preferred in dual-stack).
+                enum:
+                - ipv4
+                - ipv6
+                type: string
               vni:
                 description: vni is the VXLan VNI to be used
                 format: int32

--- a/operator/bundle/manifests/openpe.openperouter.github.io_underlays.yaml
+++ b/operator/bundle/manifests/openpe.openperouter.github.io_underlays.yaml
@@ -362,8 +362,7 @@ spec:
                     description: |-
                       cidrs is a list of CIDRs to be used to assign IPs to the local tunnel endpoint on
                       each node. A loopback interface will be created with IPs derived from
-                      these CIDRs. Exactly one IPv4 CIDR is required, and an optional IPv6
-                      CIDR may also be specified for dual-stack operation.
+                      these CIDRs. At least one IPv4 or IPv6 CIDR is required. At most one of each family may be specified.
                     items:
                       type: string
                     maxItems: 2
@@ -373,9 +372,9 @@ spec:
                     x-kubernetes-validations:
                     - message: all entries must be valid CIDRs
                       rule: self.all(c, isCIDR(c))
-                    - message: exactly one IPv4 CIDR is required
+                    - message: at most one IPv4 CIDR is allowed
                       rule: self.filter(c, isCIDR(c) && cidr(c).ip().family() == 4).size()
-                        == 1
+                        <= 1
                     - message: at most one IPv6 CIDR is allowed
                       rule: self.filter(c, isCIDR(c) && cidr(c).ip().family() == 6).size()
                         <= 1

--- a/website/content/docs/api-reference.md
+++ b/website/content/docs/api-reference.md
@@ -197,6 +197,7 @@ _Appears in:_
 | `vrf` _string_ | vrf is the name of the linux VRF to be used inside the PERouter namespace.<br />The field is optional, if not set it the name of the VNI instance will be used. |  | MaxLength: 15 <br />Pattern: `^[a-zA-Z][a-zA-Z0-9_-]*$` <br />Optional: \{\} <br /> |
 | `vni` _integer_ | vni is the VXLan VNI to be used |  | Maximum: 1.6777215e+07 <br />Minimum: 1 <br />Required: \{\} <br /> |
 | `vxlanport` _integer_ | vxlanport is the port to be used for VXLan encapsulation. | 4789 | Optional: \{\} <br /> |
+| `underlayAddressFamily` _string_ | underlayAddressFamily selects which VTEP address family to use for this VNI's<br />VXLAN interface. When omitted, defaults to the available family in the underlay<br />(IPv4 preferred in dual-stack). |  | Enum: [ipv4 ipv6] <br />Optional: \{\} <br /> |
 | `hostmaster` _[HostMaster](#hostmaster)_ | hostmaster is the interface on the host the veth should be enslaved to.<br />If not set, the host veth will not be enslaved to any interface and it must be<br />enslaved manually (or by some other means). This is useful if another controller<br />is leveraging the host interface for the VNI. |  | Optional: \{\} <br /> |
 | `l2gatewayips` _string array_ | l2gatewayips is a list of IP addresses in CIDR notation to be used for the L2 gateway. When this is set, the<br />bridge the veths are enslaved to will be configured with these IP addresses, effectively<br />acting as a distributed gateway for the VNI. This allows for dual-stack (IPv4 and IPv6) support.<br />Maximum of 2 addresses are allowed. If 2 addresses are provided, one must be IPv4 and one must be IPv6. |  | MaxItems: 2 <br />Optional: \{\} <br /> |
 
@@ -301,6 +302,7 @@ _Appears in:_
 | `vrf` _string_ | vrf is the name of the linux VRF to be used inside the PERouter namespace. |  | MaxLength: 15 <br />MinLength: 1 <br />Pattern: `^[a-zA-Z][a-zA-Z0-9_-]*$` <br />Required: \{\} <br /> |
 | `vni` _integer_ | vni is the VXLan VNI to be used |  | Maximum: 1.6777215e+07 <br />Minimum: 1 <br />Required: \{\} <br /> |
 | `vxlanport` _integer_ | vxlanport is the port to be used for VXLan encapsulation. | 4789 | Optional: \{\} <br /> |
+| `underlayAddressFamily` _string_ | underlayAddressFamily selects which VTEP address family to use for this VNI's<br />VXLAN interface. When omitted, defaults to the available family in the underlay<br />(IPv4 preferred in dual-stack). |  | Enum: [ipv4 ipv6] <br />Optional: \{\} <br /> |
 | `hostsession` _[HostSession](#hostsession)_ | hostsession is the configuration for the host session. |  | Optional: \{\} <br /> |
 | `exportRTs` _[RouteTarget](#routetarget) array_ | exportRTs are the Route Targets to be used for exporting routes.<br />RouteTarget defines a BGP Extended Community for route filtering. |  | MaxItems: 100 <br />MaxLength: 21 <br />Optional: \{\} <br /> |
 | `importRTs` _[RouteTarget](#routetarget) array_ | importRTs are the Route Targets to be used for importing routes.<br />RouteTarget defines a BGP Extended Community for route filtering. |  | MaxItems: 100 <br />MaxLength: 21 <br />Optional: \{\} <br /> |
@@ -527,7 +529,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `cidrs` _string array_ | cidrs is a list of CIDRs to be used to assign IPs to the local tunnel endpoint on<br />each node. A loopback interface will be created with IPs derived from<br />these CIDRs. Exactly one IPv4 CIDR is required, and an optional IPv6<br />CIDR may also be specified for dual-stack operation. |  | MaxItems: 2 <br />MinItems: 1 <br />Required: \{\} <br /> |
+| `cidrs` _string array_ | cidrs is a list of CIDRs to be used to assign IPs to the local tunnel endpoint on<br />each node. A loopback interface will be created with IPs derived from<br />these CIDRs. At least one IPv4 or IPv6 CIDR is required. At most one of each family may be specified. |  | MaxItems: 2 <br />MinItems: 1 <br />Required: \{\} <br /> |
 
 
 #### Underlay

--- a/website/content/docs/configuration/evpn.md
+++ b/website/content/docs/configuration/evpn.md
@@ -30,7 +30,7 @@ spec:
       address: 192.168.11.2
 ```
 
-The `evpn.vtepCIDR` field defines the IP range used for VTEP addresses. OpenPERouter automatically assigns a unique VTEP IP to each node from this range. For example, with `100.65.0.0/24`:
+The `tunnelEndpoint.cidrs` field defines the IP range used for VTEP addresses. OpenPERouter automatically assigns a unique VTEP IP to each node from this range. At least one CIDR (IPv4 or IPv6) is required, and both may be specified for dual-stack operation. For example, with `100.65.0.0/24`:
 
 - Node 1: `100.65.0.1`
 - Node 2: `100.65.0.2`
@@ -38,6 +38,19 @@ The `evpn.vtepCIDR` field defines the IP range used for VTEP addresses. OpenPERo
 - etc.
 
 A loopback interface is created inside the router namespace with the allocated IP, and OpenPERouter advertises the VTEP IP to the fabric over the BGP underlay session.
+
+#### IPv6 and Dual-Stack VTEP
+
+IPv6-only or dual-stack (IPv4 + IPv6) VTEP configurations are supported:
+
+```yaml
+  tunnelEndpoint:
+    cidrs:
+    - 100.65.0.0/24
+    - fd00:64::/120
+```
+
+When both IPv4 and IPv6 CIDRs are specified, individual VNIs can select which address family to use via the `underlayAddressFamily` field on the L3VNI or L2VNI resource. When omitted, it defaults to the available family (IPv4 preferred in dual-stack).
 
 ### Configuration Fields
 
@@ -79,6 +92,7 @@ spec:
 |-------|------|-------------|----------|
 | `vrf` | string | Name of the VRF (Virtual Routing and Forwarding) instance | Yes |
 | `vni` | integer | Virtual Network Identifier (1-16777215) | Yes |
+| `underlayAddressFamily` | string | VTEP address family for this VNI (`ipv4` or `ipv6`). Defaults to available family (IPv4 preferred in dual-stack). | No |
 | `hostsession.asn` | integer | Router ASN for BGP session with host | Yes |
 | `hostsession.hostasn` | integer | Host ASN for BGP session | Yes |
 | `hostsession.localcidr` | string | CIDR for veth pair IP allocation | Yes |
@@ -142,6 +156,7 @@ L2VNIs provide Layer 2 connectivity across nodes using EVPN tunnels. Unlike L3VN
 |-------|------|-------------|----------|
 | `vni` | integer | Virtual Network Identifier for the EVPN tunnel | Yes |
 | `vrf` | string | Name of the VRF to associate with this L2VNI | Yes |
+| `underlayAddressFamily` | string | VTEP address family for this VNI (`ipv4` or `ipv6`). Defaults to available family (IPv4 preferred in dual-stack). | No |
 | `hostmaster.type` | string | Type of host interface management (`linux-bridge` or `ovs-bridge`) | Yes |
 | `hostmaster.linuxBridge.autoCreate` | boolean | Whether to automatically create a Linux bridge | No |
 | `hostmaster.linuxBridge.name` | string | Name of the Linux bridge to attach to (if not auto-creating) | No |


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
/kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

Fixes https://github.com/openperouter/openperouter/issues/512 . Allow having ipv6 VTEPs for EVPN / VXLan.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Allow ipv6 vteps for evpn / vxlan.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
