### PR TITLE
fix: restrict RawFRRConfig to operator namespace

### DIFF
--- a/cmd/nodemarker/main.go
+++ b/cmd/nodemarker/main.go
@@ -184,13 +184,18 @@ func main() {
 			datapathConfigValidator = &conversion.GroutDatapathConfigValidator{}
 		}
 
+		operatorNS := args.namespace
+		if operatorNS == "" {
+			operatorNS = os.Getenv("POD_NAMESPACE")
+		}
+
 		if args.webhookMode == WebhookModeEnabled || args.webhookMode == WebhookModeWebhookOnly {
 			setupLog.Info("Starting webhooks")
 			if err := v1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 				logger.Error("unable to add v1alpha1 scheme", "error", err)
 			}
 
-			err := setupWebhook(mgr, logger, datapathConfigValidator)
+			err := setupWebhook(mgr, logger, datapathConfigValidator, operatorNS)
 			if err != nil {
 				setupLog.Error(err, "unable to create", "webhooks")
 				os.Exit(1)
@@ -258,7 +263,12 @@ func setupCertRotation(notifyFinished chan struct{}, mgr manager.Manager, logger
 	return nil
 }
 
-func setupWebhook(mgr manager.Manager, logger *slog.Logger, configValidator conversion.DatapathConfigValidator) error {
+func setupWebhook(
+	mgr manager.Manager,
+	logger *slog.Logger,
+	configValidator conversion.DatapathConfigValidator,
+	operatorNamespace string,
+) error {
 	logger.Info("webhooks enabled")
 
 	webhooks.Logger = logger
@@ -285,7 +295,7 @@ func setupWebhook(mgr manager.Manager, logger *slog.Logger, configValidator conv
 		logger.Error("unable to create the webhook", "error", err, "webhook", "L3Passthroughs")
 		return err
 	}
-	if err := webhooks.SetupRawFRRConfig(mgr); err != nil {
+	if err := webhooks.SetupRawFRRConfig(mgr, operatorNamespace); err != nil {
 		logger.Error("unable to create the webhook", "error", err, "webhook", "RawFRRConfigs")
 		return err
 	}

--- a/internal/controller/routerconfiguration/underlay_vni_controller.go
+++ b/internal/controller/routerconfiguration/underlay_vni_controller.go
@@ -236,8 +236,12 @@ func (r *PERouterReconciler) getConfigFromAPI(ctx context.Context, logger *slog.
 		return conversion.APIConfigData{}, err
 	}
 
+	if r.MyNamespace == "" {
+		slog.Error("failed to list rawfrrconfigs: operator namespace is not configured")
+		return conversion.APIConfigData{}, fmt.Errorf("operator namespace is not configured")
+	}
 	var rawFRRConfigs v1alpha1.RawFRRConfigList
-	if err := r.List(ctx, &rawFRRConfigs, r.notStaticConfigsListOpts); err != nil {
+	if err := r.List(ctx, &rawFRRConfigs, r.notStaticConfigsListOpts, client.InNamespace(r.MyNamespace)); err != nil {
 		slog.Error("failed to list rawfrrconfigs", "error", err)
 		return conversion.APIConfigData{}, err
 	}

--- a/internal/webhooks/rawfrrconfig_webhook.go
+++ b/internal/webhooks/rawfrrconfig_webhook.go
@@ -20,12 +20,14 @@ const (
 )
 
 type RawFRRConfigValidator struct {
-	decoder admission.Decoder
+	decoder           admission.Decoder
+	operatorNamespace string
 }
 
-func SetupRawFRRConfig(mgr ctrl.Manager) error {
+func SetupRawFRRConfig(mgr ctrl.Manager, operatorNamespace string) error {
 	validator := &RawFRRConfigValidator{
-		decoder: admission.NewDecoder(mgr.GetScheme()),
+		decoder:           admission.NewDecoder(mgr.GetScheme()),
+		operatorNamespace: operatorNamespace,
 	}
 
 	mgr.GetWebhookServer().Register(
@@ -50,15 +52,23 @@ func (v *RawFRRConfigValidator) Handle(_ context.Context, req admission.Request)
 
 	switch req.Operation {
 	case v1.Create, v1.Update:
-		if err := validateRawFRRConfig(&rawFRRConfig); err != nil {
+		if err := validateRawFRRConfig(&rawFRRConfig, v.operatorNamespace); err != nil {
 			return admission.Denied(err.Error())
 		}
 	}
 	return admission.Allowed("").WithWarnings("please note RawFRRConfig is for experimentation only and not supported")
 }
 
-func validateRawFRRConfig(rawFRRConfig *v1alpha1.RawFRRConfig) error {
+func validateRawFRRConfig(rawFRRConfig *v1alpha1.RawFRRConfig, operatorNamespace string) error {
 	Logger.Debug("webhook rawfrrconfig", "action", "validate", "name", rawFRRConfig.Name, "namespace", rawFRRConfig.Namespace)
+
+	if operatorNamespace == "" {
+		return fmt.Errorf("operator namespace is not configured; cannot validate RawFRRConfig")
+	}
+	if rawFRRConfig.Namespace != operatorNamespace {
+		return fmt.Errorf("RawFRRConfig must be created in the operator namespace %q, got %q",
+			operatorNamespace, rawFRRConfig.Namespace)
+	}
 
 	if rawFRRConfig.Spec.RawConfig == "" {
 		return fmt.Errorf("rawConfig must not be empty")

--- a/internal/webhooks/rawfrrconfig_webhook_test.go
+++ b/internal/webhooks/rawfrrconfig_webhook_test.go
@@ -15,6 +15,8 @@ import (
 // is not to test each called function (functions themselves should have unit tests for that),
 // but to make sure that the webhook's logic overall is sound.
 func TestValidateRawFRRConfig(t *testing.T) {
+	const operatorNamespace = "openperouter-system"
+
 	tcs := []struct {
 		name         string
 		rawFRRConfig *v1alpha1.RawFRRConfig
@@ -24,7 +26,7 @@ func TestValidateRawFRRConfig(t *testing.T) {
 			name: "webhook passes",
 			rawFRRConfig: &v1alpha1.RawFRRConfig{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
+					Namespace: operatorNamespace,
 					Name:      "rawfrrconfig",
 				},
 				Spec: v1alpha1.RawFRRConfigSpec{
@@ -36,7 +38,7 @@ func TestValidateRawFRRConfig(t *testing.T) {
 			name: "empty rawConfig",
 			rawFRRConfig: &v1alpha1.RawFRRConfig{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
+					Namespace: operatorNamespace,
 					Name:      "rawfrrconfig",
 				},
 				Spec: v1alpha1.RawFRRConfigSpec{
@@ -44,6 +46,19 @@ func TestValidateRawFRRConfig(t *testing.T) {
 				},
 			},
 			errorString: "rawConfig must not be empty",
+		},
+		{
+			name: "wrong namespace is rejected",
+			rawFRRConfig: &v1alpha1.RawFRRConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "other-namespace",
+					Name:      "rawfrrconfig",
+				},
+				Spec: v1alpha1.RawFRRConfigSpec{
+					RawConfig: "some config",
+				},
+			},
+			errorString: "RawFRRConfig must be created in the operator namespace \"openperouter-system\", got \"other-namespace\"",
 		},
 	}
 	for _, tc := range tcs {
@@ -54,7 +69,7 @@ func TestValidateRawFRRConfig(t *testing.T) {
 			}()
 			Logger, _ = logging.New("debug")
 
-			err := validateRawFRRConfig(tc.rawFRRConfig)
+			err := validateRawFRRConfig(tc.rawFRRConfig, operatorNamespace)
 			if tc.errorString == "" {
 				if err != nil {
 					t.Fatalf("expected no error, but got %q", err)
@@ -69,4 +84,29 @@ func TestValidateRawFRRConfig(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("empty operator namespace rejects", func(t *testing.T) {
+		origLogger := Logger
+		defer func() {
+			Logger = origLogger
+		}()
+		Logger, _ = logging.New("debug")
+
+		cr := &v1alpha1.RawFRRConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "any-namespace",
+				Name:      "rawfrrconfig",
+			},
+			Spec: v1alpha1.RawFRRConfigSpec{
+				RawConfig: "some config",
+			},
+		}
+		err := validateRawFRRConfig(cr, "")
+		if err == nil {
+			t.Fatal("expected error with empty operator namespace, but got none")
+		}
+		if !strings.Contains(err.Error(), "not configured") {
+			t.Fatalf("expected error about namespace not configured, got %q", err)
+		}
+	})
 }


### PR DESCRIPTION
RawFRRConfig CRs were listed cluster-wide and accepted from any namespace. A principal with create permission in any namespace could inject arbitrary FRR config onto all nodes.

Add namespace validation to the webhook (fail-closed when the operator namespace is not configured) and scope the controller's List call with client.InNamespace.

**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**Special notes for your reviewer**:



```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The operator now derives its operator namespace from the runtime environment when no namespace flag is provided.
* **Bug Fixes**
  * Admission validation denies `RawFRRConfig` requests when the operator namespace isn’t configured or when the `RawFRRConfig` resource namespace doesn’t match.
  * `RawFRRConfig` lookups are now scoped to the configured operator namespace, and fail fast when it’s missing.
* **Tests**
  * Updated webhook tests to use the configured operator namespace, added coverage for namespace mismatches, and verified errors when the operator namespace is not configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->