### PR TITLE
fix(unittests): rename vrfsWithL2Gateways to vrfsFromVNIsWithL2Gateways

### DIFF
--- a/e2etests/tests/l3vpn_l2.go
+++ b/e2etests/tests/l3vpn_l2.go
@@ -390,7 +390,7 @@ var _ = Describe("SRV6 routes between bgp and the fabric", Ordered, func() {
 			hostMaster: v1alpha1.HostMaster{
 				Type: linuxBridgeHostAttachment,
 				LinuxBridge: &v1alpha1.LinuxBridgeConfig{
-					AutoCreate: ptr.To(true),
+					AutoCreate: new(true),
 				},
 			},
 		}),

--- a/internal/conversion/frr_conversion_test.go
+++ b/internal/conversion/frr_conversion_test.go
@@ -3473,7 +3473,7 @@ func TestTunnelEndpointToFRRDualStack(t *testing.T) {
 	}
 }
 
-func TestVrfsWithL2Gateways(t *testing.T) {
+func TestVRFsFromVNIsWithL2Gateways(t *testing.T) {
 	tests := []struct {
 		name   string
 		l2vnis []v1alpha1.L2VNI
@@ -3629,9 +3629,9 @@ func TestVrfsWithL2Gateways(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := vrfsWithL2Gateways(tt.l2vnis)
+			got := vrfsFromVNIsWithL2Gateways(tt.l2vnis)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("vrfsWithL2Gateways() mismatch (-want +got):\n%s", diff)
+				t.Errorf("vrfsFromVNIsWithL2Gateways() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:
Commits 80c94b74c5bae80f97926bd380060f8a06002211 and
        8fde9ce4a4a2e36a527fb1cd6cc1626d5afbe571 crossed in flight.
Fix the unit tests to use the new function name.

**Special notes for your reviewer**:
N/A

**Release note**:

```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Renamed an internal VRF conversion test to better reflect the scenario being validated, and aligned its failure messaging accordingly.
  * Updated an end-to-end L3VPN/L2 test configuration for the “single stack IPv4 without gateway IPs” case to use a different boolean initialization approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->