### PR TITLE
WIP | fix(grout): set short BGP connect-retry on passthrough neighbors

### DIFF
--- a/internal/conversion/frr_conversion.go
+++ b/internal/conversion/frr_conversion.go
@@ -403,11 +403,14 @@ func passthroughToFRR(l3Passthroughs []v1alpha1.L3Passthrough, nodeIndex int) (*
 		return nil, fmt.Errorf("could not parse passthrough HostSession, err: %w", err)
 	}
 
+	const passthroughConnectRetrySeconds = int64(5)
+
 	if vethIPs.Ipv4.HostSide.IP != nil {
 		res.LocalNeighborV4 = &frr.NeighborConfig{
-			ASN:  asn,
-			Addr: vethIPs.Ipv4.HostSide.IP.String(),
-			ID:   vethIPs.Ipv4.HostSide.IP.String(),
+			ASN:         asn,
+			Addr:        vethIPs.Ipv4.HostSide.IP.String(),
+			ID:          vethIPs.Ipv4.HostSide.IP.String(),
+			ConnectTime: ptr.To(passthroughConnectRetrySeconds),
 		}
 		ipnet := net.IPNet{
 			IP:   vethIPs.Ipv4.HostSide.IP,
@@ -418,9 +421,10 @@ func passthroughToFRR(l3Passthroughs []v1alpha1.L3Passthrough, nodeIndex int) (*
 	}
 	if vethIPs.Ipv6.HostSide.IP != nil {
 		res.LocalNeighborV6 = &frr.NeighborConfig{
-			ASN:  asn,
-			Addr: vethIPs.Ipv6.HostSide.IP.String(),
-			ID:   vethIPs.Ipv6.HostSide.IP.String(),
+			ASN:         asn,
+			Addr:        vethIPs.Ipv6.HostSide.IP.String(),
+			ID:          vethIPs.Ipv6.HostSide.IP.String(),
+			ConnectTime: ptr.To(passthroughConnectRetrySeconds),
 		}
 
 		ipnet := net.IPNet{

--- a/internal/conversion/frr_conversion_test.go
+++ b/internal/conversion/frr_conversion_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/openperouter/openperouter/api/v1alpha1"
 	"github.com/openperouter/openperouter/internal/frr"
@@ -1113,14 +1114,16 @@ func TestAPItoFRR(t *testing.T) {
 				},
 				Passthrough: &frr.PassthroughConfig{
 					LocalNeighborV4: &frr.NeighborConfig{
-						ASN:  mustNewPeerASNFromNumber(65001),
-						Addr: "192.168.2.2",
-						ID:   "192.168.2.2",
+						ASN:         mustNewPeerASNFromNumber(65001),
+						Addr:        "192.168.2.2",
+						ID:          "192.168.2.2",
+						ConnectTime: ptr.To(int64(5)),
 					},
 					LocalNeighborV6: &frr.NeighborConfig{
-						ASN:  mustNewPeerASNFromNumber(65001),
-						Addr: "2001:db8::2",
-						ID:   "2001:db8::2",
+						ASN:         mustNewPeerASNFromNumber(65001),
+						Addr:        "2001:db8::2",
+						ID:          "2001:db8::2",
+						ConnectTime: ptr.To(int64(5)),
 					},
 					ToAdvertiseIPv4: []string{"192.168.2.2/32"},
 					ToAdvertiseIPv6: []string{"2001:db8::2/128"},
@@ -1187,6 +1190,7 @@ func TestAPItoFRR(t *testing.T) {
 						ASN:  mustNewPeerASNFromNumber(65001),
 						Addr: "192.168.2.2",
 						ID:   "192.168.2.2",
+						ConnectTime: ptr.To(int64(5)),
 					},
 					ToAdvertiseIPv4: []string{"192.168.2.2/32"},
 					ToAdvertiseIPv6: []string{},
@@ -1246,6 +1250,7 @@ func TestAPItoFRR(t *testing.T) {
 						ASN:  mustNewPeerASNFromNumber(65001),
 						Addr: "2001:db8::2",
 						ID:   "2001:db8::2",
+						ConnectTime: ptr.To(int64(5)),
 					},
 					ToAdvertiseIPv4: []string{},
 					ToAdvertiseIPv6: []string{"2001:db8::2/128"},
@@ -1311,6 +1316,7 @@ func TestAPItoFRR(t *testing.T) {
 						ASN:  mustNewPeerASNFromNumber(65001),
 						Addr: "192.168.2.2",
 						ID:   "192.168.2.2",
+						ConnectTime: ptr.To(int64(5)),
 					},
 					ToAdvertiseIPv4: []string{"192.168.2.2/32"},
 					ToAdvertiseIPv6: []string{},
@@ -1372,6 +1378,7 @@ func TestAPItoFRR(t *testing.T) {
 						ASN:  mustNewPeerASNFromNumber(65001),
 						Addr: "2001:db8::2",
 						ID:   "2001:db8::2",
+						ConnectTime: ptr.To(int64(5)),
 					},
 					ToAdvertiseIPv4: []string{},
 					ToAdvertiseIPv6: []string{"2001:db8::2/128"},
@@ -1440,6 +1447,7 @@ func TestAPItoFRR(t *testing.T) {
 						ASN:  mustNewPeerASNFromNumber(65001),
 						Addr: "192.168.2.2",
 						ID:   "192.168.2.2",
+						ConnectTime: ptr.To(int64(5)),
 					},
 					ToAdvertiseIPv4: []string{"192.168.2.2/32"},
 					ToAdvertiseIPv6: []string{},
@@ -1531,11 +1539,13 @@ func TestAPItoFRR(t *testing.T) {
 						ASN:  mustNewPeerASNFromType("external"),
 						Addr: "192.168.2.2",
 						ID:   "192.168.2.2",
+						ConnectTime: ptr.To(int64(5)),
 					},
 					LocalNeighborV6: &frr.NeighborConfig{
 						ASN:  mustNewPeerASNFromType("external"),
 						Addr: "2001:db8::2",
 						ID:   "2001:db8::2",
+						ConnectTime: ptr.To(int64(5)),
 					},
 					ToAdvertiseIPv4: []string{"192.168.2.2/32"},
 					ToAdvertiseIPv6: []string{"2001:db8::2/128"},
@@ -1605,11 +1615,13 @@ func TestAPItoFRR(t *testing.T) {
 						ASN:  mustNewPeerASNFromType("internal"),
 						Addr: "192.168.2.2",
 						ID:   "192.168.2.2",
+						ConnectTime: ptr.To(int64(5)),
 					},
 					LocalNeighborV6: &frr.NeighborConfig{
 						ASN:  mustNewPeerASNFromType("internal"),
 						Addr: "2001:db8::2",
 						ID:   "2001:db8::2",
+						ConnectTime: ptr.To(int64(5)),
 					},
 					ToAdvertiseIPv4: []string{"192.168.2.2/32"},
 					ToAdvertiseIPv6: []string{"2001:db8::2/128"},

--- a/internal/frr/frr_test.go
+++ b/internal/frr/frr_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/openperouter/openperouter/internal/networklayerprotocol"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -729,9 +730,10 @@ func TestPassthroughNoEVPN(t *testing.T) {
 		},
 		Passthrough: &PassthroughConfig{
 			LocalNeighborV4: &NeighborConfig{
-				ASN:  mustNewPeerASNFromNumber(64513),
-				Addr: "192.168.1.3",
-				ID:   "192.168.1.3",
+				ASN:         mustNewPeerASNFromNumber(64513),
+				Addr:        "192.168.1.3",
+				ID:          "192.168.1.3",
+				ConnectTime: ptr.To(int64(5)),
 			},
 			ToAdvertiseIPv4: []string{
 				"192.169.20.0/24",
@@ -765,9 +767,10 @@ func TestPassthroughExternal(t *testing.T) {
 		},
 		Passthrough: &PassthroughConfig{
 			LocalNeighborV4: &NeighborConfig{
-				ASN:  mustNewPeerASNFromType("external"),
-				Addr: "192.168.1.3",
-				ID:   "192.168.1.3",
+				ASN:         mustNewPeerASNFromType("external"),
+				Addr:        "192.168.1.3",
+				ID:          "192.168.1.3",
+				ConnectTime: ptr.To(int64(5)),
 			},
 			ToAdvertiseIPv4: []string{
 				"192.169.20.0/24",
@@ -801,9 +804,10 @@ func TestPassthroughV4(t *testing.T) {
 		},
 		Passthrough: &PassthroughConfig{
 			LocalNeighborV4: &NeighborConfig{
-				ASN:  mustNewPeerASNFromNumber(64513),
-				Addr: "192.168.1.3",
-				ID:   "192.168.1.3",
+				ASN:         mustNewPeerASNFromNumber(64513),
+				Addr:        "192.168.1.3",
+				ID:          "192.168.1.3",
+				ConnectTime: ptr.To(int64(5)),
 			},
 			ToAdvertiseIPv4: []string{
 				"192.169.20.0/24",
@@ -849,14 +853,16 @@ func TestPassthroughDual(t *testing.T) {
 		},
 		Passthrough: &PassthroughConfig{
 			LocalNeighborV4: &NeighborConfig{
-				ASN:  mustNewPeerASNFromNumber(64513),
-				Addr: "192.168.1.3",
-				ID:   "192.168.1.3",
+				ASN:         mustNewPeerASNFromNumber(64513),
+				Addr:        "192.168.1.3",
+				ID:          "192.168.1.3",
+				ConnectTime: ptr.To(int64(5)),
 			},
 			LocalNeighborV6: &NeighborConfig{
-				ASN:  mustNewPeerASNFromNumber(64513),
-				Addr: "2001:db8:20::2",
-				ID:   "2001:db8:20::2",
+				ASN:         mustNewPeerASNFromNumber(64513),
+				Addr:        "2001:db8:20::2",
+				ID:          "2001:db8:20::2",
+				ConnectTime: ptr.To(int64(5)),
 			},
 			ToAdvertiseIPv4: []string{
 				"192.169.20.0/24",

--- a/internal/frr/templates/local_passthrough.tmpl
+++ b/internal/frr/templates/local_passthrough.tmpl
@@ -3,6 +3,9 @@
 {{- if .Passthrough.LocalNeighborV4 }}
 
   neighbor {{ .Passthrough.LocalNeighborV4.ID }} remote-as {{ .Passthrough.LocalNeighborV4.ASN }}
+  {{- if .Passthrough.LocalNeighborV4.ConnectTime }}
+  neighbor {{ .Passthrough.LocalNeighborV4.ID }} timers connect {{ .Passthrough.LocalNeighborV4.ConnectTime }}
+  {{- end }}
 
   address-family ipv4 unicast
   {{/* the ToAdvertiseIPv4 addresses are intended to be advertised to the fabric */}}
@@ -21,6 +24,9 @@
 {{- if .Passthrough.LocalNeighborV6 }}
 
   neighbor {{ .Passthrough.LocalNeighborV6.ID }} remote-as {{ .Passthrough.LocalNeighborV6.ASN }}
+  {{- if .Passthrough.LocalNeighborV6.ConnectTime }}
+  neighbor {{ .Passthrough.LocalNeighborV6.ID }} timers connect {{ .Passthrough.LocalNeighborV6.ConnectTime }}
+  {{- end }}
 
   address-family ipv6 unicast
   {{/* the ToAdvertiseIPv6 addresses are intended to be advertised to the fabric */}}

--- a/internal/frr/testdata/TestPassthroughDual.golden
+++ b/internal/frr/testdata/TestPassthroughDual.golden
@@ -40,6 +40,7 @@ router bgp 64512
   exit-address-family
 
   neighbor 192.168.1.3 remote-as 64513
+  neighbor 192.168.1.3 timers connect 5
 
   address-family ipv4 unicast
   
@@ -51,6 +52,7 @@ router bgp 64512
   exit-address-family
 
   neighbor 2001:db8:20::2 remote-as 64513
+  neighbor 2001:db8:20::2 timers connect 5
 
   address-family ipv6 unicast
   

--- a/internal/frr/testdata/TestPassthroughExternal.golden
+++ b/internal/frr/testdata/TestPassthroughExternal.golden
@@ -21,6 +21,7 @@ router bgp 64512
   exit-address-family
 
   neighbor 192.168.1.3 remote-as external
+  neighbor 192.168.1.3 timers connect 5
 
   address-family ipv4 unicast
   

--- a/internal/frr/testdata/TestPassthroughNoEVPN.golden
+++ b/internal/frr/testdata/TestPassthroughNoEVPN.golden
@@ -21,6 +21,7 @@ router bgp 64512
   exit-address-family
 
   neighbor 192.168.1.3 remote-as 64513
+  neighbor 192.168.1.3 timers connect 5
 
   address-family ipv4 unicast
   

--- a/internal/frr/testdata/TestPassthroughV4.golden
+++ b/internal/frr/testdata/TestPassthroughV4.golden
@@ -21,6 +21,7 @@ router bgp 64512
   exit-address-family
 
   neighbor 192.168.1.3 remote-as 64513
+  neighbor 192.168.1.3 timers connect 5
 
   address-family ipv4 unicast
   


### PR DESCRIPTION
Passthrough neighbors use a local link (veth/TAP) where FRR's default ConnectRetryTimer of 120s causes unnecessary delays if the first TCP SYN fails — e.g. during IPv6 DAD after setUniqueMAC bounces the link.

Set `timers connect 5` unconditionally on all passthrough BGP neighbors, matching the value already used for underlay neighbors when graceful restart is enabled.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```

**AI Guidelines Acknowledgment**:

- [ ] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
