### PR TITLE
feat: apply least-privilege security contexts to DaemonSets

### DIFF
--- a/Dockerfile.grout
+++ b/Dockerfile.grout
@@ -60,6 +60,17 @@ RUN dnf install -y iproute iproute-tc catatonit && dnf clean all
 RUN ln -s /usr/libexec/podman/catatonit /sbin/tini
 
 RUN mkdir /rpms
+
+# Pin FRR GIDs before RPM install so they match the supplementalGroups
+# in the Kubernetes pod spec. The grout FRR RPM uses sysusers.d which
+# assigns dynamic GIDs; pre-creating the groups forces stable values.
+# GID 92: frr group (VTY sockets are owned frr:frr in this image)
+# GID 102: frrvty group (VTY sockets are owned frr:frrvty in the Alpine image)
+RUN groupadd -r -g 92 frr && \
+    useradd -r -u 92 -g frr -d /var/run/frr -s /sbin/nologin -c "FRRouting suite" frr && \
+    groupadd -r -g 102 frrvty && \
+    usermod -a -G frrvty frr
+
 ADD https://github.com/DPDK/grout/releases/download/v0.16.0/frr.x86_64.rpm /tmp/
 ADD https://github.com/DPDK/grout/releases/download/v0.16.0/grout-frr.x86_64.rpm /tmp/
 ADD https://github.com/DPDK/grout/releases/download/v0.16.0/grout.x86_64.rpm /tmp/

--- a/charts/openperouter/templates/hostbridge.yaml
+++ b/charts/openperouter/templates/hostbridge.yaml
@@ -49,8 +49,12 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         securityContext:
-          privileged: true
           runAsUser: 0
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - name: shared-config
           mountPath: /shared

--- a/charts/openperouter/templates/router.yaml
+++ b/charts/openperouter/templates/router.yaml
@@ -146,15 +146,25 @@ spec:
       hostNetwork: true
       terminationGracePeriodSeconds: 10
       shareProcessNamespace: true
+      securityContext:
+        supplementalGroups: [92, 102]
       containers:
       - name: frr
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
+            drop: ["ALL"]
             add:
             - NET_ADMIN
             - NET_RAW
             - SYS_ADMIN
             - NET_BIND_SERVICE
+            - SETUID
+            - SETGID
+            - CHOWN
+            - DAC_OVERRIDE
+          seccompProfile:
+            type: Unconfined
         image: {{ .Values.openperouter.image.repository }}:{{ .Values.openperouter.image.tag | default .Chart.AppVersion }}
         {{- if .Values.openperouter.image.pullPolicy }}
         imagePullPolicy: {{ .Values.openperouter.image.pullPolicy }}
@@ -174,6 +184,7 @@ spec:
           - name: netns
             mountPath: /var/run/netns
             mountPropagation: HostToContainer
+            readOnly: true
           {{- if eq .Values.openperouter.datapath "grout" }}
           - name: grout-socket
             mountPath: /var/run/grout
@@ -229,6 +240,11 @@ spec:
         securityContext:
           seLinuxOptions:
             type: spc_t
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
           - name: frrconfig
             mountPath: /etc/frr
@@ -263,7 +279,17 @@ spec:
       {{- if eq .Values.openperouter.datapath "grout" }}
       - name: grout
         securityContext:
-          privileged: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+            add:
+            - SYS_ADMIN
+            - NET_ADMIN
+            - NET_RAW
+            - IPC_LOCK
+          seccompProfile:
+            type: Unconfined
         image: "{{ .Values.openperouter.grout.image.repository }}:{{ .Values.openperouter.grout.image.tag }}"
         {{- if .Values.openperouter.grout.image.pullPolicy }}
         imagePullPolicy: {{ .Values.openperouter.grout.image.pullPolicy }}
@@ -301,6 +327,10 @@ spec:
           - name: host-nsenter
             mountPath: /usr/bin/nsenter
             readOnly: true
+          - name: dev-net-tun
+            mountPath: /dev/net/tun
+          - name: dpdk-runtime
+            mountPath: /var/run/dpdk
         {{- with .Values.openperouter.grout.resources }}
         resources:
           {{- toYaml . | nindent 12 }}
@@ -362,10 +392,22 @@ spec:
           hostPath:
             path: /usr/bin/nsenter
             type: File
