### PR TITLE
Fix operator grout startup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -304,12 +304,20 @@ jobs:
             sleep 5; 
             kubectl -n openperouter-system wait --for=condition=Ready pods -l "component in (controller,router,nodemarker)" --timeout 300s; 
           fi
-          if [ ${{ matrix.deployment }} = "operator-grout" ]; then 
-            IMG_TAG="main-grout" IMG_REPO="quay.io/openperouter" make load-on-kind; 
-            kubectl apply -f operator/config/samples/openperouter.yaml; 
-            kubectl patch openperouter openperouter -n openperouter-system --type merge -p '{"spec":{"datapath":"grout"}}'
-            sleep 5; 
-            kubectl -n openperouter-system wait --for=condition=Ready pods -l "component in (controller,router,nodemarker)" --timeout 300s; 
+          if [ ${{ matrix.deployment }} = "operator-grout" ]; then
+            IMG_TAG="main-grout" IMG_REPO="quay.io/openperouter" make load-on-kind;
+            kubectl apply -f - <<EOF
+          apiVersion: openpe.openperouter.github.io/v1alpha1
+          kind: OpenPERouter
+          metadata:
+            name: openperouter
+            namespace: openperouter-system
+          spec:
+            logLevel: debug
+            datapath: grout
+          EOF
+            sleep 5;
+            kubectl -n openperouter-system wait --for=condition=Ready pods -l "component in (controller,router,nodemarker)" --timeout 300s;
           fi
 
 

--- a/charts/openperouter/templates/router.yaml
+++ b/charts/openperouter/templates/router.yaml
@@ -310,15 +310,18 @@ spec:
             command: ["/bin/sh", "-c", "grcli -e"]
           initialDelaySeconds: 2
           periodSeconds: 5
+          timeoutSeconds: 5
           failureThreshold: 12
         readinessProbe:
           exec:
             command: ["/bin/sh", "-c", "grcli -e"]
           periodSeconds: 10
+          timeoutSeconds: 5
         livenessProbe:
           exec:
             command: ["/bin/sh", "-c", "grcli -e"]
           periodSeconds: 30
+          timeoutSeconds: 5
       {{- end }}
       tolerations:
       {{- if .Values.openperouter.runOnMaster }}

--- a/config/grout/perouter_patch.yaml
+++ b/config/grout/perouter_patch.yaml
@@ -58,7 +58,7 @@ spec:
           readOnly: true
         startupProbe:
           exec:
-            command: ["/bin/sh", "-c", "grcli -e trace enable all"]
+            command: ["/bin/sh", "-c", "grcli -e"]
           initialDelaySeconds: 2
           periodSeconds: 5
           timeoutSeconds: 5

--- a/config/grout/perouter_patch.yaml
+++ b/config/grout/perouter_patch.yaml
@@ -61,15 +61,18 @@ spec:
             command: ["/bin/sh", "-c", "grcli -e trace enable all"]
           initialDelaySeconds: 2
           periodSeconds: 5
+          timeoutSeconds: 5
           failureThreshold: 12
         readinessProbe:
           exec:
             command: ["/bin/sh", "-c", "grcli -e"]
           periodSeconds: 10
+          timeoutSeconds: 5
         livenessProbe:
           exec:
             command: ["/bin/sh", "-c", "grcli -e"]
           periodSeconds: 30
+          timeoutSeconds: 5
       volumes:
       - name: grout-socket
         hostPath:

--- a/operator/bindata/deployment/openperouter/templates/router.yaml
+++ b/operator/bindata/deployment/openperouter/templates/router.yaml
@@ -310,15 +310,18 @@ spec:
             command: ["/bin/sh", "-c", "grcli -e"]
           initialDelaySeconds: 2
           periodSeconds: 5
+          timeoutSeconds: 5
           failureThreshold: 12
         readinessProbe:
           exec:
             command: ["/bin/sh", "-c", "grcli -e"]
           periodSeconds: 10
+          timeoutSeconds: 5
         livenessProbe:
           exec:
             command: ["/bin/sh", "-c", "grcli -e"]
           periodSeconds: 30
+          timeoutSeconds: 5
       {{- end }}
       tolerations:
       {{- if .Values.openperouter.runOnMaster }}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>

/kind bug

> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
The operator-grout CI lane intermittently fails during cluster startup because the two-phase CR deployment (apply without datapath, then patch to add datapath: grout) triggers rolling updates that leave the old nodemarker pod in Terminating state. 

This leads `kubectl wait --for=condition=Ready` to never succeed on `Terminating` pods, causing a 5-minute timeout.

By applying the CR with the `datapath: grout` already set in a single step to eliminate the rolling update entirely we eliminate this intermittent failure.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
