### PR TITLE
fix(status): prevent reconcile storm from LastTransitionTime mismatch

### DIFF
--- a/e2etests/pkg/openperouter/status.go
+++ b/e2etests/pkg/openperouter/status.go
@@ -4,8 +4,14 @@ package openperouter
 
 import (
 	"context"
+	"fmt"
+	"time"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/openperouter/openperouter/api/v1alpha1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -19,4 +25,26 @@ func GetNodeStatus(cli client.Client, nodeName string) (*v1alpha1.RouterNodeConf
 		return nil, err
 	}
 	return status, nil
+}
+
+// AssertNodesStatusReady verifies that all RouterNodeConfigurationStatus CRs
+// have Ready=True and Degraded=False conditions set.
+func AssertNodesStatusReady(cli client.Client) {
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		statusList := &v1alpha1.RouterNodeConfigurationStatusList{}
+		g.Expect(cli.List(context.Background(), statusList, &client.ListOptions{Namespace: Namespace})).To(Succeed())
+		g.Expect(statusList.Items).NotTo(BeEmpty(), "should have at least one node status")
+
+		for _, nodeStatus := range statusList.Items {
+			g.Expect(nodeStatus.Status).NotTo(BeNil(),
+				fmt.Sprintf("node-status %q should have status set", nodeStatus.Name))
+			g.Expect(apimeta.IsStatusConditionPresentAndEqual(nodeStatus.Status.Conditions, v1alpha1.ConditionTypeReady, metav1.ConditionTrue)).
+				To(BeTrue(), fmt.Sprintf("node-status %q Ready should be True", nodeStatus.Name))
+			g.Expect(apimeta.IsStatusConditionPresentAndEqual(nodeStatus.Status.Conditions, v1alpha1.ConditionTypeDegraded, metav1.ConditionFalse)).
+				To(BeTrue(), fmt.Sprintf("node-status %q Degraded should be False", nodeStatus.Name))
+			g.Expect(nodeStatus.Status.FailedResources).To(BeEmpty(),
+				fmt.Sprintf("node-status %q should have no failed resources", nodeStatus.Name))
+		}
+	}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
 }

--- a/e2etests/tests/node_status.go
+++ b/e2etests/tests/node_status.go
@@ -40,11 +40,13 @@ var _ = Describe("Node Router Status", func() {
 
 	It("should ensure RouterNodeConfigurationStatus per each node", func() {
 		assertSingleNodeStatusPerNode(nodes, routerNamespace)
+		openperouter.AssertNodesStatusReady(Updater.Client())
 
 		By("delete all CRs and verify they are recreated")
 		Expect(Updater.Client().DeleteAllOf(context.Background(), &v1alpha1.RouterNodeConfigurationStatus{}, client.InNamespace(routerNamespace))).To(Succeed())
 
 		assertSingleNodeStatusPerNode(nodes, routerNamespace)
+		openperouter.AssertNodesStatusReady(Updater.Client())
 	})
 })
 

--- a/internal/controller/routerconfiguration/node_status.go
+++ b/internal/controller/routerconfiguration/node_status.go
@@ -39,7 +39,7 @@ func (r *PERouterReconciler) reconcileNodeStatus(ctx context.Context, reconcileE
 		return fmt.Errorf("failed to create or update node status: %w", err)
 	}
 
