### PR TITLE
Choose image architecture dynamically in common.sh

### DIFF
--- a/clab/common.sh
+++ b/clab/common.sh
@@ -26,6 +26,8 @@ if [[ $CONTAINER_ENGINE == "podman" ]]; then
     fi
 fi
 
+PLATFORM="linux/$($(which go) env GOARCH)"
+
 export CONTAINER_ENGINE_CLI
 
 load_image_to_podman_on_nodes() {
@@ -58,6 +60,6 @@ load_local_image_to_kind() {
 load_image_to_kind() {
     local image_tag=$1
     local file_name=$2
-    ${CONTAINER_ENGINE_CLI} image pull --platform linux/amd64 ${image_tag}
+    ${CONTAINER_ENGINE_CLI} image pull --platform ${PLATFORM} ${image_tag}
     load_local_image_to_kind ${image_tag} ${file_name}
 }


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

In order to be able to deploy the lab on aarch64,
dynamically set the image architecture in common.sh.

**Special notes for your reviewer**:

Needed to make things work on Apple silicon.

**Release note**:

```release-note
In order to be able to deploy the lab on aarch64,
dynamically set the image architecture in common.sh.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
