### PR TITLE
fix(grout): disable rp_filter on grout ports

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -258,6 +258,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install linux-modules-extra-$(uname -r)
 
+      # rp_filter is off on CI runners; enable it so kind nodes inherit a production-like default
+      - name: Enable rp_filter
+        run: |
+          sudo sysctl -w net.ipv4.conf.default.rp_filter=1
+          sudo sysctl -w net.ipv4.conf.default.log_martians=1
+
       - name: Disable containerd image store
         run: |
           sudo bash -c 'cat > /etc/docker/daemon.json << EOF
@@ -340,6 +346,12 @@ jobs:
         if: ${{ failure() }}
         run:
           make kind-export-logs
+
+      # Needed to debug kernel "martian source" packets
+      - name: Collect dmesg logs
+        if: ${{ failure() }}
+        run: |
+          sudo dmesg -T > /tmp/kind_logs/dmesg.log
 
       - name: Collect veth monitor logs
         if: ${{ failure() }}

--- a/internal/grout/passthrough.go
+++ b/internal/grout/passthrough.go
@@ -11,6 +11,8 @@ import (
 	"net"
 
 	"github.com/openperouter/openperouter/internal/hostnetwork"
+	"github.com/openperouter/openperouter/internal/netnamespace"
+	"github.com/openperouter/openperouter/internal/sysctl"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 )
@@ -51,6 +53,18 @@ func SetupPassthrough(ctx context.Context, client *Client, params hostnetwork.Pa
 	// Assign IPs to the grout port "pt-ns" via grcli.
 	if err := ensurePortAddresses(ctx, client, portName, params.LinkIPs.NSIPv4, params.LinkIPs.NSIPv6); err != nil {
 		return fmt.Errorf("failed to ensure IPs to grout port: %w", err)
+	}
+
+	if err := netnamespace.In(peRouterNs, func() error {
+		// Grout creates a NOARP kernel interface for each port. BGP packets leave
+		// through the `main` interface but return on the port's kernel interface (grout control plane tap),
+		// so rp_filter must be disabled to allow the asymmetric path.
+		if err := sysctl.Ensure(sysctl.DisableRPFilter(portName)); err != nil {
+			return fmt.Errorf("failed to disable rp_filter on passthrough port %s: %w", portName, err)
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/grout/underlay.go
+++ b/internal/grout/underlay.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/openperouter/openperouter/internal/hostnetwork"
 	"github.com/openperouter/openperouter/internal/netnamespace"
+	"github.com/openperouter/openperouter/internal/sysctl"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 )
@@ -182,13 +183,25 @@ func migrateAddressesToGrout(ctx context.Context, client *Client, underlayInterf
 		}
 
 		// FRR needs kernel routes to enstabilish BGP connections. Grout requires that all the kernel
-		// traffic must enter/leave grout via the `main` TAP device.
+		// traffic must enter grout via the `main` TAP device.
 		if err := ensureKernelSubnetRoute("main", addr.IPNet.String()); err != nil {
 			return fmt.Errorf("failed to add kernel route for underlay subnet %s: %w", addr, err)
 		}
 
 		slog.InfoContext(ctx, "migrated underlay address to grout", "cidr", cidr, "iface", UnderlayPortNamePrefix+underlayInterface)
 	}
+
+	// for each port, grout creates a NOARP kernel interface to make FRR zebra daemon work.
+	// 5: u_enp3s0: <BROADCAST,MULTICAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
+	//    link/ether 00:09:a8:38:8e:3b brd ff:ff:ff:ff:ff:ff promiscuity 0 allmulti 0 minmtu 68 maxmtu 65521
+	//    tun type tap ...
+	//    alias Grout control plane interface
+	// bgpd packets will leave through the `main` intrerface and will come back on the `u_xxx` interface, hence the
+	// need to disable rp_filter on the `u_xxx` interface.
+	if err := sysctl.Ensure(sysctl.DisableRPFilter(UnderlayPortNamePrefix + underlayInterface)); err != nil {
+		return fmt.Errorf("failed to disable rp_filter on underlay interface %s: %w", UnderlayPortNamePrefix+underlayInterface, err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Grout creates NOARP kernel interfaces (u_<port>) for FRR's zebra daemon. BGP packets leave through the `main` TAP interface but return on the `u_<port>` interface. When rp_filter is enabled (as in OpenShift, where the default is set to 1), the kernel drops these return packets due to the asymmetric path, breaking BGP sessions.

Disable rp_filter on the underlay interfaces to allow this traffic.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Disable rp_filter sysctl on grout ports
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved networking reliability for passthrough and underlay interfaces by adjusting reverse-path filtering behavior.
  * Enhanced end-to-end test diagnostics with kernel message collection when failures occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->