### PR TITLE
Controller cni integration plugins install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,17 @@
 ARG FRR_IMAGE=quay.io/frrouting/frr:10.6.0
+ARG CNI_PLUGINS_VERSION=v1.6.2
+
+# Build CNI plugin binaries
+FROM golang:1.26.4 AS cni-plugins-builder
+
+ARG CNI_PLUGINS_VERSION
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /cni-plugins
+RUN git clone --branch ${CNI_PLUGINS_VERSION} --depth 1 https://github.com/containernetworking/plugins.git .
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} ./build_linux.sh \
+  -ldflags "-extldflags -static"
 
 # Build the manager binary
 FROM golang:1.26.4 AS builder
@@ -47,6 +60,10 @@ COPY --from=builder /go/openperouter/hostbridge .
 COPY --from=builder /go/openperouter/nodemarker .
 COPY --from=builder /go/openperouter/operatorbinary ./operator
 COPY operator/bindata bindata
+COPY --from=cni-plugins-builder /cni-plugins/bin/macvlan /opt/openperouter/cni/bin/
+COPY --from=cni-plugins-builder /cni-plugins/bin/ipvlan /opt/openperouter/cni/bin/
+COPY --from=cni-plugins-builder /cni-plugins/bin/static /opt/openperouter/cni/bin/
+COPY --from=cni-plugins-builder /cni-plugins/bin/dhcp /opt/openperouter/cni/bin/
 # Copy FRR startup configuration to the default location
 COPY systemdmode/frrconfig/daemons /etc/frr/daemons
 COPY systemdmode/frrconfig/vtysh.conf /etc/frr/vtysh.conf

--- a/charts/openperouter/README.md
+++ b/charts/openperouter/README.md
@@ -27,6 +27,8 @@ Kubernetes: `>= 1.19.0-0`
 | fullnameOverride | string | `""` |  |
 | nameOverride | string | `""` |  |
 | openperouter.affinity | object | `{}` |  |
+| openperouter.controller.cniBinDir | string | `"/opt/openperouter/cni/bin/"` | CNI plugin binary directory. The default matches the path baked into the controller image. Override only to use externally-provided binaries (e.g. host-mounted). Supports colon-separated paths for multiple directories. |
+| openperouter.controller.cniCacheDir | string | `"/var/lib/openperouter/cni/cache"` | CNI cache directory for persistent CNI state across pod restarts |
 | openperouter.controller.healthProbePort | int | `9081` | Health probe port for liveness and readiness checks |
 | openperouter.controller.resources | object | `{}` |  |
 | openperouter.cri | string | `"containerd"` |  |

--- a/charts/openperouter/templates/controller.yaml
+++ b/charts/openperouter/templates/controller.yaml
@@ -62,6 +62,8 @@ spec:
         {{- with .Values.openperouter.ovsSocketPath }}
         - --ovssocket={{ . }}
         {{- end }}
+        - --cni-bin-dir={{ .Values.openperouter.controller.cniBinDir }}
+        - --cni-cache-dir={{ .Values.openperouter.controller.cniCacheDir }}
         command:
         - /controller
         env:
@@ -132,6 +134,8 @@ spec:
           mountPropagation: HostToContainer
         - mountPath: /var/run/frr
           name: frr-sockets
+        - mountPath: {{ .Values.openperouter.controller.cniCacheDir | default "/var/lib/openperouter/cni/cache" }}
+          name: cni-cache
       hostNetwork: true
       hostPID: true
       tolerations:
@@ -175,4 +179,8 @@ spec:
           path: /var/run/openperouter/frr
           type: DirectoryOrCreate
         name: frr-sockets
+      - hostPath:
+          path: {{ .Values.openperouter.controller.cniCacheDir | default "/var/lib/openperouter/cni/cache" }}
+          type: DirectoryOrCreate
+        name: cni-cache
 {{- end }}

--- a/charts/openperouter/values.yaml
+++ b/charts/openperouter/values.yaml
@@ -52,6 +52,12 @@ openperouter:
     resources: {}
     # -- Health probe port for liveness and readiness checks
     healthProbePort: 9081
+    # -- CNI plugin binary directory. The default matches the path baked into the
+    # controller image. Override only to use externally-provided binaries (e.g.
+    # host-mounted). Supports colon-separated paths for multiple directories.
+    cniBinDir: "/opt/openperouter/cni/bin/"
+    # -- CNI cache directory for persistent CNI state across pod restarts
+    cniCacheDir: "/var/lib/openperouter/cni/cache"
   nodemarker:
     resources: {}
   # frr contains configuration specific to the perouter FRR container,

