### PR TITLE
fix(srv6): improve error wrapping in VNI and L3VPN cleanup functions

### DIFF
--- a/internal/hostnetwork/l3vpn.go
+++ b/internal/hostnetwork/l3vpn.go
@@ -96,7 +96,10 @@ func RemoveNonConfiguredL3VPNs(targetNS string, params []L3VPNParams) error {
 
 	hostLinks, err := netlink.LinkList()
 	if err != nil {
-		return fmt.Errorf("remove non configured l3vpns: failed to list links: %w", err)
+		return fmt.Errorf("RemoveNonConfiguredL3VPNs: failed to list links: %w", err)
 	}
-	return errors.Join(removeHostSideVeths(hostLinks, HostVethPrefix+SRv6Infix, rdAssignedNumbers)...)
+	if err := errors.Join(removeHostSideVeths(hostLinks, HostVethPrefix+SRv6Infix, rdAssignedNumbers)...); err != nil {
+		return fmt.Errorf("RemoveNonConfiguredL3VPNs: failed to remove veths: %w", err)
+	}
+	return nil
 }

--- a/internal/hostnetwork/vni.go
+++ b/internal/hostnetwork/vni.go
@@ -277,7 +277,7 @@ func RemoveNonConfiguredVNIs(targetNS string, params []VNIParams) error {
 		vnis[p.VNI] = true
 	}
 
-	failedDeletes := removeHostSideVNIs(vnis)
+	errs := removeHostSideVNIs(vnis)
 
 	ns, err := netns.GetFromPath(targetNS)
 	if err != nil {
@@ -291,13 +291,15 @@ func RemoveNonConfiguredVNIs(targetNS string, params []VNIParams) error {
 
 	if err := netnamespace.In(ns, func() error {
 		nsErrors := removeNamespaceSideVNIs(vnis)
-		failedDeletes = append(failedDeletes, nsErrors...)
-		return errors.Join(failedDeletes...)
+		return errors.Join(nsErrors...)
 	}); err != nil {
-		return err
+		errs = append(errs, err)
 	}
 
-	return errors.Join(failedDeletes...)
+	if err := errors.Join(errs...); err != nil {
+		return fmt.Errorf("RemoveNonConfiguredVNIs: %w", err)
+	}
+	return nil
 }
 
 func removeHostSideVNIs(vnis map[int32]bool) []error {


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

Wrap errors with function names in RemoveNonConfiguredVNIs and
RemoveNonConfiguredL3VPNs for easier debugging. Refactor
RemoveNonConfiguredVNIs to avoid mutating the outer error slice
from within the namespace closure, eliminating a dead code path.

**Special notes for your reviewer**:
Follow-up to https://github.com/openperouter/openperouter/pull/485#discussion_r3524964976

**Release note**:

```release-note
Improve error wrapping in VNI and L3VPN cleanup functions
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