-	newStatus := buildStatus(reconcileErr)
+	newStatus := buildStatus(reconcileErr, nodeStatus.Status)
 
 	if equality.Semantic.DeepEqual(nodeStatus.Status, &newStatus) {
 		return nil

--- a/internal/controller/routerconfiguration/node_status_test.go
+++ b/internal/controller/routerconfiguration/node_status_test.go
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package routerconfiguration
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openperouter/openperouter/api/v1alpha1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/openperouter/openperouter/internal/conversion"
+)
+
+type failingDatapathConfigurator struct{}
+
+func (f *failingDatapathConfigurator) Configure(_ context.Context, _ interfacesConfiguration) error {
+	return fmt.Errorf("failed to setup underlay: link not found")
+}
+
+func (f *failingDatapathConfigurator) Validate(_ conversion.APIConfigData) error {
+	return nil
+}
+
+func TestReconcileUpdatesNodeStatus(t *testing.T) {
+	t.Run("sets Ready status on successful reconcile", func(t *testing.T) {
+		r := newTestPERouterReconciler(t, &noopDatapathConfigurator{}, testNode())
+
+		if _, err := r.Reconcile(context.Background(), ctrl.Request{}); err != nil {
+			t.Fatalf("Reconcile() returned error: %v", err)
+		}
+
+		assertStatusReady(t, r.Client)
+	})
+
+	t.Run("sets Degraded status on reconcile error", func(t *testing.T) {
+		r := newTestPERouterReconciler(t, &failingDatapathConfigurator{}, testNode())
+
+		if _, err := r.Reconcile(context.Background(), ctrl.Request{}); err == nil {
+			t.Fatal("expected Reconcile() to return error")
+		}
+
+		assertStatusDegraded(t, r.Client)
+	})
+
+	t.Run("no status patch on repeated successful reconcile", func(t *testing.T) {
+		r := newTestPERouterReconciler(t, &noopDatapathConfigurator{}, testNode())
+
+		if _, err := r.Reconcile(context.Background(), ctrl.Request{}); err != nil {
+			t.Fatalf("first Reconcile() returned error: %v", err)
+		}
+		first := getNodeStatus(t, r.Client)
+		firstRV := first.ResourceVersion
+		firstTransition := apimeta.FindStatusCondition(first.Status.Conditions, v1alpha1.ConditionTypeReady).LastTransitionTime
+
+		if _, err := r.Reconcile(context.Background(), ctrl.Request{}); err != nil {
+			t.Fatalf("second Reconcile() returned error: %v", err)
+		}
+		second := getNodeStatus(t, r.Client)
+
+		if second.ResourceVersion != firstRV {
+			t.Errorf("ResourceVersion changed from %s to %s; expected no status patch (reconcile storm)", firstRV, second.ResourceVersion)
+		}
+		secondTransition := apimeta.FindStatusCondition(second.Status.Conditions, v1alpha1.ConditionTypeReady).LastTransitionTime
+		if !secondTransition.Equal(&firstTransition) {
+			t.Errorf("LastTransitionTime changed from %v to %v; expected preserved", firstTransition, secondTransition)
+		}
+	})
+
+	t.Run("no status patch on repeated failed reconcile", func(t *testing.T) {
+		r := newTestPERouterReconciler(t, &failingDatapathConfigurator{}, testNode())
+
+		if _, err := r.Reconcile(context.Background(), ctrl.Request{}); err == nil {
+			t.Fatal("expected Reconcile() to return error")
+		}
+		first := getNodeStatus(t, r.Client)
+		firstRV := first.ResourceVersion
+		firstTransition := apimeta.FindStatusCondition(first.Status.Conditions, v1alpha1.ConditionTypeReady).LastTransitionTime
+
+		if _, err := r.Reconcile(context.Background(), ctrl.Request{}); err == nil {
+			t.Fatal("expected Reconcile() to return error")
+		}
+		second := getNodeStatus(t, r.Client)
+
+		if second.ResourceVersion != firstRV {
+			t.Errorf("ResourceVersion changed from %s to %s; expected no status patch (reconcile storm)", firstRV, second.ResourceVersion)
+		}
+		secondTransition := apimeta.FindStatusCondition(second.Status.Conditions, v1alpha1.ConditionTypeReady).LastTransitionTime
+		if !secondTransition.Equal(&firstTransition) {
+			t.Errorf("LastTransitionTime changed from %v to %v; expected preserved", firstTransition, secondTransition)
+		}
+	})
+
+	t.Run("transitions from Degraded to Ready", func(t *testing.T) {
+		r := newTestPERouterReconciler(t, &failingDatapathConfigurator{}, testNode())
+
+		if _, err := r.Reconcile(context.Background(), ctrl.Request{}); err == nil {
+			t.Fatal("expected Reconcile() to return error")
+		}
+		assertStatusDegraded(t, r.Client)
+
+		r.DatapathConfigurator = &noopDatapathConfigurator{}
+		if _, err := r.Reconcile(context.Background(), ctrl.Request{}); err != nil {
+			t.Fatalf("Reconcile() returned error: %v", err)
+		}
+		assertStatusReady(t, r.Client)
+	})
+}
+
+type mockRouterProvider struct{}
+
+func (m *mockRouterProvider) New(_ context.Context) (Router, error) {
+	return &mockRouter{}, nil
+}
+
+func (m *mockRouterProvider) NodeIndex(_ context.Context) (int, error) {
+	return 0, nil
+}
+
+type mockRouter struct{}
+
+func (m *mockRouter) TargetNS(_ context.Context) (string, error)        { return "", nil }
+func (m *mockRouter) CanReconcile() (bool, error)                       { return true, nil }
+func (m *mockRouter) HandleNonRecoverableError(_ context.Context) error { return nil }
+
+func newTestPERouterReconciler(t *testing.T, datapathConfigurator DatapathConfigurator, objects ...client.Object) *PERouterReconciler {
+	t.Helper()
+	s := testScheme(t)
+	cli := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(objects...).
+		WithStatusSubresource(&v1alpha1.RouterNodeConfigurationStatus{}).
+		Build()
+	notMirrored, err := labels.NewRequirement(StaticSourceLabel, selection.DoesNotExist, nil)
+	if err != nil {
+		t.Fatalf("failed to build label requirement: %v", err)
+	}
+	frrConfigPath := filepath.Join(t.TempDir(), "frr.conf")
+	if err := os.WriteFile(frrConfigPath, nil, 0600); err != nil {
+		t.Fatalf("failed to create frr config: %v", err)
+	}
+	return &PERouterReconciler{
+		Client:                   cli,
+		Scheme:                   s,
+		MyNode:                   testNodeName,
+		MyNamespace:              testNamespace,
+		Logger:                   testLogger(),
+		RouterProvider:           &mockRouterProvider{},
+		DatapathConfigurator:     datapathConfigurator,
+		FRRReloadSocket:          newFRRSocketServer(t),
+		FRRConfigPath:            frrConfigPath,
+		notStaticConfigsListOpts: &client.ListOptions{LabelSelector: labels.NewSelector().Add(*notMirrored)},
+	}
+}
+
+func newFRRSocketServer(t *testing.T) string {
+	t.Helper()
+	socketPath := filepath.Join(t.TempDir(), "frr.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("failed to create unix socket: %v", err)
+	}
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { _ = server.Close() })
+	return socketPath
+}
+
+func assertStatusReady(t *testing.T, cli client.Client) {
+	t.Helper()
+	status := getNodeStatus(t, cli)
+	if status.Status == nil {
+		t.Fatal("Status should not be nil")
+	}
+	if len(status.Status.FailedResources) != 0 {
+		t.Errorf("expected no failed resources, got: %+v", status.Status.FailedResources)
+	}
+	if !apimeta.IsStatusConditionPresentAndEqual(status.Status.Conditions, v1alpha1.ConditionTypeReady, metav1.ConditionTrue) {
+		t.Errorf("expected Ready=True, got conditions: %+v", status.Status.Conditions)
+	}
+	if !apimeta.IsStatusConditionPresentAndEqual(status.Status.Conditions, v1alpha1.ConditionTypeDegraded, metav1.ConditionFalse) {
+		t.Errorf("expected Degraded=False, got conditions: %+v", status.Status.Conditions)
+	}
+}
+
+func assertStatusDegraded(t *testing.T, cli client.Client) {
+	t.Helper()
+	status := getNodeStatus(t, cli)
+	if status.Status == nil {
+		t.Fatal("Status should not be nil")
+	}
+	if !apimeta.IsStatusConditionPresentAndEqual(status.Status.Conditions, v1alpha1.ConditionTypeReady, metav1.ConditionFalse) {
+		t.Errorf("expected Ready=False, got conditions: %+v", status.Status.Conditions)
+	}
+	if !apimeta.IsStatusConditionPresentAndEqual(status.Status.Conditions, v1alpha1.ConditionTypeDegraded, metav1.ConditionTrue) {
+		t.Errorf("expected Degraded=True, got conditions: %+v", status.Status.Conditions)
+	}
+}
+
+func getNodeStatus(t *testing.T, cli client.Client) *v1alpha1.RouterNodeConfigurationStatus {
+	t.Helper()
+	status := &v1alpha1.RouterNodeConfigurationStatus{}
+	if err := cli.Get(context.Background(), client.ObjectKey{
+		Name:      testNodeName,
+		Namespace: testNamespace,
+	}, status); err != nil {
+		t.Fatalf("failed to get node status: %v", err)
+	}
+	return status
+}

