### PR TITLE
Systemd mode: run the router containers in a named namespace

### DIFF
--- a/e2etests/tests/systemd_resiliency.go
+++ b/e2etests/tests/systemd_resiliency.go
@@ -5,6 +5,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -15,8 +16,10 @@ import (
 	"github.com/openperouter/openperouter/e2etests/pkg/config"
 	"github.com/openperouter/openperouter/e2etests/pkg/executor"
 	"github.com/openperouter/openperouter/e2etests/pkg/infra"
+	"github.com/openperouter/openperouter/e2etests/pkg/k8s"
 	"github.com/openperouter/openperouter/e2etests/pkg/k8sclient"
 	"github.com/openperouter/openperouter/e2etests/pkg/openperouter"
+	"github.com/openperouter/openperouter/e2etests/pkg/url"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -128,4 +131,366 @@ var _ = Describe("Systemd Router Restart Resiliency", Label("systemdmode"), Orde
 		validateTORSessions()
 	})
 
+})
+
+var _ = Describe("Systemd: Named netns and kernel objects survive FRR container kill", Label("systemdmode"), Ordered, func() {
+	var cs clientset.Interface
+	var nodes []corev1.Node
+
+	vniRed := v1alpha1.L3VNI{
+		ObjectMeta: metav1.ObjectMeta{Name: "red", Namespace: openperouter.Namespace},
+		Spec:       v1alpha1.L3VNISpec{VRF: "red", VNI: 100},
+	}
+
+	l2VniRed := v1alpha1.L2VNI{
+		ObjectMeta: metav1.ObjectMeta{Name: "red110", Namespace: openperouter.Namespace},
+		Spec: v1alpha1.L2VNISpec{
+			VRF: new("red"),
+			VNI: 110,
+			HostMaster: &v1alpha1.HostMaster{
+				Type:        "linux-bridge",
+				LinuxBridge: &v1alpha1.LinuxBridgeConfig{AutoCreate: new(true)},
+			},
+		},
+	}
+
+	BeforeAll(func() {
+		err := Updater.CleanAll()
+		Expect(err).NotTo(HaveOccurred())
+
+		cs = k8sclient.New()
+		_, err = openperouter.Get(cs, HostMode)
+		Expect(err).NotTo(HaveOccurred())
+
+		nodesItems, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		nodes = nodesItems.Items
+
+		err = Updater.Update(config.Resources{
+			Underlays: []v1alpha1.Underlay{infra.Underlay},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(infra.LeafKind1Config.UpdateConfig(nodes, infra.LeafKindConfiguration{})).To(Succeed())
+		Expect(infra.LeafKind2Config.UpdateConfig(nodes, infra.LeafKindConfiguration{})).To(Succeed())
+
+		err = Updater.Update(config.Resources{
+			L3VNIs: []v1alpha1.L3VNI{vniRed},
+			L2VNIs: []v1alpha1.L2VNI{l2VniRed},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("waiting for interfaces in named netns on all nodes")
+		for _, node := range nodes {
+			for _, ifType := range []string{"vrf", "bridge", "vxlan"} {
+				Eventually(func(g Gomega) {
+					g.Expect(openperouter.NamedNetnsHasInterfaceType(node.Name, ifType)).To(BeTrue())
+				}).WithTimeout(2 * time.Minute).WithPolling(time.Second).Should(Succeed())
+			}
+		}
+	})
+
+	AfterAll(func() {
+		Expect(infra.LeafKind1Config.UpdateConfig(nodes, infra.LeafKindConfiguration{})).To(Succeed())
+		Expect(infra.LeafKind2Config.UpdateConfig(nodes, infra.LeafKindConfiguration{})).To(Succeed())
+		Expect(Updater.CleanAll()).To(Succeed())
+	})
+
+	AfterEach(func() {
+		dumpIfFails(cs)
+	})
+
+	It("should preserve named netns and kernel objects when FRR container is killed", func() {
+		Expect(nodes).NotTo(BeEmpty())
+		nodeName := nodes[0].Name
+		nodeExec := executor.ForContainer(nodeName)
+
+		By("verifying named netns exists before crash")
+		Expect(openperouter.NamedNetnsExists(nodeName)).To(BeTrue())
+
+		By("verifying kernel objects exist before crash")
+		for _, ifType := range []string{"vrf", "bridge", "vxlan"} {
+			Expect(openperouter.NamedNetnsHasInterfaceType(nodeName, ifType)).To(BeTrue(), "interface type %s must exist before crash", ifType)
+		}
+
+		By("killing FRR container via podman")
+		_, err := nodeExec.Exec("podman", "kill", "frr")
+		Expect(err).NotTo(HaveOccurred())
+
+		By("immediately asserting named netns and kernel objects survived")
+		Expect(openperouter.NamedNetnsExists(nodeName)).To(BeTrue(), "named netns must survive FRR container kill")
+
+		for _, ifType := range []string{"vrf", "bridge", "vxlan"} {
+			Expect(openperouter.NamedNetnsHasInterfaceType(nodeName, ifType)).To(BeTrue(), "interface type %s must survive FRR container kill", ifType)
+		}
+
+		By("waiting for routerpod service to restart")
+		Eventually(func() error {
+			output, err := nodeExec.Exec("systemctl", "is-active", "routerpod-pod.service")
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(output) != "active" {
+				return fmt.Errorf("service is not active: %s", output)
+			}
+			return nil
+		}, 2*time.Minute, time.Second).Should(Succeed())
+
+		By("waiting for BGP sessions to re-establish")
+		neighborIP, err := infra.NeighborIP(infra.KindLeaf, nodeName)
+		Expect(err).NotTo(HaveOccurred())
+		validateSessionWithNeighbor(
+			executor.ForContainer(infra.KindLeaf),
+			validationParameters{
+				fromName:    infra.KindLeaf,
+				toName:      nodeName,
+				neighborIP:  neighborIP,
+				established: Established,
+			},
+		)
+	})
+})
+
+var _ = Describe("Systemd: Controller auto-recovers when operator deletes named netns", Label("systemdmode"), Ordered, func() {
+	var cs clientset.Interface
+	var nodes []corev1.Node
+
+	BeforeAll(func() {
+		err := Updater.CleanAll()
+		Expect(err).NotTo(HaveOccurred())
+
+		cs = k8sclient.New()
+		_, err = openperouter.Get(cs, HostMode)
+		Expect(err).NotTo(HaveOccurred())
+
+		nodesItems, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		nodes = nodesItems.Items
+
+		err = Updater.Update(config.Resources{
+			Underlays: []v1alpha1.Underlay{infra.Underlay},
+			L3VNIs: []v1alpha1.L3VNI{{
+				ObjectMeta: metav1.ObjectMeta{Name: "red", Namespace: openperouter.Namespace},
+				Spec:       v1alpha1.L3VNISpec{VRF: "red", VNI: 100},
+			}},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(infra.LeafKind1Config.UpdateConfig(nodes, infra.LeafKindConfiguration{})).To(Succeed())
+		Expect(infra.LeafKind2Config.UpdateConfig(nodes, infra.LeafKindConfiguration{})).To(Succeed())
+
+		By("waiting for interfaces in named netns")
+		for _, node := range nodes {
+			for _, ifType := range []string{"vrf", "bridge", "vxlan"} {
+				Eventually(func(g Gomega) {
+					g.Expect(openperouter.NamedNetnsHasInterfaceType(node.Name, ifType)).To(BeTrue())
+				}).WithTimeout(2 * time.Minute).WithPolling(time.Second).Should(Succeed())
+			}
+		}
+	})
+
+	AfterAll(func() {
+		Expect(infra.LeafKind1Config.UpdateConfig(nodes, infra.LeafKindConfiguration{})).To(Succeed())
+		Expect(infra.LeafKind2Config.UpdateConfig(nodes, infra.LeafKindConfiguration{})).To(Succeed())
+		Expect(Updater.CleanAll()).To(Succeed())
+	})
+
+	AfterEach(func() {
+		dumpIfFails(cs)
+	})
+
+	It("should auto-recover after ip netns delete without manual restart", func() {
+		Expect(nodes).NotTo(BeEmpty())
+		nodeName := nodes[0].Name
+
+		By("verifying named netns exists")
+		Expect(openperouter.NamedNetnsExists(nodeName)).To(BeTrue())
+
+		By("deleting named netns — do NOT manually restart routerpod")
+		Expect(openperouter.DeleteNamedNetns(nodeName)).To(Succeed())
+
+		By("waiting for controller to detect missing netns and auto-restart routerpod")
+		Eventually(func() (bool, error) {
+			return openperouter.NamedNetnsExists(nodeName)
+		}, 3*time.Minute, 2*time.Second).Should(BeTrue(), "controller must auto-recreate named netns")
+
+		By("waiting for all interface types to be recreated")
+		for _, ifType := range []string{"vrf", "bridge", "vxlan"} {
+			Eventually(func() (bool, error) {
+				return openperouter.NamedNetnsHasInterfaceType(nodeName, ifType)
+			}, 2*time.Minute, 2*time.Second).Should(BeTrue(), "interface type %s must be recreated", ifType)
+		}
+
+		By("waiting for routerpod service to become active")
+		nodeExec := executor.ForContainer(nodeName)
+		Eventually(func() error {
+			output, err := nodeExec.Exec("systemctl", "is-active", "routerpod-pod.service")
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(output) != "active" {
+				return fmt.Errorf("service not active: %s", output)
+			}
+			return nil
+		}, 2*time.Minute, time.Second).Should(Succeed())
+
+		By("waiting for BGP sessions to re-establish")
+		neighborIP, err := infra.NeighborIP(infra.KindLeaf, nodeName)
+		Expect(err).NotTo(HaveOccurred())
+		validateSessionWithNeighbor(
+			executor.ForContainer(infra.KindLeaf),
+			validationParameters{
+				fromName:    infra.KindLeaf,
+				toName:      nodeName,
+				neighborIP:  neighborIP,
+				established: Established,
+			},
+		)
+	})
+})
+
+var _ = Describe("Systemd: Data plane continuity during FRR restart", Label("systemdmode"), Ordered, func() {
+	var cs clientset.Interface
+	var nodes []corev1.Node
+	const testNamespace = "test-systemd-dataplane"
+
+	BeforeAll(func() {
+		err := Updater.CleanAll()
+		Expect(err).NotTo(HaveOccurred())
+
+		cs = k8sclient.New()
+		_, err = openperouter.Get(cs, HostMode)
+		Expect(err).NotTo(HaveOccurred())
+
+		nodesItems, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		nodes = nodesItems.Items
+		Expect(len(nodes)).To(BeNumerically(">=", 2), "stretched L2 test requires at least 2 nodes")
+
+		l2VniRedWithGateway := v1alpha1.L2VNI{
+			ObjectMeta: metav1.ObjectMeta{Name: "red110", Namespace: openperouter.Namespace},
+			Spec: v1alpha1.L2VNISpec{
+				VRF:          new("red"),
+				VNI:          110,
+				L2GatewayIPs: []string{"192.171.24.1/24"},
+				HostMaster:   &v1alpha1.HostMaster{Type: "linux-bridge", LinuxBridge: &v1alpha1.LinuxBridgeConfig{AutoCreate: new(true)}},
+			},
+		}
+
+		err = Updater.Update(config.Resources{
+			Underlays: []v1alpha1.Underlay{infra.Underlay},
+			L3VNIs: []v1alpha1.L3VNI{{
+				ObjectMeta: metav1.ObjectMeta{Name: "red", Namespace: openperouter.Namespace},
+				Spec:       v1alpha1.L3VNISpec{VRF: "red", VNI: 100},
+			}},
+			L2VNIs: []v1alpha1.L2VNI{l2VniRedWithGateway},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+	})
+
+	AfterAll(func() {
+		Expect(infra.LeafKind1Config.UpdateConfig(nodes, infra.LeafKindConfiguration{})).To(Succeed())
+		Expect(infra.LeafKind2Config.UpdateConfig(nodes, infra.LeafKindConfiguration{})).To(Succeed())
+		_ = k8s.DeleteNamespace(cs, testNamespace)
+		Expect(Updater.CleanAll()).To(Succeed())
+	})
+
+	AfterEach(func() {
+		dumpIfFails(cs, testNamespace)
+	})
+
+	It("should maintain data plane during routerpod restart", func() {
+		const (
+			serverIP = "192.171.24.2"
+			clientIP = "192.171.24.3"
+			subnet   = "/24"
+			port     = "8090"
+		)
+
+		_, err := k8s.CreateNamespace(cs, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		nad, err := k8s.CreateMacvlanNad("110", testNamespace, "br-hs-110", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating server pod on node 0")
+		_, err = k8s.CreateAgnhostPod(cs, "server", testNamespace,
+			k8s.WithNad(nad.Name, testNamespace, []string{serverIP + subnet}),
+			k8s.OnNode(nodes[0].Name))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating client pod on node 1")
+		clientPod, err := k8s.CreateAgnhostPod(cs, "client", testNamespace,
+			k8s.WithNad(nad.Name, testNamespace, []string{clientIP + subnet}),
+			k8s.OnNode(nodes[1].Name))
+		Expect(err).NotTo(HaveOccurred())
+
+		clientExec := executor.ForPod(clientPod.Namespace, clientPod.Name, "agnhost")
+		hostPort := net.JoinHostPort(serverIP, port)
+		urlStr := url.Format("http://%s/clientip", hostPort)
+
+		By("waiting for BGP sessions to establish")
+		for _, node := range nodes {
+			neighborIP, err := infra.NeighborIP(infra.KindLeaf, node.Name)
+			Expect(err).NotTo(HaveOccurred())
+			validateSessionWithNeighbor(
+				executor.ForContainer(infra.KindLeaf),
+				validationParameters{
+					fromName:    infra.KindLeaf,
+					toName:      node.Name,
+					neighborIP:  neighborIP,
+					established: Established,
+				},
+			)
+		}
+
+		By("verifying stretched L2 traffic works before restart")
+		Eventually(func() error {
+			_, err := clientExec.Exec("curl", "-sS", "--max-time", "2", urlStr)
+			return err
+		}).WithTimeout(2 * time.Minute).WithPolling(time.Second).Should(Succeed())
+
+		By("starting continuous traffic measurement")
+		stopAndCount := measureTrafficLoss(clientExec, urlStr)
+
+		By("restarting routerpod on server's node")
+		serverNodeExec := executor.ForContainer(nodes[0].Name)
+		_, err = serverNodeExec.Exec("systemctl", "restart", "routerpod-pod.service")
+		Expect(err).NotTo(HaveOccurred())
+
+		By("waiting for service to restart and BGP to re-establish")
+		Eventually(func() error {
+			output, err := serverNodeExec.Exec("systemctl", "is-active", "routerpod-pod.service")
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(output) != "active" {
+				return fmt.Errorf("service not active: %s", output)
+			}
+			return nil
+		}, 2*time.Minute, time.Second).Should(Succeed())
+
+		neighborIP, err := infra.NeighborIP(infra.KindLeaf, nodes[0].Name)
+		Expect(err).NotTo(HaveOccurred())
+		validateSessionWithNeighbor(
+			executor.ForContainer(infra.KindLeaf),
+			validationParameters{
+				fromName:    infra.KindLeaf,
+				toName:      nodes[0].Name,
+				neighborIP:  neighborIP,
+				established: Established,
+			},
+		)
+
+		By("asserting data plane disruption is within acceptable bounds")
+		result := stopAndCount()
+		By(fmt.Sprintf("==> %s", result.String()))
+		Expect(result.eval()).To(
+			Succeed(),
+			"curl failures exceeded threshold during routerpod restart (%d/%d failed)",
+			result.failCount,
+			result.totalCount,
+		)
+	})
 })

--- a/internal/controller/routerconfiguration/router.go
+++ b/internal/controller/routerconfiguration/router.go
@@ -7,11 +7,11 @@ import (
 )
 
 type RouterProvider interface {
-	New() (Router, error)
+	New(ctx context.Context) (Router, error)
 	NodeIndex(ctx context.Context) (int, error)
 }
 
 type Router interface {
 	TargetNS(ctx context.Context) (string, error)
-	CanReconcile(ctx context.Context) (bool, error)
+	CanReconcile() (bool, error)
 }

--- a/internal/controller/routerconfiguration/router_host.go
+++ b/internal/controller/routerconfiguration/router_host.go
@@ -4,12 +4,12 @@ package routerconfiguration
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -35,7 +35,28 @@ type RouterHostContainer struct {
 
 var _ Router = (*RouterHostContainer)(nil)
 
-func (r *RouterHostProvider) New() (Router, error) {
+func (r *RouterHostProvider) New(ctx context.Context) (Router, error) {
+	// If the service is running but the netns is gone, restart the service so it
+	// recreates the netns on startup. Without this, CanReconcile() loops forever
+	// returning false and the netns is never recovered.
+	missing, err := isRouterPodActiveWithNoNamespace()
+	if err != nil {
+		return nil, fmt.Errorf("failed to check router pod netns state: %w", err)
+	}
+	if !missing {
+		return &RouterHostContainer{
+			manager: r,
+		}, nil
+	}
+	slog.Info("named netns missing while service is active, restarting service to recover",
+		"path", netnamespace.NamedNSPath)
+	sdClient, err := systemdctl.NewClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create systemd client for restart: %w", err)
+	}
+	if err := sdClient.Restart(ctx, "routerpod-pod.service"); err != nil {
+		slog.Warn("failed to restart routerpod service after missing netns", "error", err)
+	}
 	return &RouterHostContainer{
 		manager: r,
 	}, nil
@@ -45,50 +66,36 @@ func (r *RouterHostProvider) NodeIndex(ctx context.Context) (int, error) {
 	return r.CurrentNodeIndex, nil
 }
 
-func (r *RouterHostContainer) TargetNS(ctx context.Context) (string, error) {
-	pidData, err := os.ReadFile(r.manager.RouterPidFilePath)
-	if err != nil {
-		return "", fmt.Errorf("failed to read PID file %s: %w", r.manager.RouterPidFilePath, err)
-	}
-
-	pidStr := strings.TrimSpace(string(pidData))
-	pid, err := strconv.Atoi(pidStr)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse PID from file %s: %w", r.manager.RouterPidFilePath, err)
-	}
-
-	res := fmt.Sprintf("/hostproc/%d/ns/net", pid)
-	return res, nil
+func (r *RouterHostContainer) TargetNS(_ context.Context) (string, error) {
+	return netnamespace.NamedNSPath, nil
 }
 
-func (r *RouterHostContainer) CanReconcile(ctx context.Context) (bool, error) {
+func (r *RouterHostContainer) CanReconcile() (bool, error) {
 	client, err := systemdctl.NewClient()
 	if err != nil {
-		return false, fmt.Errorf("failed to create systemd client %w", err)
+		return false, fmt.Errorf("failed to create systemd client: %w", err)
 	}
 	isActive, err := client.IsActive("routerpod-pod.service")
 	if err != nil {
-		return false, fmt.Errorf("failed to check if router pod service is active")
+		return false, fmt.Errorf("failed to check if router pod service is active: %w", err)
 	}
 	if !isActive {
 		slog.Info("router pod service is not active")
 		return false, nil
 	}
 
-	targetNS, err := r.TargetNS(ctx)
-	if err != nil {
-		slog.Error("failed to get router target namespace", "error", err)
+	ns, err := netns.GetFromPath(netnamespace.NamedNSPath)
+	if errors.Is(err, os.ErrNotExist) {
+		slog.Info("named netns not found, will retry on next reconcile",
+			"path", netnamespace.NamedNSPath, "error", err)
 		return false, nil
 	}
-
-	ns, err := netns.GetFromPath(targetNS)
 	if err != nil {
-		slog.Info("failed to open router network namespace", "namespace", targetNS, "error", err)
-		return false, nil
+		return false, fmt.Errorf("failed to open named netns %s: %w", netnamespace.NamedNSPath, err)
 	}
 	defer func() {
 		if err := ns.Close(); err != nil {
-			slog.Error("failed to close namespace", "namespace", targetNS, "error", err)
+			slog.Error("failed to close namespace", "error", err)
 		}
 	}()
 
@@ -196,4 +203,26 @@ func (r *RouterHostProvider) StartFRRRestartWatcher(ctx context.Context, onResta
 	}()
 
 	return nil
+}
+
+func isRouterPodActiveWithNoNamespace() (bool, error) {
+	sdClient, err := systemdctl.NewClient()
+	if err != nil {
+		return false, fmt.Errorf("failed to create systemd client: %w", err)
+	}
+	state, err := sdClient.ActiveState("routerpod-pod.service")
+	if err != nil {
+		return false, fmt.Errorf("failed to check router pod service state: %w", err)
+	}
+	if state != systemdctl.StateActive {
+		return false, nil
+	}
+	ns, err := netns.GetFromPath(netnamespace.NamedNSPath)
+	if err == nil {
+		if closeErr := ns.Close(); closeErr != nil {
+			slog.Error("failed to close namespace handle", "error", closeErr)
+		}
+		return false, nil
+	}
+	return errors.Is(err, os.ErrNotExist), nil
 }

--- a/internal/controller/routerconfiguration/router_named_ns.go
+++ b/internal/controller/routerconfiguration/router_named_ns.go
@@ -31,7 +31,7 @@ type RouterNamedNS struct {
 
 var _ Router = (*RouterNamedNS)(nil)
 
-func (r *RouterNamedNSProvider) New() (Router, error) {
+func (r *RouterNamedNSProvider) New(ctx context.Context) (Router, error) {
 	if err := netnamespace.EnsureNamespace(); err != nil {
 		return nil, fmt.Errorf("failed to ensure named netns: %w", err)
 	}
@@ -64,7 +64,7 @@ func (r *RouterNamedNS) TargetNS(_ context.Context) (string, error) {
 	return netnamespace.NamedNSPath, nil
 }
 
-func (r *RouterNamedNS) CanReconcile(_ context.Context) (bool, error) {
+func (r *RouterNamedNS) CanReconcile() (bool, error) {
 	ns, err := netns.GetFromPath(netnamespace.NamedNSPath)
 	if err != nil {
 		slog.Info("named netns not available", "path", netnamespace.NamedNSPath, "error", err)

--- a/internal/controller/routerconfiguration/static_configuration_controller.go
+++ b/internal/controller/routerconfiguration/static_configuration_controller.go
@@ -58,12 +58,12 @@ func (r *StaticConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		"underlays", len(apiConfig.Underlays),
 		"l3passthrough", len(apiConfig.L3Passthrough))
 
-	router, err := r.RouterProvider.New()
+	router, err := r.RouterProvider.New(ctx)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get router instance: %w", err)
 	}
 
-	canReconcile, err := router.CanReconcile(ctx)
+	canReconcile, err := router.CanReconcile()
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("canReconcile error: %w", err)
 	}

--- a/internal/controller/routerconfiguration/underlay_vni_controller.go
+++ b/internal/controller/routerconfiguration/underlay_vni_controller.go
@@ -126,7 +126,7 @@ func (r *PERouterReconciler) reconcile(ctx context.Context, logger *slog.Logger)
 		}
 	}
 
-	router, err := r.RouterProvider.New()
+	router, err := r.RouterProvider.New(ctx)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get router pod instance: %w", err)
 	}
@@ -135,7 +135,7 @@ func (r *PERouterReconciler) reconcile(ctx context.Context, logger *slog.Logger)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to retrieve target namespace: %w", err)
 	}
-	canReconcile, err := router.CanReconcile(ctx)
+	canReconcile, err := router.CanReconcile()
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to check if router can be reconciled: %w", err)
 	}

--- a/internal/systemdctl/systemdctl.go
+++ b/internal/systemdctl/systemdctl.go
@@ -14,6 +14,11 @@ const (
 	HostDBusSocket = "unix:path=/host/dbus/system_bus_socket"
 
 	DefaultTimeout = 30 * time.Second
+
+	StateActive     = "active"
+	StateActivating = "activating"
+	StateInactive   = "inactive"
+	StateFailed     = "failed"
 )
 
 // Client is a systemd client that uses systemctl commands via nsenter
@@ -43,6 +48,26 @@ func (c *Client) Restart(ctx context.Context, unitName string) error {
 
 // IsActive checks if a systemd unit is active
 func (c *Client) IsActive(unitName string) (bool, error) {
+	state, err := c.ActiveState(unitName)
+	if err != nil {
+		return false, err
+	}
+	return state == StateActive, nil
+}
+
+// IsActivating checks if a systemd unit is in the "activating" state
+// (i.e. still starting up).
+func (c *Client) IsActivating(unitName string) (bool, error) {
+	state, err := c.ActiveState(unitName)
+	if err != nil {
+		return false, err
+	}
+	return state == StateActivating, nil
+}
+
+// ActiveState returns the ActiveState of a systemd unit
+// (e.g. "active", "activating", "inactive", "failed").
+func (c *Client) ActiveState(unitName string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
 
@@ -56,18 +81,17 @@ func (c *Client) IsActive(unitName string) (bool, error) {
 
 	cmd := exec.CommandContext(ctx, "nsenter", cmdArgs...)
 	output, err := cmd.CombinedOutput()
+	state := strings.TrimSpace(string(output))
 
-	// systemctl is-active returns 0 if active, non-zero otherwise
+	// systemctl is-active returns non-zero for anything other than "active"
 	if err != nil {
-		// Check if it's just because the unit is not active
-		if strings.TrimSpace(string(output)) == "inactive" ||
-			strings.TrimSpace(string(output)) == "failed" {
-			return false, nil
+		if state == StateInactive || state == StateFailed || state == StateActivating {
+			return state, nil
 		}
-		return false, fmt.Errorf("systemctl is-active %s failed: %w: %s", unitName, err, string(output))
+		return "", fmt.Errorf("systemctl is-active %s failed: %w: %s", unitName, err, string(output))
 	}
 
-	return strings.TrimSpace(string(output)) == "active", nil
+	return state, nil
 }
 
 // runSystemctl executes a systemctl command in the host's namespaces

--- a/systemdmode/quadlets/routerpod.pod
+++ b/systemdmode/quadlets/routerpod.pod
@@ -14,6 +14,8 @@ After=network-online.target
 # Pod name - will create Podman pod named "systemd-routerpod"
 PodName=routerpod
 
+Network=ns:/var/run/netns/perouter
+
 # PID namespace sharing - required for FRR process management
 # The reloader needs to see FRR processes to signal configuration reloads
 # Note: Using PodmanArgs because quadlet has no native PodShare= directive
@@ -26,6 +28,10 @@ Restart=on-failure
 
 # Timeout for stopping the pod
 TimeoutStopSec=70
+
+# Create named netns if not present (- prefix = ignore failure when already exists)
+ExecStartPre=-/usr/sbin/ip netns add perouter
+ExecStartPre=/usr/sbin/ip netns exec perouter ip link set lo up
 
 [Install]
 # Automatically enable this pod at boot


### PR DESCRIPTION


<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
/kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

Aligning systemd mode to k8s and running frr in a named network namespace. With podman quadlets this is handled directly by the quadlet.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Run systemd mode frr containers in a separate network namespace, like the k8s variant does.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
