### PR TITLE
WIP: Add unit tests for RouteTarget CEL rules

### DIFF
--- a/celvalidation/cel_test.go
+++ b/celvalidation/cel_test.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package celvalidation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openperouter/openperouter/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	namespace = "openperouter-system"
+)
+
+var _ = Describe("CEL Validation", func() {
+	BeforeEach(func() {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		}
+		err := k8sClient.Create(context.Background(), ns)
+		Expect(err).To(SatisfyAny(Not(HaveOccurred()), WithTransform(apierrors.IsAlreadyExists, BeTrue())))
+	})
+
+	AfterEach(func() {
+		Expect(cleanupResources(k8sClient, namespace)).To(Succeed())
+	})
+
+	// This context verifies RouteTarget CEL rules by creating an L3VNI resources with a single
+	// export route target for each test case. It then expects either success, or in case of failure it expects
+	// a single failure cause to be present (meaning at max 1 CEL rule should ever report an error) with the
+	// exact provided error string.
+	Context("RouteTarget", func() {
+		tcs := []struct {
+			routeTarget     v1alpha1.RouteTarget
+			wantErrorString string
+		}{
+			{
+				routeTarget: v1alpha1.RouteTarget("123:10"),
+			},
+			{
+				routeTarget: v1alpha1.RouteTarget("65535:65535"),
+			},
+			{
+				routeTarget: v1alpha1.RouteTarget("0:0"),
+			},
+			{
+				routeTarget: v1alpha1.RouteTarget("4294967295:100"),
+			},
+			{
+				routeTarget: v1alpha1.RouteTarget("100:4294967295"),
+			},
+			{
+				routeTarget: v1alpha1.RouteTarget("10.0.0.1:100"),
+			},
+			{
+				routeTarget: v1alpha1.RouteTarget("192.168.1.1:65535"),
+			},
+			{
+				routeTarget: v1alpha1.RouteTarget("0.0.0.0:0"),
+			},
+			{
+				routeTarget: v1alpha1.RouteTarget("255.255.255.255:0"),
+			},
+			{
+				routeTarget:     v1alpha1.RouteTarget("10.0.0.1"),
+				wantErrorString: "Invalid value: \"string\": routeTarget must be in ASN:NN or IP:NN format",
+			},
+			{
+				routeTarget:     v1alpha1.RouteTarget("100000:abc"),
+				wantErrorString: "Invalid value: \"string\": routeTarget must be in ASN:NN or IP:NN format",
+			},
+			{
+				routeTarget:     v1alpha1.RouteTarget("abc:100"),
+				wantErrorString: "Invalid value: \"string\": routeTarget must be in ASN:NN or IP:NN format",
+			},
+			{
+				routeTarget:     v1alpha1.RouteTarget(":100"),
+				wantErrorString: "Invalid value: \"string\": routeTarget must be in ASN:NN or IP:NN format",
+			},
+			{
+				routeTarget:     v1alpha1.RouteTarget("100:"),
+				wantErrorString: "Invalid value: \"string\": routeTarget must be in ASN:NN or IP:NN format",
+			},
+			{
+				routeTarget:     v1alpha1.RouteTarget("1000.0.0.1:100"),
+				wantErrorString: "Invalid value: \"string\": routeTarget must be in ASN:NN or IP:NN format",
+			},
+			{
+				routeTarget:     v1alpha1.RouteTarget("10.0.0:100"),
+				wantErrorString: "Invalid value: \"string\": routeTarget must be in ASN:NN or IP:NN format",
+			},
+			{
+				routeTarget:     v1alpha1.RouteTarget("4294967296:100"),
+				wantErrorString: "Invalid value: \"string\": in ASN:NN format, ASN must not exceed 4294967295",
+			},
+			{
+				routeTarget:     v1alpha1.RouteTarget("100:4294967296"),
+				wantErrorString: "Invalid value: \"string\": in ASN:NN format, NN must not exceed 4294967295",
+			},
+			{
+				routeTarget:     v1alpha1.RouteTarget("65536:65536"),
+				wantErrorString: "Invalid value: \"string\": in ASN:NN format, either ASN or NN must be <= 65535",
+			},
+			{
+				routeTarget:     v1alpha1.RouteTarget("10.0.0.1:65536"),
+				wantErrorString: "Invalid value: \"string\": in IP:NN format, NN must be <= 65535",
+			},
+			// We'd need more complex validation to cover this, but then the regex's complexity would get out of hand.
+			// Therefore, let CEL accept this and instead rely on the webhook for better validation.
+			{
+				routeTarget: v1alpha1.RouteTarget("300.300.300.300:100"),
+			},
+		}
+
+		testCases := make([]testCase, len(tcs))
+		for i, tc := range tcs {
+			testCases[i] = testCase{
+				name: fmt.Sprintf("route target: %s", tc.routeTarget),
+				objects: []client.Object{
+					&v1alpha1.L3VNI{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test",
+							Namespace: namespace,
+						},
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "L3VNI",
+							APIVersion: v1alpha1.GroupVersion.String(),
+						},
+						Spec: v1alpha1.L3VNISpec{
+							VNI:       100,
+							VRF:       "red",
+							ExportRTs: []v1alpha1.RouteTarget{tc.routeTarget},
+						},
+					},
+				},
+			}
+			if tc.wantErrorString != "" {
+				testCases[i].wantCauses = []metav1.StatusCause{
+					{
+						Type:    "FieldValueInvalid",
+						Message: tc.wantErrorString,
+						Field:   "spec.exportRTs[0]",
+					},
+				}
+			}
+		}
+
+		runTestCases(testCases)
+	})
+})
+
+type testCase struct {
+	name       string
+	objects    []client.Object
+	wantCauses []metav1.StatusCause
+}
+
+func runTestCases(testCases []testCase) {
+	for _, tc := range testCases {
+		Context(tc.name, func() {
+			if len(tc.wantCauses) == 0 {
+				It("should pass validation", func() {
+					unstructuredObjects, err := objectsToUnstructured(tc.objects)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(createObjects(k8sClient, unstructuredObjects...)).To(Succeed())
+				})
+				return
+			}
+
+			It("should fail validation", func() {
+				unstructuredObjects, err := objectsToUnstructured(tc.objects)
+				Expect(err).NotTo(HaveOccurred())
+				err = createObjects(k8sClient, unstructuredObjects...)
+				var statusErr *apierrors.StatusError
+				Expect(errors.As(err, &statusErr)).To(BeTrue())
+				Expect(statusErr.ErrStatus.Details).NotTo(BeNil())
+				Expect(statusErr.ErrStatus.Details.Causes).To(Equal(tc.wantCauses))
+			})
+		})
+	}
+}
+
+func objectsToUnstructured(objects []client.Object) ([]unstructured.Unstructured, error) {
+	unstructuredObjects := make([]unstructured.Unstructured, len(objects))
+	for i, obj := range objects {
+		data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert to unstructured, err: %w", err)
+		}
+		unstructuredObjects[i] = unstructured.Unstructured{Object: data}
+	}
+	return unstructuredObjects, nil
+}

