### PR TITLE
chore: remove accidentally committed hostbridge binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ go.work
 *.swo
 *~
 logs_*/
+
+cmd/hostbridge/hostbridge


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:

Removes `cmd/hostbridge/hostbridge`, a 34MB compiled ELF binary that was
accidentally committed in d16a95de, and adds it to `.gitignore` so it does
not get committed again by accident.

**Special notes for your reviewer**:

The blob will still exist in git history; fully purging it would require a
history rewrite, which is likely not worth it.

**Release note**:

```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated version control exclusions to prevent the generated host bridge binary from being tracked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->