### PR TITLE
fix/srv6 l2gatewayips

### DIFF
--- a/e2etests/tests/l3vpn_l2.go
+++ b/e2etests/tests/l3vpn_l2.go
@@ -172,18 +172,24 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 	})
 
 	// This test tests that L2VNI and L3VPN work at the same time.
-	// For L2VNI:
+	// For East/West traffic:
 	// Pods can ping each other across net1 which is a macvlan interface that is connected to br-hs-110 inside the host
 	// network namespace. From there, the packet travels to host-110 (still inside the host netns) which is a veth that
 	// is connected to pe-110 inside the OpenPERouter network namespace. Traffic is bridged via br-pe-110 to the VXLAN
 	// interface vni110 from where it is sent to the other kubernetes nodes.
-	// For L3VPN:
+	// For North/South traffic, we have 2 scenarios:
+	// Scenario a):
 	// This test adds an L3VPN with a hostsession with FRR for L3 connectivity with the hosts behind the leaf nodes
 	// inside VRF red.
 	// Traffic will leave via the default interface of the pod (eth0), will hit the global host namespace, where FRR-K8S
 	// will have injected a route via host-100. host-100 is a veth that's connected to pe-100 which resides inside
 	// the OpenPERouter and which is attached to VRF red. From there, the packet is then SNATed and travels to
-	// the cluster external hosts inside VRF red.
+	// the cluster external hosts inside VRF red via SRv6.
+	// Scenario b):
+	// We set l2GatewayIPs in the l2vni and remove the default route via eth0. Instead, we add a default route via
+	// the pod's secondary interface (net1) to the L2 gateway. Traffic frames leave via net1, br-hs-110, host-110,
+	// pe-110 to br-pe-110. The l2Gateway is on br-pe-110. Once a packet hits the l2Gateway, it is routed via SRv6 to
+	// the destination host.
 	// Diagram:
 	// openperouter|
 	// ------------|
@@ -248,6 +254,15 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 		secondPod, err = k8s.CreateAgnhostPod(cs, "pod2", testNamespace, k8s.WithNad(netAttachDef.Name, testNamespace, tc.secondPodIPs), k8s.OnNode(nodes[1].Name))
 		Expect(err).NotTo(HaveOccurred())
 
