### PR TITLE
fix(webhook): invert parameters of validateL2VNIUpdate

### DIFF
--- a/internal/webhooks/l2vni_webhook.go
+++ b/internal/webhooks/l2vni_webhook.go
@@ -93,7 +93,7 @@ func validateL2VNICreate(l2vni *v1alpha1.L2VNI) error {
 	return validateL2VNI(l2vni)
 }
 
-func validateL2VNIUpdate(l2vni *v1alpha1.L2VNI, oldL2VNI *v1alpha1.L2VNI) error {
+func validateL2VNIUpdate(oldL2VNI, l2vni *v1alpha1.L2VNI) error {
 	Logger.Debug("webhook l2vni", "action", "update", "name", l2vni.Name, "namespace", l2vni.Namespace)
 	defer Logger.Debug("webhook l2vni", "action", "end update", "name", l2vni.Name, "namespace", l2vni.Namespace)
 


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

The old and new parameters were mixed up. This commit fixes this.

**Special notes for your reviewer**:
Fixes https://github.com/openperouter/openperouter/issues/586

**Release note**:

```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the order of “old” vs “new” data used during L2VNI update validation, ensuring immutability checks and update logging apply to the intended versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->