### PR TITLE
docs: add modern Go features guideline to Claude.md

### DIFF
--- a/Claude.md
+++ b/Claude.md
@@ -41,6 +41,23 @@ The development environment uses kind and containerlab. Details can be found in 
 
 You can run `make lint` to run the go linter against the codebase.
 
+### Use Modern Go Features
+
+Always check the Go version in `go.mod` and prefer language features and standard library additions from that version
+over third-party helpers or older patterns.
+
+**Example - Go 1.26 `new()` builtin:**
+```go
+// Good: use the builtin
+val := new("hello")
+
+// Avoid: third-party pointer helpers
+val := ptr.To("hello")
+```
+
+When writing new code, modifying existing code, or reviewing code, prefer the latest idiomatic constructs available in
+the project's Go version rather than relying on utility packages that duplicate standard functionality.
+
 ### Code Readability: Line of Sight
 
 Write code that's easy to scan vertically:


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind documentation

**What this PR does / why we need it**:

Adds a "Use Modern Go Features" section under Go Style Guidelines in Claude.md. This instructs contributors and AI to prefer language features from the project's Go version over third-party helpers (e.g. Go 1.26 builtin `new()` instead of `ptr.To()`).

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.