+		// We can reach the host either via the pod's eth0 (passing through the host<->pe veth),
+		// or via the secondary interface directly connected to the perouter namespace. Therefore, with l2GatewayIPs
+		// present, we need to remove the gateway via eth0.
+		if len(tc.l2GatewayIPs) > 0 {
+			By("removing the default gateway via the primary interface")
+			Expect(removeGatewayFromPod(firstPod)).To(Succeed())
+			Expect(removeGatewayFromPod(secondPod)).To(Succeed())
+		}
+
 		By("Getting the pod's node")
 		firstPodNode, err := cs.CoreV1().Nodes().Get(context.Background(), firstPod.Spec.NodeName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
@@ -270,7 +285,12 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 		secondPodHostSideV6, err := openperouter.HostIPFromCIDRForNode(localCIDRV6, secondPodNode)
 		Expect(err).NotTo(HaveOccurred())
-		expectedHostIPs := func(podCIDRs []string, podName string) []string {
+		// With l2GatewayIPs, we expect to see the pod IPs. Otherwise, we pass through the host
+		// and we expect to see the host's IPs (NAT).
+		expectedIPsForPod := func(podCIDRs []string, podName string, l2GatewayIPs []string) []string {
+			if len(l2GatewayIPs) > 0 {
+				return podCIDRs
+			}
 			hostIPs := []string{}
 			switch podName {
 			case "firstPod":
@@ -303,6 +323,7 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 
 		podExecutor := executor.ForPod(firstPod.Namespace, firstPod.Name, "agnhost")
 		secondPodExecutor := executor.ForPod(secondPod.Namespace, secondPod.Name, "agnhost")
+		hostSRV6RedExecutor := executor.ForContainer("clab-kind-hostSRV6_red")
 
 		tests := []struct {
 			exec        executor.Executor
@@ -314,20 +335,40 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 		}{
 			{
 				exec: podExecutor, from: "firstPod", to: "secondPod",
-				fromIPs: tc.firstPodIPs, toIPs: tc.secondPodIPs, expectedIPs: tc.firstPodIPs,
+				fromIPs: tc.firstPodIPs, toIPs: tc.secondPodIPs,
+				expectedIPs: tc.firstPodIPs,
 			},
 			{
 				exec: secondPodExecutor, from: "secondPod", to: "firstPod",
-				fromIPs: tc.secondPodIPs, toIPs: tc.firstPodIPs, expectedIPs: tc.secondPodIPs,
+				fromIPs: tc.secondPodIPs, toIPs: tc.firstPodIPs,
+				expectedIPs: tc.secondPodIPs,
 			},
 			{
 				exec: podExecutor, from: "firstPod", to: "hostSRV6Red",
-				fromIPs: tc.firstPodIPs, toIPs: tc.hostSRV6RedIPs, expectedIPs: expectedHostIPs(tc.firstPodIPs, "firstPod"),
+				fromIPs: tc.firstPodIPs, toIPs: tc.hostSRV6RedIPs,
+				expectedIPs: expectedIPsForPod(tc.firstPodIPs, "firstPod", tc.l2GatewayIPs),
 			},
 			{
 				exec: secondPodExecutor, from: "secondPod", to: "hostSRV6Red",
-				fromIPs: tc.secondPodIPs, toIPs: tc.hostSRV6RedIPs, expectedIPs: expectedHostIPs(tc.secondPodIPs, "secondPod"),
+				fromIPs: tc.secondPodIPs, toIPs: tc.hostSRV6RedIPs,
+				expectedIPs: expectedIPsForPod(tc.secondPodIPs, "secondPod", tc.l2GatewayIPs),
 			},
+		}
+
+		// Reaching the pods from the host is only possible when traffic passes via the l2GatewayIPs.
+		if len(tc.l2GatewayIPs) > 0 {
+			tests = append(tests, struct {
+				exec        executor.Executor
+				from        string
+				to          string
+				fromIPs     []string
+				toIPs       []string
+				expectedIPs []string
+			}{
+				exec: hostSRV6RedExecutor, from: "hostSRV6Red", to: "firstPod",
+				fromIPs: tc.hostSRV6RedIPs, toIPs: tc.firstPodIPs,
+				expectedIPs: tc.hostSRV6RedIPs,
+			})
 		}
 
 		for _, test := range tests {
@@ -341,7 +382,20 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 			}
 		}
 	},
+		Entry("for single stack ipv4 without gatewayIPs (traffic via L3 host interface)", testCase{
+			firstPodIPs:    []string{"192.171.24.2/24"},
+			secondPodIPs:   []string{"192.171.24.3/24"},
+			hostSRV6RedIPs: []string{infra.HostSRV6RedIPv4},
+			nadMaster:      fmt.Sprintf("br-hs-%d", vniID),
+			hostMaster: v1alpha1.HostMaster{
+				Type: linuxBridgeHostAttachment,
+				LinuxBridge: &v1alpha1.LinuxBridgeConfig{
+					AutoCreate: ptr.To(true),
+				},
+			},
+		}),
 		Entry("for single stack ipv4", testCase{
+			l2GatewayIPs:   []string{"192.171.24.1/24"},
 			firstPodIPs:    []string{"192.171.24.2/24"},
 			secondPodIPs:   []string{"192.171.24.3/24"},
 			hostSRV6RedIPs: []string{infra.HostSRV6RedIPv4},
@@ -354,6 +408,7 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 			},
 		}),
 		Entry("for dual stack", testCase{
+			l2GatewayIPs:   []string{"192.171.24.1/24", "fd00:10:245:1::1/64"},
 			firstPodIPs:    []string{"192.171.24.2/24", "fd00:10:245:1::2/64"},
 			secondPodIPs:   []string{"192.171.24.3/24", "fd00:10:245:1::3/64"},
 			hostSRV6RedIPs: []string{infra.HostSRV6RedIPv4, infra.HostSRV6RedIPv6},
@@ -366,6 +421,7 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 			},
 		}),
 		Entry("for single stack ipv6", testCase{
+			l2GatewayIPs:   []string{"fd00:10:245:1::1/64"},
 			firstPodIPs:    []string{"fd00:10:245:1::2/64"},
 			secondPodIPs:   []string{"fd00:10:245:1::3/64"},
 			hostSRV6RedIPs: []string{infra.HostSRV6RedIPv6},
@@ -378,6 +434,7 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 			},
 		}),
 		Entry("OVS bridge autocreate for single stack ipv4", testCase{
+			l2GatewayIPs:   []string{"192.171.24.1/24"},
 			firstPodIPs:    []string{"192.171.24.2/24"},
 			secondPodIPs:   []string{"192.171.24.3/24"},
 			hostSRV6RedIPs: []string{infra.HostSRV6RedIPv4},
@@ -390,6 +447,7 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 			},
 		}),
 		Entry("OVS bridge autocreate for dual stack", testCase{
+			l2GatewayIPs:   []string{"192.171.24.1/24", "fd00:10:245:1::1/64"},
 			firstPodIPs:    []string{"192.171.24.2/24", "fd00:10:245:1::2/64"},
 			secondPodIPs:   []string{"192.171.24.3/24", "fd00:10:245:1::3/64"},
 			hostSRV6RedIPs: []string{infra.HostSRV6RedIPv4, infra.HostSRV6RedIPv6},
@@ -402,6 +460,7 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 			},
 		}),
 		Entry("OVS bridge autocreate for single stack ipv6", testCase{
+			l2GatewayIPs:   []string{"fd00:10:245:1::1/64"},
 			firstPodIPs:    []string{"fd00:10:245:1::2/64"},
 			secondPodIPs:   []string{"fd00:10:245:1::3/64"},
 			hostSRV6RedIPs: []string{infra.HostSRV6RedIPv6},
@@ -414,6 +473,7 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 			},
 		}),
 		Entry("OVS bridge existing for single stack ipv4", testCase{
+			l2GatewayIPs:   []string{"192.171.24.1/24"},
 			firstPodIPs:    []string{"192.171.24.2/24"},
 			secondPodIPs:   []string{"192.171.24.3/24"},
 			hostSRV6RedIPs: []string{infra.HostSRV6RedIPv4},
@@ -427,6 +487,7 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 			},
 		}),
 		Entry("OVS bridge existing for dual stack", testCase{
+			l2GatewayIPs:   []string{"192.171.24.1/24", "fd00:10:245:1::1/64"},
 			firstPodIPs:    []string{"192.171.24.2/24", "fd00:10:245:1::2/64"},
 			secondPodIPs:   []string{"192.171.24.3/24", "fd00:10:245:1::3/64"},
 			hostSRV6RedIPs: []string{infra.HostSRV6RedIPv4, infra.HostSRV6RedIPv6},
@@ -440,6 +501,7 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 			},
 		}),
 		Entry("OVS bridge existing for single stack ipv6", testCase{
+			l2GatewayIPs:   []string{"fd00:10:245:1::1/64"},
 			firstPodIPs:    []string{"fd00:10:245:1::2/64"},
 			secondPodIPs:   []string{"fd00:10:245:1::3/64"},
 			hostSRV6RedIPs: []string{infra.HostSRV6RedIPv6},
@@ -453,5 +515,4 @@ var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
 			},
 		}),
 	)
