### PR TITLE
fix: increase resilience of multus installation in clab

### DIFF
--- a/clab/kind/frr-k8s/setup.sh
+++ b/clab/kind/frr-k8s/setup.sh
@@ -5,8 +5,23 @@ MULTUS_VERSION=${MULTUS_VERSION:-"v4.2.1"}
 CNI_PLUGINS_VERSION=${CNI_PLUGINS_VERSION:-"v1.7.1"}
 KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-"pe-kind"}
 
+retry_cmd() {
+  local cmd=${1}
+  local max_retries=10
+  local i=0
+  while ! ${cmd}; do
+    i=$((i+1))
+    if [ ${i} -ge ${max_retries} ]; then
+      echo "Running command failed. Aborting."
+      exit 1
+    fi
+    echo "Running command failed. Retrying."
+    sleep 2
+  done
+}
+
 kubectl apply -k $(dirname ${BASH_SOURCE[0]})
-kubectl apply -f https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/refs/tags/${MULTUS_VERSION}/deployments/multus-daemonset.yml
+retry_cmd "kubectl apply -f https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/refs/tags/${MULTUS_VERSION}/deployments/multus-daemonset.yml"
 
 sleep 2s
 echo "Waiting for frr-k8s-system pods to be ready"


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:

The containerlab installation applies a multus .yml file directly
from githubusercontent. This may fail due to rate limits (e.g. code
429 too many requests). Retry 10 times, and if it fails nevertheless,
bail out of setup.sh.

**Special notes for your reviewer**:

Hit during example deployment. Without the multus installation, the networkattachmentdefinitions are broken. When multus install fails, the clab setup just continues nevertheless, without bailing, leading to problems later down the road. Potentially important for e2e tests as well, though I'm not sure.

**Release note**:

```release-note
Make multus installation more resilient for container lab.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Multus installation reliability by automatically retrying failed deployments.
  * Installation now reports an error and stops cleanly if deployment remains unsuccessful after multiple attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->