--- a/celvalidation/celvalidation_suite_test.go
+++ b/celvalidation/celvalidation_suite_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package celvalidation
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	openpeapi "github.com/openperouter/openperouter/api/v1alpha1"
+)
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
+
+func TestCelValidation(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Tests Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+
+		// The BinaryAssetsDirectory is only required if you want to run the tests directly
+		// without call the makefile target test. If not informed it will look for the
+		// default path defined in controller-runtime which is /usr/local/kubebuilder/.
+		// Note that you must have the required binaries setup under the bin directory to perform
+		// the tests directly. When we run make test it will be setup and used automatically.
+		BinaryAssetsDirectory: filepath.Join("..", "bin", "k8s",
+			fmt.Sprintf("1.31.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	err = openpeapi.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancel()
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/celvalidation/resource.go
+++ b/celvalidation/resource.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package celvalidation
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// containsOpenPERouterCR checks if YAML contains OpenPERouter custom resources
+func containsOpenPERouterCR(content string) bool {
+	return strings.Contains(content, "openpe.openperouter.github.io")
+}
+
+// createObjects creates the provided objects.
+func createObjects(k8sClient client.Client, objects ...unstructured.Unstructured) error {
+	for _, obj := range objects {
+		if obj.GetNamespace() == "" {
+			return fmt.Errorf("empty namespace")
+		}
+
+		err := k8sClient.Create(context.Background(), &obj, &client.CreateOptions{FieldValidation: "Strict"})
+		if err != nil {
+			return fmt.Errorf("failed to create %s %s/%s: %w",
+				obj.GetKind(), obj.GetNamespace(), obj.GetName(), err)
+		}
+	}
+	return nil
+}
+
+// cleanupResources deletes all OpenPERouter custom resources in the specified namespace.
+func cleanupResources(k8sClient client.Client, namespace string) error {
+	ctx := context.Background()
+
+	crdList := &apiextensionsv1.CustomResourceDefinitionList{}
+	err := k8sClient.List(ctx, crdList)
+	if err != nil {
+		return err
+	}
+
+	for _, crd := range crdList.Items {
+		if !containsOpenPERouterCR(crd.Spec.Group) {
+			continue
+		}
+
+		kind := crd.Spec.Names.Kind
+
+		if len(crd.Spec.Versions) == 0 {
+			continue
+		}
+		version := crd.Spec.Versions[0].Name
+
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   crd.Spec.Group,
+			Version: version,
+			Kind:    kind + "List",
+		})
+
+		err = k8sClient.List(ctx, list, client.InNamespace(namespace))
+		if err != nil {
+			return err
+		}
+
+		for _, item := range list.Items {
+			err = k8sClient.Delete(ctx, &item)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Add unit testing for CEL rules, and start with the new RouteTarget.
The unit tests can later be expanded for other CEL rules.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
