### PR TITLE
Fix L2 gateway IPs being overwritten when multiple L2VNIs share a VRF

### DIFF
--- a/internal/conversion/frr_conversion.go
+++ b/internal/conversion/frr_conversion.go
@@ -963,8 +963,12 @@ func vrfsWithL2Gateways(l2vnis []v1alpha1.L2VNI) map[string][]string {
 			if l2vni.Spec.VRF != nil {
 				vrf = *l2vni.Spec.VRF
 			}
-			res[vrf] = l2vni.Spec.L2GatewayIPs
+			res[vrf] = append(res[vrf], l2vni.Spec.L2GatewayIPs...)
 		}
+	}
+	for vrf := range res {
+		slices.Sort(res[vrf])
+		res[vrf] = slices.Compact(res[vrf])
 	}
 	return res
 }

--- a/internal/conversion/frr_conversion_test.go
+++ b/internal/conversion/frr_conversion_test.go
@@ -2810,6 +2810,94 @@ func TestAPItoFRR(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name:      "multiple L2VNIs with same VRF accumulate gateway IPs",
+			nodeIndex: 0,
+			underlays: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						ASN:          65000,
+						RouterIDCIDR: new("10.0.0.0/24"),
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								Address: new("192.168.1.1"),
+								ASN:     new(int64(65001)),
+							},
+						},
+					},
+				},
+			},
+			vnis: []v1alpha1.L3VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni1"},
+					Spec: v1alpha1.L3VNISpec{
+						VRF: "red",
+						VNI: 200,
+					},
+				},
+			},
+			l2vnis: []v1alpha1.L2VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "l2vni100"},
+					Spec: v1alpha1.L2VNISpec{
+						VRF:          new("red"),
+						VNI:          100,
+						L2GatewayIPs: []string{"192.168.100.1/24", "2001:db8:100::1/64"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "l2vni101"},
+					Spec: v1alpha1.L2VNISpec{
+						VRF:          new("red"),
+						VNI:          101,
+						L2GatewayIPs: []string{"192.168.101.1/24", "2001:db8:101::1/64"},
+					},
+				},
+			},
+			l3Passthrough: []v1alpha1.L3Passthrough{},
+			logLevel:      "debug",
+			want: frr.Config{
+				Underlay: frr.UnderlayConfig{
+					MyASN:    65000,
+					RouterID: "10.0.0.1",
+					Neighbors: []frr.NeighborConfig{
+						{
+							Name: "65001@192.168.1.1",
+							ASN:  mustNewPeerASNFromNumber(65001),
+							Addr: "192.168.1.1",
+							ID:   "192.168.1.1",
+							NetworkLayerProtocols: []networklayerprotocol.NLP{
+								{AFI: networklayerprotocol.IPv4, SAFI: networklayerprotocol.Unicast},
+								{AFI: networklayerprotocol.L2VPN, SAFI: networklayerprotocol.EVPN},
+							},
+							EBGPMultiHop: false,
+						},
+					},
+				},
+				VNIs: []frr.L3VNIConfig{
+					{
+						ASN:      65000,
+						VNI:      200,
+						VRF:      "red",
+						RouterID: "10.0.0.1",
+						ToAdvertiseIPv4: []string{
+							"192.168.100.0/24",
+							"192.168.101.0/24",
+						},
+						ToAdvertiseIPv6: []string{
+							"2001:db8:100::/64",
+							"2001:db8:101::/64",
+						},
+						ExportRTs: []string{},
+						ImportRTs: []string{},
+					},
+				},
+				VPNs:        []frr.L3VPNConfig{},
+				BFDProfiles: []frr.BFDProfile{},
+				Loglevel:    "debug",
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -3154,6 +3242,170 @@ func TestTunnelEndpointToFRRDualStack(t *testing.T) {
 	}
 	if got.IPv6CIDR != ipv6TestVTEP {
 		t.Errorf("IPv6CIDR = %q, want %q", got.IPv6CIDR, ipv6TestVTEP)
+	}
+}
+
+func TestVrfsWithL2Gateways(t *testing.T) {
+	tests := []struct {
+		name   string
+		l2vnis []v1alpha1.L2VNI
+		want   map[string][]string
+	}{
+		{
+			name: "single L2VNI with gateway IPs",
+			l2vnis: []v1alpha1.L2VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni100"},
+					Spec: v1alpha1.L2VNISpec{
+						L2GatewayIPs: []string{"192.168.0.1/24", "2001:db8::1/64"},
+					},
+				},
+			},
+			want: map[string][]string{
+				"vni100": {"192.168.0.1/24", "2001:db8::1/64"},
+			},
+		},
+		{
+			name: "multiple L2VNIs with same VRF - accumulate gateway IPs",
+			l2vnis: []v1alpha1.L2VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni100"},
+					Spec: v1alpha1.L2VNISpec{
+						VRF:          new("red"),
+						L2GatewayIPs: []string{"192.168.0.1/24", "2001:db8:1::1/64"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni101"},
+					Spec: v1alpha1.L2VNISpec{
+						VRF:          new("red"),
+						L2GatewayIPs: []string{"192.168.1.1/24", "2001:db8:2::1/64"},
+					},
+				},
+			},
+			want: map[string][]string{
+				"red": {"192.168.0.1/24", "192.168.1.1/24", "2001:db8:1::1/64", "2001:db8:2::1/64"},
+			},
+		},
+		{
+			name: "multiple L2VNIs with different VRFs",
+			l2vnis: []v1alpha1.L2VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni100"},
+					Spec: v1alpha1.L2VNISpec{
+						VRF:          new("red"),
+						L2GatewayIPs: []string{"192.168.0.1/24", "2001:db8:1::1/64"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni200"},
+					Spec: v1alpha1.L2VNISpec{
+						VRF:          new("blue"),
+						L2GatewayIPs: []string{"192.168.1.1/24", "2001:db8:2::1/64"},
+					},
+				},
+			},
+			want: map[string][]string{
+				"red":  {"192.168.0.1/24", "2001:db8:1::1/64"},
+				"blue": {"192.168.1.1/24", "2001:db8:2::1/64"},
+			},
+		},
+		{
+			name: "L2VNI without gateway IPs is skipped",
+			l2vnis: []v1alpha1.L2VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni100"},
+					Spec: v1alpha1.L2VNISpec{
+						VRF: new("red"),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni101"},
+					Spec: v1alpha1.L2VNISpec{
+						VRF:          new("red"),
+						L2GatewayIPs: []string{"192.168.1.1/24"},
+					},
+				},
+			},
+			want: map[string][]string{
+				"red": {"192.168.1.1/24"},
+			},
+		},
+		{
+			name: "accumulated gateway IPs are sorted",
+			l2vnis: []v1alpha1.L2VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni100"},
+					Spec: v1alpha1.L2VNISpec{
+						VRF:          new("red"),
+						L2GatewayIPs: []string{"192.168.1.1/24"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni101"},
+					Spec: v1alpha1.L2VNISpec{
+						VRF:          new("red"),
+						L2GatewayIPs: []string{"192.168.0.1/24"},
+					},
+				},
+			},
+			want: map[string][]string{
+				"red": {"192.168.0.1/24", "192.168.1.1/24"},
+			},
+		},
+		{
+			name: "duplicate gateway IPs are deduplicated",
+			l2vnis: []v1alpha1.L2VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni100"},
+					Spec: v1alpha1.L2VNISpec{
+						VRF:          new("red"),
+						L2GatewayIPs: []string{"192.168.0.1/24", "192.168.1.1/24"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni101"},
+					Spec: v1alpha1.L2VNISpec{
+						VRF:          new("red"),
+						L2GatewayIPs: []string{"192.168.0.1/24", "192.168.2.1/24"},
+					},
+				},
+			},
+			want: map[string][]string{
+				"red": {"192.168.0.1/24", "192.168.1.1/24", "192.168.2.1/24"},
+			},
+		},
+		{
+			name: "L2VNIs with and without VRF use separate keys",
+			l2vnis: []v1alpha1.L2VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni100"},
+					Spec: v1alpha1.L2VNISpec{
+						VRF:          new("red"),
+						L2GatewayIPs: []string{"192.168.0.1/24"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni101"},
+					Spec: v1alpha1.L2VNISpec{
+						L2GatewayIPs: []string{"192.168.1.1/24"},
+					},
+				},
+			},
+			want: map[string][]string{
+				"red":    {"192.168.0.1/24"},
+				"vni101": {"192.168.1.1/24"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := vrfsWithL2Gateways(tt.l2vnis)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("vrfsWithL2Gateways() mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
vrfsWithL2Gateways used assignment instead of append, so only the last
L2VNI's gateway IPs were kept per VRF. Switch to append to accumulate
all gateway IPs across L2VNIs sharing the same VRF.

Add unit tests for vrfsWithL2Gateways and an integration test case in
TestAPItoFRR covering the multi-L2VNI-per-VRF scenario.

**Special notes for your reviewer**:
Fixes https://github.com/openperouter/openperouter/issues/563

On EVPN, the issue never surfaced, because EVPN injects /32 routes per
host. But this will be important for SRv6.

**Release note**:

```release-note
Fix bug in vrfsWithL2Gateways
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
