### PR TITLE
fix, deployment: add missing reloader-socket arg to controller

### DIFF
--- a/config/all-in-one/crio.yaml
+++ b/config/all-in-one/crio.yaml
@@ -2095,6 +2095,7 @@ spec:
         - --namespace=$(NAMESPACE)
         - --frrconfig=/etc/frr/frr.conf
         - --crisocket=/crio.sock
+        - --reloader-socket=/etc/frr/reload.sock
         command:
         - /controller
         env:

--- a/config/crio/controller_patch.yaml
+++ b/config/crio/controller_patch.yaml
@@ -18,6 +18,7 @@ spec:
           - "--namespace=$(NAMESPACE)"
           - "--frrconfig=/etc/frr/frr.conf"
           - "--crisocket=/crio.sock"
+          - "--reloader-socket=/etc/frr/reload.sock"
       volumes:
       - name: varrun
         hostPath:


### PR DESCRIPTION
The all-in-one CRIO config was notoriously missing the frr-reloader-socket path, which caused it to fail deployment in OpenShift - the default is an empty string, which caused the controller pod to start.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>

/kind bug

> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
The CRI-O kustomize patch replaces the entire controller args list
but was missing --reloader-socket. Without it the flag defaults to
an empty string, so RouterNamedNS.CanReconcile() cannot check
reloader socket readiness -- breaking named-netns deployments on
OpenShift.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fixed CRI-O (e.g. OpenShift) deployments failing because the controller was missing the FRR reloader socket path.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the controller’s reloader socket, enabling improved reload handling for CRIO/Frr deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->