--- a/cmd/hostcontroller/main.go
+++ b/cmd/hostcontroller/main.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
@@ -48,6 +49,7 @@ import (
 	"github.com/openperouter/openperouter/api/static"
 	periov1alpha1 "github.com/openperouter/openperouter/api/v1alpha1"
 	"github.com/openperouter/openperouter/internal/buildversion"
+	"github.com/openperouter/openperouter/internal/cni"
 	"github.com/openperouter/openperouter/internal/controller/routerconfiguration"
 	"github.com/openperouter/openperouter/internal/filewatcher"
 	"github.com/openperouter/openperouter/internal/hostnetwork"
@@ -97,6 +99,8 @@ type parameters struct {
 	nodeName       string
 	namespace      string
 	logLevel       string
+	cniBinDir      string
+	cniCacheDir    string
 }
 
 func main() {
@@ -132,6 +136,10 @@ func main() {
 		systemdctl.HostDBusSocket, "the path of systemd control socket")
 	flag.IntVar(&hostModeParams.routerHealthCheckPort, "router-health-check-port",
 		9080, "the port for router health check endpoint")
+	flag.StringVar(&args.cniBinDir, "cni-bin-dir", "/opt/openperouter/cni/bin/",
+		"colon-separated list of directories to search for CNI plugin binaries")
+	flag.StringVar(&args.cniCacheDir, "cni-cache-dir", "/var/lib/openperouter/cni/cache",
+		"directory to store CNI result cache")
 
 	flag.Parse()
 
@@ -146,6 +154,30 @@ func main() {
 	ctrl.SetLogger(logr.FromSlogHandler(logger.Handler()))
 	setupLog.Info("version", "version", buildversion.Version())
 	setupLog.Info("arguments", "args", fmt.Sprintf("%+v", args))
+
+	if args.cniBinDir == "" {
+		setupLog.Info("cni-bin-dir cannot be empty")
+		os.Exit(1)
+	}
+	if args.cniCacheDir == "" {
+		setupLog.Info("cni-cache-dir cannot be empty")
+		os.Exit(1)
+	}
+
+	var cniPluginDirs []string
+	for dir := range strings.SplitSeq(args.cniBinDir, ":") {
+		if trimmed := strings.TrimSpace(dir); trimmed != "" {
+			cniPluginDirs = append(cniPluginDirs, trimmed)
+		}
+	}
+	if len(cniPluginDirs) == 0 {
+		setupLog.Info("no valid CNI plugin directories specified", "cni-bin-dir", args.cniBinDir)
+		os.Exit(1)
+	}
+
+	cniInvoker := cni.NewInvoker(cniPluginDirs, args.cniCacheDir)
+	setupLog.Info("CNI plugin invoker initialized", "pluginDirs", cniInvoker.PluginDirs(), "cacheDir", args.cniCacheDir)
+	_ = cniInvoker
 
 	// Setup signal handler once for the entire process
 	ctx := ctrl.SetupSignalHandler()

--- a/config/all-in-one/crio.yaml
+++ b/config/all-in-one/crio.yaml
@@ -1768,6 +1768,8 @@ spec:
           name: ovs-var-run
         - mountPath: /var/run/frr
           name: frr-sockets
+        - mountPath: /var/lib/openperouter/cni/cache
+          name: cni-cache
       hostNetwork: true
       hostPID: true
       serviceAccountName: controller
@@ -1796,6 +1798,10 @@ spec:
           path: /var/run/openperouter/frr
           type: DirectoryOrCreate
         name: frr-sockets
+      - hostPath:
+          path: /var/lib/openperouter/cni/cache
+          type: DirectoryOrCreate
+        name: cni-cache
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/config/all-in-one/openpe.yaml
+++ b/config/all-in-one/openpe.yaml
@@ -1701,6 +1701,8 @@ spec:
         - --namespace=$(NAMESPACE)
         - --frrconfig=/etc/frr/frr.conf
         - --reloader-socket=/etc/frr/reload.sock
+        - --cni-bin-dir=/opt/openperouter/cni/bin/
+        - --cni-cache-dir=/var/lib/openperouter/cni/cache
         command:
         - /controller
         env:
@@ -1765,6 +1767,8 @@ spec:
           name: ovs-var-run
         - mountPath: /var/run/frr
           name: frr-sockets
+        - mountPath: /var/lib/openperouter/cni/cache
+          name: cni-cache
       hostNetwork: true
       hostPID: true
       serviceAccountName: controller
@@ -1793,6 +1797,10 @@ spec:
           path: /var/run/openperouter/frr
           type: DirectoryOrCreate
         name: frr-sockets
+      - hostPath:
+          path: /var/lib/openperouter/cni/cache
+          type: DirectoryOrCreate
+        name: cni-cache
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/config/pods/controller.yaml
+++ b/config/pods/controller.yaml
@@ -32,6 +32,8 @@ spec:
         - "--namespace=$(NAMESPACE)"
         - "--frrconfig=/etc/frr/frr.conf"
         - "--reloader-socket=/etc/frr/reload.sock"
+        - "--cni-bin-dir=/opt/openperouter/cni/bin/"
+        - "--cni-cache-dir=/var/lib/openperouter/cni/cache"
         image: router:latest
         imagePullPolicy: IfNotPresent
         name: controller
@@ -83,6 +85,8 @@ spec:
           mountPropagation: HostToContainer
         - mountPath: /var/run/frr
           name: frr-sockets
+        - mountPath: /var/lib/openperouter/cni/cache
+          name: cni-cache
         resources:
           limits:
             cpu: 500m
@@ -107,6 +111,10 @@ spec:
       - name: frr-sockets
         hostPath:
           path: /var/run/openperouter/frr
+          type: DirectoryOrCreate
+      - name: cni-cache
+        hostPath:
+          path: /var/lib/openperouter/cni/cache
           type: DirectoryOrCreate
       tolerations:
       - effect: NoSchedule

--- a/e2etests/pkg/openperouter/controller.go
+++ b/e2etests/pkg/openperouter/controller.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package openperouter
+
+import (
+	"fmt"
+
+	"github.com/openperouter/openperouter/e2etests/pkg/k8s"
+	corev1 "k8s.io/api/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+const controllerLabelSelector = "app=controller"
+
+func ControllerPods(cs clientset.Interface) ([]*corev1.Pod, error) {
+	pods, err := k8s.PodsForLabel(cs, Namespace, controllerLabelSelector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve controller pods: %w", err)
+	}
+	return pods, nil
+}

--- a/e2etests/suite/suite_test.go
+++ b/e2etests/suite/suite_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -68,6 +69,12 @@ var _ = ginkgo.BeforeSuite(func() {
 	reporter, err := k8s.InitReporter(kubeconfig, tests.ReportPath, openperouter.Namespace, frrk8s.Namespace)
 	Expect(err).NotTo(HaveOccurred(), "failed to initialize k8s reporter (kubeconfig=%s)", kubeconfig)
 	tests.K8sReporter = reporter
+
+	cs := k8sclient.New()
+	ginkgo.By("validating CNI binaries and cache directory in controller")
+	Eventually(func(g Gomega) {
+		tests.ValidateCNIBinaries(g, cs)
+	}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
 })
 
 var _ = ginkgo.AfterSuite(func() {

--- a/e2etests/tests/hostconfiguration.go
+++ b/e2etests/tests/hostconfiguration.go
@@ -28,6 +28,18 @@ import (
 
 var ValidatorPath string
 
+var cniBinaries = []string{"macvlan", "ipvlan", "static", "dhcp"}
+
+const (
+	cniBinDir   = "/opt/openperouter/cni/bin"
+	cniCacheDir = "/var/lib/openperouter/cni/cache"
+)
+
+type cniTarget struct {
+	exec  executor.Executor
+	label string
+}
+
 const (
 	underlayConfiguredTestSelector      = "EXTERNAL.*underlay.* is configured.*"
 	underlayNotConfiguredTestSelector   = "EXTERNAL.*underlay.* is not configured.*"
@@ -1492,4 +1504,50 @@ func routerPodsWithValidator(cs clientset.Interface) ([]*corev1.Pod, error) {
 		ensureValidator(cs, pod)
 	}
 	return routerPods, nil
+}
+
+func ValidateCNIBinaries(g Gomega, cs clientset.Interface) {
+	cniTargets := k8sModeCNITarget
+	if HostMode {
+		cniTargets = hostModeCNITarget
+	}
+	for _, t := range cniTargets(g, cs) {
+		for _, bin := range cniBinaries {
+			path := cniBinDir + "/" + bin
+			out, err := t.exec.Exec("test", "-x", path)
+			g.Expect(err).NotTo(HaveOccurred(), "CNI binary %s missing or not executable on %s: %s", path, t.label, out)
+		}
+
+		out, err := t.exec.Exec("test", "-d", cniCacheDir)
+		g.Expect(err).NotTo(HaveOccurred(), "CNI cache directory %s missing on %s: %s", cniCacheDir, t.label, out)
+		out, err = t.exec.Exec("test", "-w", cniCacheDir)
+		g.Expect(err).NotTo(HaveOccurred(), "CNI cache directory %s not writable on %s: %s", cniCacheDir, t.label, out)
+	}
+}
+
+func k8sModeCNITarget(g Gomega, cs clientset.Interface) []cniTarget {
+	pods, err := openperouter.ControllerPods(cs)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(pods).NotTo(BeEmpty(), "no controller pods found")
+	targets := make([]cniTarget, 0, len(pods))
+	for _, pod := range pods {
+		targets = append(targets, cniTarget{
+			exec:  executor.ForPod(pod.Namespace, pod.Name, "controller"),
+			label: pod.Name,
+		})
+	}
+	return targets
+}
+
+func hostModeCNITarget(g Gomega, cs clientset.Interface) []cniTarget {
+	nodes, err := k8s.GetNodes(cs)
+	g.Expect(err).NotTo(HaveOccurred())
+	targets := make([]cniTarget, 0, len(nodes))
+	for _, node := range nodes {
+		targets = append(targets, cniTarget{
+			exec:  executor.ForPodmanInContainer(node.Name, "controller"),
+			label: node.Name,
+		})
+	}
+	return targets
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.4
 
 require (
 	github.com/apparentlymart/go-cidr v1.1.0
+	github.com/containernetworking/cni v1.3.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-kit/log v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/containerd/continuity v0.4.5 h1:ZRoN1sXq9u7V6QoHMcVWGhOwDFqZ4B9i5H6un1Wh0x4=
 github.com/containerd/continuity v0.4.5/go.mod h1:/lNJvtJKUQStBzpVQ1+rasXO1LAWtUQssk28EZvJ3nE=
+github.com/containernetworking/cni v1.3.0 h1:v6EpN8RznAZj9765HhXQrtXgX+ECGebEYEmnuFjskwo=
+github.com/containernetworking/cni v1.3.0/go.mod h1:Bs8glZjjFfGPHMw6hQu82RUgEPNGEaBb9KS5KtNMnJ4=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=

--- a/internal/cni/invoker.go
+++ b/internal/cni/invoker.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package cni
+
+import (
+	"github.com/containernetworking/cni/libcni"
+)
+
+type Invoker struct {
+	cniConfig  *libcni.CNIConfig
+	cacheDir   string
+	pluginDirs []string
+}
+
+func NewInvoker(pluginDirs []string, cacheDir string) *Invoker {
+	return &Invoker{
+		cniConfig:  libcni.NewCNIConfigWithCacheDir(pluginDirs, cacheDir, nil),
+		cacheDir:   cacheDir,
+		pluginDirs: pluginDirs,
+	}
+}
+
+func (inv *Invoker) PluginDirs() []string {
+	return inv.pluginDirs
+}

--- a/operator/bindata/deployment/openperouter/README.md
+++ b/operator/bindata/deployment/openperouter/README.md
@@ -27,6 +27,8 @@ Kubernetes: `>= 1.19.0-0`
 | fullnameOverride | string | `""` |  |
 | nameOverride | string | `""` |  |
 | openperouter.affinity | object | `{}` |  |
+| openperouter.controller.cniBinDir | string | `"/opt/openperouter/cni/bin/"` | CNI plugin binary directory. The default matches the path baked into the controller image. Override only to use externally-provided binaries (e.g. host-mounted). Supports colon-separated paths for multiple directories. |
+| openperouter.controller.cniCacheDir | string | `"/var/lib/openperouter/cni/cache"` | CNI cache directory for persistent CNI state across pod restarts |
 | openperouter.controller.healthProbePort | int | `9081` | Health probe port for liveness and readiness checks |
 | openperouter.controller.resources | object | `{}` |  |
 | openperouter.cri | string | `"containerd"` |  |

--- a/operator/bindata/deployment/openperouter/templates/controller.yaml
+++ b/operator/bindata/deployment/openperouter/templates/controller.yaml
@@ -62,6 +62,8 @@ spec:
         {{- with .Values.openperouter.ovsSocketPath }}
         - --ovssocket={{ . }}
         {{- end }}
+        - --cni-bin-dir={{ .Values.openperouter.controller.cniBinDir }}
+        - --cni-cache-dir={{ .Values.openperouter.controller.cniCacheDir }}
         command:
         - /controller
         env:
@@ -132,6 +134,8 @@ spec:
           mountPropagation: HostToContainer
         - mountPath: /var/run/frr
           name: frr-sockets
+        - mountPath: {{ .Values.openperouter.controller.cniCacheDir | default "/var/lib/openperouter/cni/cache" }}
+          name: cni-cache
       hostNetwork: true
       hostPID: true
       tolerations:
@@ -175,4 +179,8 @@ spec:
           path: /var/run/openperouter/frr
           type: DirectoryOrCreate
         name: frr-sockets
+      - hostPath:
+          path: {{ .Values.openperouter.controller.cniCacheDir | default "/var/lib/openperouter/cni/cache" }}
+          type: DirectoryOrCreate
+        name: cni-cache
 {{- end }}

--- a/operator/bindata/deployment/openperouter/values.yaml
+++ b/operator/bindata/deployment/openperouter/values.yaml
@@ -52,6 +52,12 @@ openperouter:
     resources: {}
     # -- Health probe port for liveness and readiness checks
     healthProbePort: 9081
+    # -- CNI plugin binary directory. The default matches the path baked into the
+    # controller image. Override only to use externally-provided binaries (e.g.
+    # host-mounted). Supports colon-separated paths for multiple directories.
+    cniBinDir: "/opt/openperouter/cni/bin/"
+    # -- CNI cache directory for persistent CNI state across pod restarts
+    cniCacheDir: "/var/lib/openperouter/cni/cache"
   nodemarker:
     resources: {}
   # frr contains configuration specific to the perouter FRR container,

--- a/systemdmode/quadlets/controller.container
+++ b/systemdmode/quadlets/controller.container
@@ -56,6 +56,9 @@ Volume=/run/dbus/system_bus_socket:/host/dbus/system_bus_socket:rw
 # The directory is pre-created by ExecStartPre if it doesn't exist.
 Volume=/var/run/openvswitch:/var/run/openvswitch:rshared
 
+# CNI result cache - persistent across container restarts
+Volume=/var/lib/openperouter/cni/cache:/var/lib/openperouter/cni/cache:rw
+
 # Environment variables
 Environment=KUBECONFIG=/shared/kubeconfig
 
@@ -69,7 +72,7 @@ PodmanArgs=--pid=host
 PodmanArgs=--uts=host
 
 # Controller command-line arguments
-Exec=--frrconfig /etc/perouter/frr/frr.conf --pid-path /etc/perouter/frr/frr.pid --reloader-socket /etc/perouter/frr/frr.socket --mode host --namespace openperouter-system
+Exec=--frrconfig /etc/perouter/frr/frr.conf --pid-path /etc/perouter/frr/frr.pid --reloader-socket /etc/perouter/frr/frr.socket --mode host --namespace openperouter-system --cni-bin-dir=/opt/openperouter/cni/bin/ --cni-cache-dir=/var/lib/openperouter/cni/cache
 
 # Health check - kill container if controller stops responding,
 # systemd Restart=on-failure handles restart
@@ -92,6 +95,7 @@ ExecStartPre=/usr/bin/mkdir -p /etc/perouter/frr
 ExecStartPre=/usr/bin/mkdir -p /var/lib/hostbridge
 ExecStartPre=/usr/bin/mkdir -p /var/lib/openperouter
 ExecStartPre=/usr/bin/mkdir -p /var/run/openvswitch
+ExecStartPre=/usr/bin/mkdir -p /var/lib/openperouter/cni/cache
 
 # If a can_start.sh script is mounted, run it and wait for success.
 # This allows deferring startup until external dependencies are ready.


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup

/kind feature

> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

## CNI plugin integration for underlay interface provisioning

The controller image now bundles CNI plugin binaries (macvlan, ipvlan, static, dhcp) from containernetworking/plugins v1.6.2. 

A new internal/cni.Invoker wraps libcni and is initialized at controller startup via --cni-bin-dir and --cni-cache-dir flags. This lays the groundwork for the controller to provision underlay interfaces directly in the router netns, replacing the removed Multus-based integration.

All deployment methods (helm, operator, kustomize, systemd quadlet) are wired with the new flags and a persistent cache volume. CI verifies the binaries are present in the image before publishing the artifact, and e2e tests validate them at runtime across both K8s and systemd modes.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
The controller now bundles CNI plugin binaries (macvlan, ipvlan, static, dhcp) and exposes a libcni-based invoker, preparing for direct underlay interface provisioning in the router netns without Multus.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
