### PR TITLE
fix: mount parent directory in config helper pod

### DIFF
--- a/e2etests/tests/static_and_api.go
+++ b/e2etests/tests/static_and_api.go
@@ -26,10 +26,10 @@ import (
 
 const (
 	// Static configuration directory on the host (from systemdmode/generate_systemd.sh)
-	// The systemd setup mounts /var/lib/openperouter -> /etc/openperouter in the container
-	hostConfigDir = "/var/lib/openperouter/configs"
-	// Mount path inside the helper pod
-	podConfigMount = "/configs"
+	// The systemd setup mounts /var/lib/openperouter -> /etc/openperouter in the controller container.
+	// We mount the same parent directory in the helper pod so both resolve to the same overlayfs layer.
+	hostConfigDir  = "/var/lib/openperouter"
+	podConfigMount = "/hostconfig/configs"
 )
 
 // This test validates hybrid mode where configuration comes from both
@@ -292,7 +292,7 @@ func createConfigHelperDaemonSet(cs clientset.Interface) ([]*corev1.Pod, error) 
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "config-dir",
-									MountPath: podConfigMount,
+									MountPath: "/hostconfig",
 								},
 							},
 						},
@@ -304,7 +304,7 @@ func createConfigHelperDaemonSet(cs clientset.Interface) ([]*corev1.Pod, error) 
 								HostPath: &corev1.HostPathVolumeSource{
 									Path: hostConfigDir,
 									Type: func() *corev1.HostPathType {
-										t := corev1.HostPathDirectoryOrCreate
+										t := corev1.HostPathDirectory
 										return &t
 									}(),
 								},


### PR DESCRIPTION

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
/kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

The config-helper DaemonSet was mounting /var/lib/openperouter/configs directly, while the controller's quadlet mounts the parent /var/lib/openperouter. In nested container environments (Kind nodes), these can resolve to different overlayfs layers, causing files written by the helper pod to be invisible to the controller's file watcher.

Mount the same parent directory (/var/lib/openperouter) in the helper pod so both containers see the same filesystem.


Attempt to fix the flake Single Session Baseline > verifies L2 and L3 connectivity

in https://github.com/openperouter/openperouter/actions/runs/28377843441/job/84073427518?pr=469

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
