### PR TITLE
Add unit tests for validateRouteTargets and fix typo

### DIFF
--- a/internal/conversion/validate_vni.go
+++ b/internal/conversion/validate_vni.go
@@ -24,10 +24,14 @@ import (
 	"github.com/openperouter/openperouter/internal/ipfamily"
 )
 
-var interfaceNameRegexp *regexp.Regexp
+var (
+	interfaceNameRegexp *regexp.Regexp
+	ipv4LikeRegexp      *regexp.Regexp
+)
 
 func init() {
 	interfaceNameRegexp = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9._-]*$`)
+	ipv4LikeRegexp = regexp.MustCompile(`^\d+\.\d+\.\d+\.\d+$`)
 }
 
 // FilterValidL3VNIs validates L3VNIs per-field and returns the valid resources
@@ -630,9 +634,14 @@ func validateRouteTarget(rt string) error {
 		return nil
 	}
 
+	// Catch values that look like an IPv4 address but failed validation (e.g. 999.1.2.3).
+	if ipv4LikeRegexp.MatchString(rtParam[0]) {
+		return fmt.Errorf("RT format must have A.B.C.D:MN where A.B.C.D is a valid IPv4 address: %s", rt)
+	}
+
 	asn, err := strconv.ParseUint(rtParam[0], 10, 32)
 	if err != nil {
-		return fmt.Errorf("RT format must have ASN:MN %s", rt)
+		return fmt.Errorf("RT format must have ASN:MN: %s", rt)
 	}
 
 	memberNumber, err := parseMemberNumber(rtParam[1])

--- a/internal/conversion/validate_vni_test.go
+++ b/internal/conversion/validate_vni_test.go
@@ -1488,3 +1488,109 @@ func TestHasSubnetOverlap(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateRouteTarget(t *testing.T) {
+	tests := []struct {
+		name          string
+		routeTarget   string
+		wantErrString string
+	}{
+		{
+			name:        "ASN route target",
+			routeTarget: "65000:100",
+		},
+		{
+			name:        "single IP route target",
+			routeTarget: "10.0.0.1:100",
+		},
+		{
+			name:        "4-byte ASN route target",
+			routeTarget: "100000:100",
+		},
+		{
+			name:          "invalid route target missing colon",
+			routeTarget:   "65000",
+			wantErrString: "RT \"65000\" must have one of the following formats: 'ASN:MN' or 'IPv4Address:MN'",
+		},
+		{
+			name:          "invalid route target non-numeric ASN",
+			routeTarget:   "abc:100",
+			wantErrString: "RT format must have ASN:MN: abc:100",
+		},
+		{
+			name:          "invalid route target non-numeric member number",
+			routeTarget:   "65000:abc",
+			wantErrString: "RT format must have ASN:MN where MN is a number: 65000:abc",
+		},
+		{
+			name:          "invalid IP route target member number exceeds 65535",
+			routeTarget:   "10.0.0.1:65536",
+			wantErrString: "RT format must have A.B.C.D:MN where MN <= 65535: 10.0.0.1:65536",
+		},
+		{
+			name:          "invalid 4-byte ASN route target member number exceeds 65535",
+			routeTarget:   "100000:65536",
+			wantErrString: "RT format with 4-byte ASN must have ASN:MN where MN <= 65535: 100000:65536",
+		},
+		{
+			name:          "invalid route target 'invalid'",
+			routeTarget:   "invalid",
+			wantErrString: "RT \"invalid\" must have one of the following formats: 'ASN:MN' or 'IPv4Address:MN'",
+		},
+		{
+			name:          "empty string",
+			routeTarget:   "",
+			wantErrString: "RT \"\" must have one of the following formats: 'ASN:MN' or 'IPv4Address:MN'",
+		},
+		{
+			name:          "multiple colons",
+			routeTarget:   "65000:100:200",
+			wantErrString: "RT \"65000:100:200\" must have one of the following formats: 'ASN:MN' or 'IPv4Address:MN'",
+		},
+		{
+			name:          "invalid IP route target non-numeric member number",
+			routeTarget:   "10.0.0.1:abc",
+			wantErrString: "RT format must have A.B.C.D:MN where MN <= 65535: 10.0.0.1:abc",
+		},
+		{
+			name:        "2-byte ASN with max member number",
+			routeTarget: "65535:4294967295",
+		},
+		{
+			name:          "2-byte ASN with member number exceeding max",
+			routeTarget:   "65535:4294967296",
+			wantErrString: "RT format with 2-byte ASN must have ASN:MN where MN <= 4294967295: 65535:4294967296",
+		},
+		{
+			name:        "IP route target with max member number",
+			routeTarget: "10.0.0.1:65535",
+		},
+		{
+			name:        "4-byte ASN with max member number",
+			routeTarget: "100000:65535",
+		},
+		{
+			name:          "invalid IP route target invalid IP address",
+			routeTarget:   "999.999.999.999:100",
+			wantErrString: "RT format must have A.B.C.D:MN where A.B.C.D is a valid IPv4 address: 999.999.999.999:100",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRouteTarget(tt.routeTarget)
+			if tt.wantErrString != "" {
+				if err == nil {
+					t.Fatalf("validateRouteTarget() expected error %q, got nil", tt.wantErrString)
+				}
+				if err.Error() != tt.wantErrString {
+					t.Fatalf("validateRouteTarget() error = %q, want %q", err.Error(), tt.wantErrString)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("validateRouteTarget() expected no error but got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:
Add unit tests for validateRouteTargets and fix typo

**Special notes for your reviewer**:
N/A

**Release note**:

```release-note
Add unit tests for validateRouteTargets and fix typo
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved route-target validation by distinguishing true ASN prefixes from malformed IPv4-like values.
  - When an IPv4-like pattern is detected in the ASN portion, validation now returns an error that requires `A.B.C.D:MN` with a valid IPv4 address.
  - Refined error messages for invalid route-target formats, including missing separators, empty values, multiple colons, and numeric overflow/limit violations.
- **Tests**
  - Expanded table-driven unit tests for route-target validation, covering valid `ASN:MN` and `IPv4Address:MN` inputs plus many invalid cases with exact error assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->