+        - name: dev-net-tun
+          hostPath:
+            path: /dev/net/tun
+            type: CharDevice
+        - name: dpdk-runtime
+          emptyDir: {}
         {{- end }}
       initContainers:
         # Copies the initial config files with the right permissions to the shared volume.
         - name: cp-frr-files
+          securityContext:
+            capabilities:
+              drop: ["ALL"]
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
           image: {{ .Values.openperouter.image.repository }}:{{ .Values.openperouter.image.tag | default .Chart.AppVersion }}
           {{- if .Values.openperouter.image.pullPolicy }}
           imagePullPolicy: {{ .Values.openperouter.image.pullPolicy }}

--- a/config/all-in-one/crio.yaml
+++ b/config/all-in-one/crio.yaml
@@ -2301,12 +2301,21 @@ spec:
           timeoutSeconds: 10
         name: frr
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
             add:
             - NET_ADMIN
             - NET_RAW
             - SYS_ADMIN
             - NET_BIND_SERVICE
+            - SETUID
+            - SETGID
+            - CHOWN
+            - DAC_OVERRIDE
+            drop:
+            - ALL
+          seccompProfile:
+            type: Unconfined
         volumeMounts:
         - mountPath: /var/run/frr
           name: frr-sockets
@@ -2315,6 +2324,7 @@ spec:
         - mountPath: /var/run/netns
           mountPropagation: HostToContainer
           name: netns
+          readOnly: true
       - args:
         - --frrconfig=/etc/perouter/frr.conf
         - --loglevel=debug
@@ -2345,8 +2355,14 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 10
         securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
           seLinuxOptions:
             type: spc_t
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/frr
           name: frrconfig
@@ -2363,11 +2379,22 @@ spec:
         image: quay.io/openperouter/router:main
         imagePullPolicy: IfNotPresent
         name: cp-frr-files
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /tmp/frr
           name: frr-startup
         - mountPath: /etc/frr
           name: frrconfig
+      securityContext:
+        supplementalGroups:
+        - 92
+        - 102
       serviceAccountName: perouter
       shareProcessNamespace: true
       terminationGracePeriodSeconds: 10

--- a/config/all-in-one/openpe.yaml
+++ b/config/all-in-one/openpe.yaml
@@ -2299,12 +2299,21 @@ spec:
           timeoutSeconds: 10
         name: frr
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
             add:
             - NET_ADMIN
             - NET_RAW
             - SYS_ADMIN
             - NET_BIND_SERVICE
+            - SETUID
+            - SETGID
+            - CHOWN
+            - DAC_OVERRIDE
+            drop:
+            - ALL
+          seccompProfile:
+            type: Unconfined
         volumeMounts:
         - mountPath: /var/run/frr
           name: frr-sockets
@@ -2313,6 +2322,7 @@ spec:
         - mountPath: /var/run/netns
           mountPropagation: HostToContainer
           name: netns
+          readOnly: true
       - args:
         - --frrconfig=/etc/perouter/frr.conf
         - --loglevel=debug
@@ -2343,8 +2353,14 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 10
         securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
           seLinuxOptions:
             type: spc_t
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/frr
           name: frrconfig
@@ -2361,11 +2377,22 @@ spec:
         image: quay.io/openperouter/router:main
         imagePullPolicy: IfNotPresent
         name: cp-frr-files
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /tmp/frr
           name: frr-startup
         - mountPath: /etc/frr
           name: frrconfig
+      securityContext:
+        supplementalGroups:
+        - 92
+        - 102
       serviceAccountName: perouter
       shareProcessNamespace: true
       terminationGracePeriodSeconds: 10

--- a/config/grout/perouter_patch.yaml
+++ b/config/grout/perouter_patch.yaml
@@ -21,11 +21,18 @@ spec:
         - name: netns
           mountPath: /var/run/netns
           mountPropagation: HostToContainer
+          readOnly: true
         - name: grout-socket
           mountPath: /var/run/grout
       - name: grout
         securityContext:
-          privileged: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+            add: ["SYS_ADMIN", "NET_ADMIN", "NET_RAW", "IPC_LOCK"]
+          seccompProfile:
+            type: Unconfined
         image: quay.io/openperouter/router
         imagePullPolicy: IfNotPresent
         env:
@@ -56,6 +63,10 @@ spec:
         - name: host-nsenter
           mountPath: /usr/bin/nsenter
           readOnly: true
+        - name: dev-net-tun
+          mountPath: /dev/net/tun
+        - name: dpdk-runtime
+          mountPath: /var/run/dpdk
         startupProbe:
           exec:
             command: ["/bin/sh", "-c", "grcli -e"]
@@ -82,3 +93,9 @@ spec:
         hostPath:
           path: /usr/bin/nsenter
           type: File
+      - name: dev-net-tun
+        hostPath:
+          path: /dev/net/tun
+          type: CharDevice
+      - name: dpdk-runtime
+        emptyDir: {}

--- a/config/hostmode/hostbridgepod.yaml
+++ b/config/hostmode/hostbridgepod.yaml
@@ -35,8 +35,12 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         securityContext:
-          privileged: true
           runAsUser: 0
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - name: shared-config
           mountPath: /shared

--- a/config/pods/perouter.yaml
+++ b/config/pods/perouter.yaml
@@ -26,11 +26,17 @@ spec:
       hostNetwork: true
       terminationGracePeriodSeconds: 10
       shareProcessNamespace: true
+      securityContext:
+        supplementalGroups: [92, 102]
       containers:
       - name: frr
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
-            add: ["NET_ADMIN", "NET_RAW", "SYS_ADMIN", "NET_BIND_SERVICE"]
+            drop: ["ALL"]
+            add: ["NET_ADMIN", "NET_RAW", "SYS_ADMIN", "NET_BIND_SERVICE", "SETUID", "SETGID", "CHOWN", "DAC_OVERRIDE"]
+          seccompProfile:
+            type: Unconfined
         image: router:latest
         imagePullPolicy: IfNotPresent
         env:
@@ -44,6 +50,7 @@ spec:
           - name: netns
             mountPath: /var/run/netns
             mountPropagation: HostToContainer
+            readOnly: true
         command:
           - /bin/sh
           - -c
@@ -78,9 +85,14 @@ spec:
         - "--frrconfig=/etc/perouter/frr.conf"
         - "--loglevel=debug"
         - "--unixsocket=/etc/perouter/reload.sock"
-        securityContext: 
+        securityContext:
           seLinuxOptions:
             type: spc_t
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
           - name: frrconfig
             mountPath: /etc/frr
@@ -133,6 +145,12 @@ spec:
       initContainers:
         # Copies the initial config files with the right permissions to the shared volume.
         - name: cp-frr-files
+          securityContext:
+            capabilities:
+              drop: ["ALL"]
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
           image: router:latest
           imagePullPolicy: IfNotPresent
           command: ["/bin/sh", "-c", "cp -rLf /tmp/frr/* /etc/frr/"]

--- a/internal/frrconfig/frrconfig.go
+++ b/internal/frrconfig/frrconfig.go
@@ -34,7 +34,7 @@ var execCommand = exec.Command
 
 func reloadAction(path string, action Action) error {
 	reloadParameter := "--" + string(action)
-	cmd := execCommand("python3", reloaderPath, reloadParameter, path)
+	cmd := execCommand("python3", reloaderPath, reloadParameter, "--logfile", "/dev/null", path)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		slog.Error("frr update failed", "action", action, "error", err, "output", string(output))

--- a/internal/frrconfig/frrconfig_test.go
+++ b/internal/frrconfig/frrconfig_test.go
@@ -83,8 +83,8 @@ func TestFakeReloadHelper(t *testing.T) {
 		}
 		args = args[1:]
 	}