-
 })

--- a/e2etests/tests/l3vpn_l2.go
+++ b/e2etests/tests/l3vpn_l2.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-var _ = Describe("SRV6 Routes between bgp and the fabric", Ordered, func() {
+var _ = Describe("SRV6 routes between bgp and the fabric", Ordered, func() {
 	var (
 		cs           clientset.Interface
 		routers      openperouter.Routers

--- a/examples/l3vpn/layer2/openpe.yaml
+++ b/examples/l3vpn/layer2/openpe.yaml
@@ -64,3 +64,4 @@ spec:
     type: linux-bridge
     linuxBridge:
       autoCreate: true
+  l2gatewayips: ["192.170.1.1/24"]

--- a/examples/l3vpn/layer2/workload.yaml
+++ b/examples/l3vpn/layer2/workload.yaml
@@ -150,10 +150,13 @@ spec:
   containers:
     - name: agnhost
       image: k8s.gcr.io/e2e-test-images/agnhost:2.45
-      command: ["/agnhost", "netexec", "--http-port=8090"]
+      command: ["/bin/sh", "-c", "ip r del default dev eth0 && /agnhost netexec --http-port=8090"]
       ports:
       - containerPort: 8090
         name: http
+      securityContext:
+        capabilities:
+          add: ["NET_ADMIN"]
 ---
 apiVersion: v1
 kind: Pod
@@ -171,7 +174,10 @@ spec:
   containers:
     - name: agnhost
       image: k8s.gcr.io/e2e-test-images/agnhost:2.45
-      command: ["/agnhost", "netexec", "--http-port=8090"]
+      command: ["/bin/sh", "-c", "ip r del default dev eth0 && /agnhost netexec --http-port=8090"]
       ports:
       - containerPort: 8090
         name: http
+      securityContext:
+        capabilities:
+          add: ["NET_ADMIN"]

--- a/internal/conversion/frr_conversion.go
+++ b/internal/conversion/frr_conversion.go
@@ -64,6 +64,27 @@ func WithGatewayIPs(cidrs []string) L3VNIOption {
 	}
 }
 
+type L3VPNOption func(*frr.L3VPNConfig) error
+
+func L3VPNWithGatewayIPs(cidrs []string) L3VPNOption {
+	return func(cfg *frr.L3VPNConfig) error {
+		for _, cidr := range cidrs {
+			_, ipnet, err := net.ParseCIDR(cidr)
+			if err != nil {
+				return fmt.Errorf("failed to parse L2 gateway CIDR %s: %w", cidr, err)
+			}
+			prefix := ipnet.String()
+			if ipfamily.ForCIDR(ipnet) == ipfamily.IPv4 {
+				cfg.ToAdvertiseIPv4 = append(cfg.ToAdvertiseIPv4, prefix)
+			}
+			if ipfamily.ForCIDR(ipnet) == ipfamily.IPv6 {
+				cfg.ToAdvertiseIPv6 = append(cfg.ToAdvertiseIPv6, prefix)
+			}
+		}
+		return nil
+	}
+}
+
 func APItoFRR(config APIConfigData, nodeIndex int, logLevel string) (frr.Config, error) {
 	rawSnippets := rawConfigSnippets(config.RawFRRConfigs)
 	if len(rawSnippets) > 0 && len(config.Underlays) == 0 {
@@ -130,7 +151,15 @@ func APItoFRR(config APIConfigData, nodeIndex int, logLevel string) (frr.Config,
 
 	applyGracefulRestart(&underlayConfig, underlay.Spec.GracefulRestart)
 
-	vniConfigs, err := vniConfigsToFRR(config.L3VNIs, config.L2VNIs, routerID, underlay.Spec.ASN, nodeIndex)
+	vrfsWithL2Gateway := vrfsFromVNIsWithL2Gateways(config.L2VNIs)
+
+	vniConfigs, err := vniConfigsToFRR(
+		config.L3VNIs,
+		routerID,
+		underlay.Spec.ASN,
+		nodeIndex,
+		vrfsWithL2Gateway,
+	)
 	if err != nil {
 		return frr.Config{}, err
 	}
@@ -140,7 +169,13 @@ func APItoFRR(config APIConfigData, nodeIndex int, logLevel string) (frr.Config,
 		return frr.Config{}, fmt.Errorf("failed to translate passthrough to frr: %w", err)
 	}
 
-	vpnConfigs, err := l3vpnConfigsToFRR(config.L3VPNs, routerID, underlay.Spec.ASN, nodeIndex)
+	vpnConfigs, err := l3vpnConfigsToFRR(
+		config.L3VPNs,
+		routerID,
+		underlay.Spec.ASN,
+		nodeIndex,
+		vrfsWithL2Gateway,
+	)
 	if err != nil {
 		return frr.Config{}, err
 	}
@@ -236,17 +271,16 @@ func tunnelEndpointToFRR(tunnelEndpointConfig *v1alpha1.TunnelEndpointConfig, no
 
 func vniConfigsToFRR(
 	l3vnis []v1alpha1.L3VNI,
-	l2vnis []v1alpha1.L2VNI,
 	routerID string,
 	underlayASN int64,
 	nodeIndex int,
+	vrfsWithL2Gateway map[string][]string,
 ) ([]frr.L3VNIConfig, error) {
-	vrfsWithL2Gateway := vrfsWithL2Gateways(l2vnis)
 	configs := []frr.L3VNIConfig{}
 	for _, vni := range l3vnis {
 		var opts []L3VNIOption
 		if gatewayCIDRs, ok := vrfsWithL2Gateway[vni.Spec.VRF]; ok {
-			opts = append(opts, WithGatewayIPs(gatewayCIDRs))
+			opts = []L3VNIOption{WithGatewayIPs(gatewayCIDRs)}
 		}
 		frrVNI, err := l3vniToFRR(vni, routerID, underlayASN, nodeIndex, opts...)
 		if err != nil {
@@ -511,10 +545,20 @@ func l3vniToFRR(vni v1alpha1.L3VNI, routerID string, underlayASN int64, nodeInde
 	return configs, nil
 }
 
-func l3vpnConfigsToFRR(l3VPNs []v1alpha1.L3VPN, routerID string, asn int64, nodeIndex int) ([]frr.L3VPNConfig, error) {
+func l3vpnConfigsToFRR(
+	l3VPNs []v1alpha1.L3VPN,
+	routerID string,
+	asn int64,
+	nodeIndex int,
+	vrfsWithL2Gateway map[string][]string,
+) ([]frr.L3VPNConfig, error) {
 	vpnConfigs := []frr.L3VPNConfig{}
 	for _, vpn := range l3VPNs {
-		frrVNI, err := l3vpnToFRR(vpn, routerID, asn, nodeIndex)
+		var opts []L3VPNOption
+		if gatewayCIDRs, ok := vrfsWithL2Gateway[vpn.Spec.VRF]; ok {
+			opts = []L3VPNOption{L3VPNWithGatewayIPs(gatewayCIDRs)}
+		}
+		frrVNI, err := l3vpnToFRR(vpn, routerID, asn, nodeIndex, opts...)
 		if err != nil {
 			return []frr.L3VPNConfig{}, fmt.Errorf("failed to translate l3vpn to frr: %w, vni %v", err, vpn)
 		}
@@ -528,7 +572,13 @@ func l3vpnConfigsToFRR(l3VPNs []v1alpha1.L3VPN, routerID string, asn int64, node
 // Otherwise, it derives veth IPs from the HostSession's local CIDR pool for the given node index
 // and creates a config per IP family (IPv4/IPv6), each with a local neighbor and the corresponding prefixes to
 // advertise.
-func l3vpnToFRR(vpn v1alpha1.L3VPN, routerID string, underlayASN int64, nodeIndex int) ([]frr.L3VPNConfig, error) {
+func l3vpnToFRR(
+	vpn v1alpha1.L3VPN,
+	routerID string,
+	underlayASN int64,
+	nodeIndex int,
+	opts ...L3VPNOption,
+) ([]frr.L3VPNConfig, error) {
 	// importRTs cannot be auto-derived. Unfortunately, FRR does not support wildcard notation, e.g. *:200. And
 	// using 0, e.g. 0:200, imports the route target verbatim.
 	if len(vpn.Spec.ImportRTs) < 1 {
@@ -542,17 +592,20 @@ func l3vpnToFRR(vpn v1alpha1.L3VPN, routerID string, underlayASN int64, nodeInde
 	}
 
 	if vpn.Spec.HostSession == nil { // no neighbor, just the vni / vrf
-		conf := []frr.L3VPNConfig{
-			{
-				ASN:                underlayASN, // Since there is no session, the ASN is arbitrary
-				VRF:                vpn.Spec.VRF,
-				RouterID:           routerID,
-				ExportRTs:          exportRTs,
-				ImportRTs:          importRTs,
-				RouteDistinguisher: routeDistinguisher(routerID, vpn.Spec.RDAssignedNumber),
-			},
+		cfg := frr.L3VPNConfig{
+			ASN:                underlayASN, // Since there is no session, the ASN is arbitrary
+			VRF:                vpn.Spec.VRF,
+			RouterID:           routerID,
+			ExportRTs:          exportRTs,
+			ImportRTs:          importRTs,
+			RouteDistinguisher: routeDistinguisher(routerID, vpn.Spec.RDAssignedNumber),
 		}
-		return conf, nil
+		for _, opt := range opts {
+			if err := opt(&cfg); err != nil {
+				return nil, err
+			}
+		}
+		return []frr.L3VPNConfig{cfg}, nil
 	}
 
 	hostASN, err := frr.NewPeerASN(vpn.Spec.HostSession.HostASN, vpn.Spec.HostSession.HostType)
@@ -594,7 +647,13 @@ func l3vpnToFRR(vpn v1alpha1.L3VPN, routerID string, underlayASN int64, nodeInde
 			ToAdvertiseIPv6: toAdvertiseIPv6,
 		})
 	}
-
+	for i := range configs {
+		for _, opt := range opts {
+			if err := opt(&configs[i]); err != nil {
+				return nil, err
+			}
+		}
+	}
 	return configs, nil
 }
 
@@ -959,7 +1018,7 @@ func routerIDFromUnderlay(underlay v1alpha1.Underlay, nodeIndex int) (string, er
 	return routerID, nil
 }
 
-func vrfsWithL2Gateways(l2vnis []v1alpha1.L2VNI) map[string][]string {
+func vrfsFromVNIsWithL2Gateways(l2vnis []v1alpha1.L2VNI) map[string][]string {
 	res := make(map[string][]string)
 	for _, l2vni := range l2vnis {
 		if len(l2vni.Spec.L2GatewayIPs) > 0 {

--- a/internal/conversion/frr_conversion_test.go
+++ b/internal/conversion/frr_conversion_test.go
@@ -1837,6 +1837,213 @@ func TestAPItoFRR(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:      "l3vpn with matching L2 gateway IPv4",
+			nodeIndex: 0,
+			underlays: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						ASN:          65000,
+						RouterIDCIDR: new("10.0.0.0/24"),
+						Neighbors:    []v1alpha1.Neighbor{{Address: new("192.168.1.1"), ASN: new(int64(65001))}},
+					},
+				},
+			},
+			vpns: []v1alpha1.L3VPN{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni1"},
+					Spec: v1alpha1.L3VPNSpec{
+						VRF:              "red",
+						RDAssignedNumber: 200,
+						ImportRTs:        []v1alpha1.RouteTarget{"65000:200"},
+					},
+				},
+			},
+			l2vnis: []v1alpha1.L2VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "l2vni1"},
+					Spec: v1alpha1.L2VNISpec{
+						VRF:          new("red"),
+						VNI:          100,
+						L2GatewayIPs: []string{"192.168.100.1/24"},
+					},
+				},
+			},
+			l3Passthrough: []v1alpha1.L3Passthrough{},
+			logLevel:      "debug",
+			want: frr.Config{
+				Underlay: frr.UnderlayConfig{
+					MyASN:    65000,
+					RouterID: "10.0.0.1",
+					Neighbors: []frr.NeighborConfig{
+						{
+							Name: "65001@192.168.1.1",
+							ASN:  mustNewPeerASNFromNumber(65001),
+							Addr: "192.168.1.1",
+							ID:   "192.168.1.1",
+							NetworkLayerProtocols: []networklayerprotocol.NLP{
+								{AFI: networklayerprotocol.IPv4, SAFI: networklayerprotocol.Unicast},
+								{AFI: networklayerprotocol.L2VPN, SAFI: networklayerprotocol.EVPN},
+							},
+							EBGPMultiHop: false,
+						},
+					},
+				},
+				VNIs: []frr.L3VNIConfig{},
+				VPNs: []frr.L3VPNConfig{
+					{
+						ASN:                65000,
+						VRF:                "red",
+						RouterID:           "10.0.0.1",
+						ToAdvertiseIPv4:    []string{"192.168.100.0/24"},
+						ExportRTs:          []string{"65000:200"},
+						ImportRTs:          []string{"65000:200"},
+						RouteDistinguisher: "10.0.0.1:200",
+					},
+				},
+				BFDProfiles: []frr.BFDProfile{},
+				Loglevel:    "debug",
+			},
+			wantErr: false,
+		},
+		{
+			name:      "l3vpn with matching L2 gateway dual-stack",
+			nodeIndex: 0,
+			underlays: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						ASN:          65000,
+						RouterIDCIDR: new("10.0.0.0/24"),
+						Neighbors:    []v1alpha1.Neighbor{{Address: new("192.168.1.1"), ASN: new(int64(65001))}},
+					},
+				},
+			},
+			vpns: []v1alpha1.L3VPN{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni1"},
+					Spec: v1alpha1.L3VPNSpec{
+						VRF:              "red",
+						RDAssignedNumber: 200,
+						ImportRTs:        []v1alpha1.RouteTarget{"65000:200"},
+					},
+				},
+			},
+			l2vnis: []v1alpha1.L2VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "l2vni1"},
+					Spec: v1alpha1.L2VNISpec{
+						VRF:          new("red"),
+						VNI:          100,
+						L2GatewayIPs: []string{"10.0.0.1/24", "2001:db8::1/64"},
+					},
+				},
+			},
+			l3Passthrough: []v1alpha1.L3Passthrough{},
+			logLevel:      "debug",
+			want: frr.Config{
+				Underlay: frr.UnderlayConfig{
+					MyASN:    65000,
+					RouterID: "10.0.0.1",
+					Neighbors: []frr.NeighborConfig{
+						{
+							Name: "65001@192.168.1.1",
+							ASN:  mustNewPeerASNFromNumber(65001),
+							Addr: "192.168.1.1",
+							ID:   "192.168.1.1",
+							NetworkLayerProtocols: []networklayerprotocol.NLP{
+								{AFI: networklayerprotocol.IPv4, SAFI: networklayerprotocol.Unicast},
+								{AFI: networklayerprotocol.L2VPN, SAFI: networklayerprotocol.EVPN},
+							},
+							EBGPMultiHop: false,
+						},
+					},
+				},
+				VNIs: []frr.L3VNIConfig{},
+				VPNs: []frr.L3VPNConfig{
+					{
+						ASN:                65000,
+						VRF:                "red",
+						RouterID:           "10.0.0.1",
+						ToAdvertiseIPv4:    []string{"10.0.0.0/24"},
+						ToAdvertiseIPv6:    []string{"2001:db8::/64"},
+						ExportRTs:          []string{"65000:200"},
+						ImportRTs:          []string{"65000:200"},
+						RouteDistinguisher: "10.0.0.1:200",
+					},
+				},
+				BFDProfiles: []frr.BFDProfile{},
+				Loglevel:    "debug",
+			},
+			wantErr: false,
+		},
+		{
+			name:      "l3vpn with non-matching L2 gateway VRF",
+			nodeIndex: 0,
+			underlays: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						ASN:          65000,
+						RouterIDCIDR: new("10.0.0.0/24"),
+						Neighbors:    []v1alpha1.Neighbor{{Address: new("192.168.1.1"), ASN: new(int64(65001))}},
+					},
+				},
+			},
+			vpns: []v1alpha1.L3VPN{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni1"},
+					Spec: v1alpha1.L3VPNSpec{
+						VRF:              "red",
+						RDAssignedNumber: 200,
+						ImportRTs:        []v1alpha1.RouteTarget{"65000:200"},
+					},
+				},
+			},
+			l2vnis: []v1alpha1.L2VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "l2vni1"},
+					Spec: v1alpha1.L2VNISpec{
+						VRF:          new("blue"),
+						VNI:          100,
+						L2GatewayIPs: []string{"192.168.100.1/24"},
+					},
+				},
+			},
+			l3Passthrough: []v1alpha1.L3Passthrough{},
+			logLevel:      "debug",
+			want: frr.Config{
+				Underlay: frr.UnderlayConfig{
+					MyASN:    65000,
+					RouterID: "10.0.0.1",
+					Neighbors: []frr.NeighborConfig{
+						{
+							Name: "65001@192.168.1.1",
+							ASN:  mustNewPeerASNFromNumber(65001),
+							Addr: "192.168.1.1",
+							ID:   "192.168.1.1",
+							NetworkLayerProtocols: []networklayerprotocol.NLP{
+								{AFI: networklayerprotocol.IPv4, SAFI: networklayerprotocol.Unicast},
+								{AFI: networklayerprotocol.L2VPN, SAFI: networklayerprotocol.EVPN},
+							},
+							EBGPMultiHop: false,
+						},
+					},
+				},
+				VNIs: []frr.L3VNIConfig{},
+				VPNs: []frr.L3VPNConfig{
+					{
+						ASN:                65000,
+						VRF:                "red",
+						RouterID:           "10.0.0.1",
+						ExportRTs:          []string{"65000:200"},
+						ImportRTs:          []string{"65000:200"},
+						RouteDistinguisher: "10.0.0.1:200",
+					},
+				},
+				BFDProfiles: []frr.BFDProfile{},
+				Loglevel:    "debug",
+			},
+			wantErr: false,
+		},
+		{
 			name:      "Neighbor Address and Interface cannot both be set",
 			nodeIndex: 0,
 			underlays: []v1alpha1.Underlay{
@@ -2656,7 +2863,7 @@ func TestAPItoFRR(t *testing.T) {
 			wantErr:  true,
 		},
 		{
-			name:      "SRV6 with L3VPN and L2VNI",
+			name:      "SRV6 with L3VPN and L2VNI with hostsession",
 			nodeIndex: 0,
 			underlays: []v1alpha1.Underlay{
 				{
@@ -2716,8 +2923,8 @@ func TestAPItoFRR(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "l2vni1"},
 					Spec: v1alpha1.L2VNISpec{
 						VRF:          new("vrf1"),
-						VNI:          101,                                             // TODO: test overlap
-						L2GatewayIPs: []string{"192.168.100.1/24", "2001:db8:1::/64"}, // TODO: test overlap
+						VNI:          101,
+						L2GatewayIPs: []string{"192.168.100.1/24", "2001:db8:1::/64"},
 					},
 				},
 			},
@@ -2786,9 +2993,14 @@ func TestAPItoFRR(t *testing.T) {
 				VNIs:        []frr.L3VNIConfig{},
 				VPNs: []frr.L3VPNConfig{
 					{
-						ASN:             65000,
-						ToAdvertiseIPv4: []string{"192.168.2.2/32"},
-						ToAdvertiseIPv6: []string{},
+						ASN: 65000,
+						ToAdvertiseIPv4: []string{
+							"192.168.2.2/32",
+							"192.168.100.0/24",
+						},
+						ToAdvertiseIPv6: []string{
+							"2001:db8:1::/64",
+						},
 						LocalNeighbor: &frr.NeighborConfig{
 							ASN:  mustNewPeerASNFromNumber(65001),
 							Addr: "192.168.2.2",
@@ -2801,9 +3013,14 @@ func TestAPItoFRR(t *testing.T) {
 						RouterID:           "10.0.0.1",
 					},
 					{
-						ASN:             65000,
-						ToAdvertiseIPv4: []string{},
-						ToAdvertiseIPv6: []string{"2001:db8::2/128"},
+						ASN: 65000,
+						ToAdvertiseIPv4: []string{
+							"192.168.100.0/24",
+						},
+						ToAdvertiseIPv6: []string{
+							"2001:db8::2/128",
+							"2001:db8:1::/64",
+						},
 						LocalNeighbor: &frr.NeighborConfig{
 							ASN:  mustNewPeerASNFromNumber(65001),
 							Addr: "2001:db8::2",

--- a/website/content/docs/concepts/srv6.md
+++ b/website/content/docs/concepts/srv6.md
@@ -146,12 +146,6 @@ East/West Layer 2 traffic. L2 frames are encapsulated in VXLAN with EVPN as
 the control plane for MAC/IP advertisement, even when the broader L3 domain
 uses SRv6.
 
-> **Note**: `l2GatewayIPs` is not supported when using L3VPN (SRv6).
-> L2VNIs with L3VPN provide Layer 2 pod-to-pod connectivity only.
-> For Layer 3 connectivity to external hosts, use the L3VPN path via the
-> pod's primary interface (eth0). The `l2GatewayIPs` field is only
-> available when using L3VNI (EVPN/VXLAN).
-
 For each Layer 2 VNI, OpenPERouter automatically:
 
 - **Creates a VXLAN Interface**: Handles VXLAN tunnel

--- a/website/content/docs/configuration/srv6.md
+++ b/website/content/docs/configuration/srv6.md
@@ -227,11 +227,6 @@ L2VNIs provide Layer 2 connectivity across nodes using EVPN as the control
 plane and VXLAN tunnels as the data plane, contrary to L3VPNs which use
 SRv6.
 
-> **Note**: `l2GatewayIPs` is not supported when using L3VPN (SRv6).
-> L2VNIs with L3VPN provide Layer 2 pod-to-pod connectivity only.
-> The `l2GatewayIPs` field is only available when using L3VNI
-> (EVPN/VXLAN).
-
 For the full list of L2VNI configuration fields, see the
 [L2VNISpec API Reference]({{< ref "api-reference#l2vnispec" >}}).
 

--- a/website/content/docs/examples/srv6examples/layer2.md
+++ b/website/content/docs/examples/srv6examples/layer2.md
@@ -31,12 +31,7 @@ make docker-build demo-metallb-l3vpn-l2vni
 The example configures both an L2 VNI and an L3VPN. The L2 VNI belongs to
 the L3VPN's routing domain. Pods are running on two separate nodes and
 connected via the overlay. Additionally, the pods are able to reach the
-broader L3 domain via the L3VPN path.
-
-> **Note**: `l2GatewayIPs` is not supported when using L3VPN (SRv6).
-> Layer 3 connectivity to external hosts goes through the pod's primary
-> interface (eth0) and the L3VPN path, not through the L2VNI's macvlan
-> interface.
+broader L3 domain via the L2 gateways.
 
 ### Pod-to-Pod Connectivity
 
@@ -47,10 +42,9 @@ corresponding L2 VNI.
 ### Pod-to-External L3 Connectivity
 
 When a pod needs to reach an external host on the L3 domain, the traffic
-leaves via the pod's primary interface (eth0), hits the host namespace
-where FRR-K8s has injected a route via the L3VPN's veth interface
-(host-s-100), and is then SNATed and routed through the L3VPN's VRF
-using SRv6 encapsulation.
+leaves via the pod's secondary interface (added by the NetworkAttachmentDefinition)
+and is routed in the VRF of the OpenPERouter pod that the pod is connected to.
+The packet is subsequently forwarded via the SRv6 overlay.
 
 ## Configuration
 
@@ -90,14 +84,13 @@ spec:
     type: linux-bridge
     linuxBridge:
       autoCreate: true
+  l2gatewayips: ["192.170.1.1/24"]
 ```
 
 **Configuration Notes:**
 
 - **hostmaster.autocreate**: Instructs OpenPERouter to create a bridge
   local to the node that can be used to access the L2 domain
-- **`l2GatewayIPs`** is not supported with L3VPN (SRv6). This field is
-  only available when using L3VNI (EVPN/VXLAN)
 
 ### Underlay Configuration
 
@@ -183,10 +176,13 @@ spec:
   containers:
     - name: agnhost
       image: k8s.gcr.io/e2e-test-images/agnhost:2.45
-      command: ["/agnhost", "netexec", "--http-port=8090"]
+      command: ["/bin/sh", "-c", "ip r del default dev eth0 && /agnhost netexec --http-port=8090"]
       ports:
       - containerPort: 8090
         name: http
+      securityContext:
+        capabilities:
+          add: ["NET_ADMIN"]
 ```
 
 ## Validation
@@ -220,10 +216,11 @@ kubectl exec -it first -- curl 192.170.20.2:8090/clientip
 
 Expected output:
 ```
-192.169.10.2:35722
+192.170.1.3:37144
 ```
 
-The traffic leaves via the pod's eth0 interface, is routed through the
-host namespace to the L3VPN's veth interface (host-s-100), SNATed, and
-then encapsulated using SRv6 towards the destination.
+The pod is able to reach a host on the layer 3 network and the IP is preserved.
 
+The packet comes from the veth interface towards the bridge associated with VNI
+110 (the default gateway), then is routed inside the layer 3 domain via the
+SRv6 overlay.


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind feature

**What this PR does / why we need it**:
-  add l2gatewayips for l3vpn + l2vni
-  adjust examples for l2gatewayips
-  adjust docs for l2gatewayips
-  adjust l3vpn l2 E2E tests for l2gatewayIPs
-  fix naming inconsistency between E2e tests (unrelated but minor fix to have all SRv6 E2E tests under "SRV6 routes")

**Special notes for your reviewer**:
Follow-up to SRv6 feature.

```release-note
L3VPN + L2VNI combinations now support l2gatewayIPs.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