--- a/internal/controller/routerconfiguration/status.go
+++ b/internal/controller/routerconfiguration/status.go
@@ -10,8 +10,12 @@ import (
 	"github.com/openperouter/openperouter/api/v1alpha1"
 )
 
-func buildStatus(err error) v1alpha1.RouterNodeConfigurationStatusStatus {
+func buildStatus(err error, existingStatus *v1alpha1.RouterNodeConfigurationStatusStatus) v1alpha1.RouterNodeConfigurationStatusStatus {
 	var s v1alpha1.RouterNodeConfigurationStatusStatus
+	if existingStatus != nil && len(existingStatus.Conditions) > 0 {
+		s.Conditions = make([]metav1.Condition, len(existingStatus.Conditions))
+		copy(s.Conditions, existingStatus.Conditions)
+	}
 
 	if err == nil {
 		setReady(&s, v1alpha1.ConditionReasonConfigSuccessful, "All configuration applied successfully")

--- a/internal/controller/routerconfiguration/status_test.go
+++ b/internal/controller/routerconfiguration/status_test.go
@@ -98,7 +98,7 @@ func TestBuildStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := buildStatus(tt.reconcileErr)
+			s := buildStatus(tt.reconcileErr, nil)
 
 			ready := apimeta.FindStatusCondition(s.Conditions, v1alpha1.ConditionTypeReady)
 			if ready == nil {


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

`reconcileNodeStatus` patches the status on every reconcile because `buildStatus()` creates conditions with a fresh `LastTransitionTime`. `DeepEqual` always returns false against the server-side value, triggering a patch that fires the `RouterNodeConfigurationStatus` watch and re-enqueues -- creating a reconcile storm (85 patches in 30s observed on a live cluster).

Fix: apply desired conditions via `SetStatusCondition` on a `DeepCopy` of the existing status. `SetStatusCondition` preserves `LastTransitionTime` when the condition `Status` is unchanged, so `DeepEqual` correctly returns true and no unnecessary patch is emitted.

Also makes `HostConfigurator` injectable on `PERouterReconciler` for testability, adds unit tests for the status update path (Ready, Degraded, no-storm, transitions), and adds e2e status condition checks to the node status test.

JIRA: [CNV-91855](https://redhat.atlassian.net/browse/CNV-91855)

**Release note**:

```release-note
Fix reconcile storm caused by status being re-patched on every reconcile due to LastTransitionTime mismatch.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved router node status reconciliation to preserve existing condition history and avoid unnecessary status updates.
  * Node status now more reliably transitions between **Ready** and **Degraded** based on reconcile outcomes (success, failure, then recovery).

* **Tests**
  * Enhanced end-to-end node status checks with explicit “all nodes ready” verification before and after status recreation.
  * Added controller-level coverage for idempotency, correct condition transitions, and recovery from failed reconciles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->