-	if len(args) != 3 {
-		fmt.Printf("expecting 3 args, got %v", args)
+	if len(args) != 5 {
+		fmt.Printf("expecting 5 args, got %v", args)
 		os.Exit(1)
 	}
 
@@ -93,7 +93,7 @@ func TestFakeReloadHelper(t *testing.T) {
 		os.Exit(1)
 	}
 	action, _ := strings.CutPrefix(args[1], "--")
-	path := args[2]
+	path := args[4]
 
 	params, ok := tests[path]
 	if !ok {

--- a/operator/bindata/deployment/openperouter/templates/hostbridge.yaml
+++ b/operator/bindata/deployment/openperouter/templates/hostbridge.yaml
@@ -49,8 +49,12 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         securityContext:
-          privileged: true
           runAsUser: 0
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - name: shared-config
           mountPath: /shared

--- a/operator/bindata/deployment/openperouter/templates/router.yaml
+++ b/operator/bindata/deployment/openperouter/templates/router.yaml
@@ -146,15 +146,25 @@ spec:
       hostNetwork: true
       terminationGracePeriodSeconds: 10
       shareProcessNamespace: true
+      securityContext:
+        supplementalGroups: [92, 102]
       containers:
       - name: frr
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
+            drop: ["ALL"]
             add:
             - NET_ADMIN
             - NET_RAW
             - SYS_ADMIN
             - NET_BIND_SERVICE
+            - SETUID
+            - SETGID
+            - CHOWN
+            - DAC_OVERRIDE
+          seccompProfile:
+            type: Unconfined
         image: {{ .Values.openperouter.image.repository }}:{{ .Values.openperouter.image.tag | default .Chart.AppVersion }}
         {{- if .Values.openperouter.image.pullPolicy }}
         imagePullPolicy: {{ .Values.openperouter.image.pullPolicy }}
@@ -174,6 +184,7 @@ spec:
           - name: netns
             mountPath: /var/run/netns
             mountPropagation: HostToContainer
+            readOnly: true
           {{- if eq .Values.openperouter.datapath "grout" }}
           - name: grout-socket
             mountPath: /var/run/grout
@@ -229,6 +240,11 @@ spec:
         securityContext:
           seLinuxOptions:
             type: spc_t
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
           - name: frrconfig
             mountPath: /etc/frr
@@ -263,7 +279,17 @@ spec:
       {{- if eq .Values.openperouter.datapath "grout" }}
       - name: grout
         securityContext:
-          privileged: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+            add:
+            - SYS_ADMIN
+            - NET_ADMIN
+            - NET_RAW
+            - IPC_LOCK
+          seccompProfile:
+            type: Unconfined
         image: "{{ .Values.openperouter.grout.image.repository }}:{{ .Values.openperouter.grout.image.tag }}"
         {{- if .Values.openperouter.grout.image.pullPolicy }}
         imagePullPolicy: {{ .Values.openperouter.grout.image.pullPolicy }}
@@ -301,6 +327,10 @@ spec:
           - name: host-nsenter
             mountPath: /usr/bin/nsenter
             readOnly: true
+          - name: dev-net-tun
+            mountPath: /dev/net/tun
+          - name: dpdk-runtime
+            mountPath: /var/run/dpdk
         {{- with .Values.openperouter.grout.resources }}
         resources:
           {{- toYaml . | nindent 12 }}
@@ -362,10 +392,22 @@ spec:
           hostPath:
             path: /usr/bin/nsenter
             type: File
+        - name: dev-net-tun
+          hostPath:
+            path: /dev/net/tun
+            type: CharDevice
+        - name: dpdk-runtime
+          emptyDir: {}
         {{- end }}
       initContainers:
         # Copies the initial config files with the right permissions to the shared volume.
         - name: cp-frr-files
+          securityContext:
+            capabilities:
+              drop: ["ALL"]
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
           image: {{ .Values.openperouter.image.repository }}:{{ .Values.openperouter.image.tag | default .Chart.AppVersion }}
           {{- if .Values.openperouter.image.pullPolicy }}
           imagePullPolicy: {{ .Values.openperouter.image.pullPolicy }}


### PR DESCRIPTION
Replace broad privilege grants with explicit capability allowlists on all router and hostbridge containers. Drop ALL capabilities by default and add back only those each container genuinely exercises. Add seccomp RuntimeDefault where possible (Unconfined for grout due to DPDK syscall requirements). Mount /var/run/netns read-only on containers that only consume it.

Use pod-level supplementalGroups for the frrvty GID so the reloader can access FRR VTY sockets through standard Unix group permissions rather than elevated capabilities.

**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

**Special notes for your reviewer**:

```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Hardened router and host-bridge workloads by removing privileged execution.
  * Disabled privilege escalation and dropped unnecessary Linux capabilities.
  * Added stricter seccomp profiles and read-only filesystem or volume settings.
  * Added required supplemental groups for consistent routing service access.
  * Hardened the optional Grout datapath while preserving access to required networking resources.
  * Standardized FRRouting user and group identities in container images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->