### PR TITLE
CNI DHCP IPAM integration

### DIFF
--- a/clab/singlecluster/dhcp1/dnsmasq.sh
+++ b/clab/singlecluster/dhcp1/dnsmasq.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+apk add --no-cache dnsmasq
+
+while ! ip link show eth1 >/dev/null 2>&1; do
+  sleep 0.1
+done
+
+ip addr add 192.168.11.1/24 dev eth1
+ip link set eth1 up
+
+exec dnsmasq \
+  --no-daemon \
+  --interface=eth1 \
+  --bind-interfaces \
+  --dhcp-range=192.168.11.100,192.168.11.150,255.255.255.0,2m \
+  --dhcp-option=option:router,192.168.11.1 \
+  --no-resolv \
+  --no-hosts \
+  --log-dhcp

--- a/clab/singlecluster/kind.clab.yml
+++ b/clab/singlecluster/kind.clab.yml
@@ -72,6 +72,13 @@ topology:
       binds:
         - ../hostSRV6_blue/setup.sh:/setup.sh
 
+    dhcp1:
+      kind: linux
+      image: alpine:3.20
+      binds:
+        - dhcp1/dnsmasq.sh:/dnsmasq.sh
+      cmd: /dnsmasq.sh
+
     leafkind1-sw:
       kind: bridge
 
@@ -99,6 +106,7 @@ topology:
     - endpoints: ["leafB:ethblue", "hostB_blue:eth1"]
     - endpoints: ["leafSRV6:ethred", "hostSRV6_red:eth1"]
     - endpoints: ["leafSRV6:ethblue", "hostSRV6_blue:eth1"]
+    - endpoints: ["dhcp1:eth1", "leafkind1-sw:dhcp1"]
     - endpoints: ["leafkind1:toswitch1", "leafkind1-sw:leaf1"]
     - endpoints: ["leafkind2:toswitch2", "leafkind2-sw:leaf2"]
     # Point to point links for IPv6 unnumbered BGP sessions.

--- a/cmd/hostcontroller/main.go
+++ b/cmd/hostcontroller/main.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
@@ -52,6 +53,7 @@ import (
 	"github.com/openperouter/openperouter/internal/cniinvoker"
 	"github.com/openperouter/openperouter/internal/controller/nodeindex"
 	"github.com/openperouter/openperouter/internal/controller/routerconfiguration"
+	"github.com/openperouter/openperouter/internal/dhcp"
 	"github.com/openperouter/openperouter/internal/filewatcher"
 	"github.com/openperouter/openperouter/internal/hostnetwork"
 	"github.com/openperouter/openperouter/internal/logging"
@@ -62,10 +64,11 @@ import (
 )
 
 const (
-	datapathKernel = "kernel"
-	datapathGrout  = "grout"
-	modeK8s        = "k8s"
-	modeHost       = "host"
+	datapathKernel   = "kernel"
+	datapathGrout    = "grout"
+	modeK8s          = "k8s"
+	modeHost         = "host"
+	restartDHCPEvent = "dhcp-restart-trigger"
 )
 
 var (
@@ -230,13 +233,14 @@ func runK8sMode(
 		os.Exit(1)
 	}
 
-	cniinvoker.Init(args.cniPluginDirs.values, args.cniCacheDir, args.nodeName)
+	dhcpSupervisor := dhcp.NewLazySupervisor(logger)
+	cniinvoker.Init(args.cniPluginDirs.values, args.cniCacheDir, args.nodeName, dhcpSupervisor)
 	setupLog.Info("CNI plugin invoker initialized for k8s mode",
 		"pluginDirs", args.cniPluginDirs.values,
 		"cacheDir", args.cniCacheDir)
 
 	// runK8sConfigReconciler is blocking so when running in k8s mode we should stop here
-	if err := runK8sConfigReconciler(ctx, args, k8sConfig, logger, args.probeAddr); err != nil {
+	if err := runK8sConfigReconciler(ctx, args, k8sConfig, logger, args.probeAddr, dhcpSupervisor); err != nil {
 		logger.Error("failed to enable k8s reconciler", "error", err)
 		os.Exit(1)
 	}
@@ -259,7 +263,8 @@ func runHostMode(
 		os.Exit(1)
 	}
 
-	cniinvoker.Init(args.cniPluginDirs.values, args.cniCacheDir, args.nodeName)
+	dhcpSupervisor := dhcp.NewLazySupervisor(logger)
+	cniinvoker.Init(args.cniPluginDirs.values, args.cniCacheDir, args.nodeName, dhcpSupervisor)
 	setupLog.Info("CNI plugin invoker initialized for host mode",
 		"pluginDirs", args.cniPluginDirs.values,
 		"cacheDir", args.cniCacheDir)
@@ -272,7 +277,7 @@ func runHostMode(
 		defer close(staticDone)
 		logger.Info("creating static configuration controller for host mode")
 		err := runStaticConfigReconciler(
-			staticControllerCtx, args, hostModeParams, nodeConfig, logger, args.probeAddr,
+			staticControllerCtx, args, hostModeParams, nodeConfig, logger, args.probeAddr, dhcpSupervisor,
 		)
 		if errors.Is(err, context.Canceled) {
 			logger.Info("static config reconciler stopped (API became available)")
@@ -314,7 +319,7 @@ func runHostMode(
 
 	// Start API reconciler in main thread (blocking) - keeps process alive
 	if err := runK8sConfigReconcilerHostMode(
-		ctx, args, hostModeParams, nodeConfig, k8sConfig, logger,
+		ctx, args, hostModeParams, nodeConfig, k8sConfig, logger, dhcpSupervisor,
 	); err != nil {
 		logger.Error("failed to enable k8s reconciler", "error", err)
 		os.Exit(1)
@@ -326,7 +331,8 @@ func runK8sConfigReconcilerHostMode(ctx context.Context,
 	hostModeParams hostModeParameters,
 	nodeConfig *static.NodeConfig,
 	k8sConfig *rest.Config,
-	logger *slog.Logger) error {
+	logger *slog.Logger,
+	dhcpSupervisor *dhcp.Supervisor) error {
 
 	mgr, err := createK8sManager(k8sConfig, args.nodeName, args.namespace, func(opts *ctrl.Options) {
 		opts.HealthProbeBindAddress = args.probeAddr
@@ -351,6 +357,16 @@ func runK8sConfigReconcilerHostMode(ctx context.Context,
 	if args.datapath == datapathGrout {
 		datapathConfigurator = routerconfiguration.NewGroutConfigurator(args.groutSocketPath)
 	}
+
+	dhcpSupervisor.OnRestart = triggerKubernetesReconcile(triggerChan, types.NamespacedName{
+		Namespace: restartDHCPEvent,
+		Name:      args.namespace,
+	})
+
+	if err := mgr.Add(dhcpSupervisor); err != nil {
+		return fmt.Errorf("unable to add DHCP supervisor: %w", err)
+	}
+
 	apiReconciler := &routerconfiguration.PERouterReconciler{
 		Client:               mgr.GetClient(),
 		Scheme:               mgr.GetScheme(),
@@ -427,7 +443,8 @@ func runK8sConfigReconciler(ctx context.Context,
 	args parameters,
 	k8sConfig *rest.Config,
 	logger *slog.Logger,
-	probeAddr string) error {
+	probeAddr string,
+	dhcpSupervisor *dhcp.Supervisor) error {
 
 	mgr, err := createK8sManager(k8sConfig, args.nodeName, args.namespace, func(opts *ctrl.Options) {
 		opts.HealthProbeBindAddress = probeAddr
@@ -448,6 +465,16 @@ func runK8sConfigReconciler(ctx context.Context,
 		datapathConfigurator = routerconfiguration.NewGroutConfigurator(args.groutSocketPath)
 	}
 
+	triggerChan := make(chan event.GenericEvent, 1)
+	dhcpSupervisor.OnRestart = triggerKubernetesReconcile(triggerChan, types.NamespacedName{
+		Namespace: args.namespace,
+		Name:      restartDHCPEvent,
+	})
+
+	if err := mgr.Add(dhcpSupervisor); err != nil {
+		return fmt.Errorf("unable to add DHCP supervisor: %w", err)
+	}
+
 	apiReconciler := &routerconfiguration.PERouterReconciler{
 		Client:               mgr.GetClient(),
 		Scheme:               mgr.GetScheme(),
@@ -459,6 +486,7 @@ func runK8sConfigReconciler(ctx context.Context,
 		RouterProvider:       routerProvider,
 		MyNamespace:          args.namespace,
 		DatapathConfigurator: datapathConfigurator,
+		TriggerChan:          triggerChan,
 	}
 
 	if err := apiReconciler.SetupWithManager(mgr); err != nil {
@@ -477,7 +505,8 @@ func runStaticConfigReconciler(ctx context.Context,
 	hostModeParams hostModeParameters,
 	nodeConfig *static.NodeConfig,
 	logger *slog.Logger,
-	probeAddr string) error {
+	probeAddr string,
+	dhcpSupervisor *dhcp.Supervisor) error {
 	mgr, err := ctrl.NewManager(&rest.Config{}, ctrl.Options{
 		Scheme:                 scheme,
 		HealthProbeBindAddress: probeAddr,
@@ -518,6 +547,15 @@ func runStaticConfigReconciler(ctx context.Context,
 	}
 	if err = staticReconciler.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller: %w", err)
+	}
+
+	dhcpSupervisor.OnRestart = func() {
+		slog.Info("triggered reconciliation after DHCP daemon restart")
+		staticReconciler.TriggerReconcile()
+	}
+
+	if err := mgr.Add(dhcpSupervisor); err != nil {
+		return fmt.Errorf("unable to add DHCP supervisor: %w", err)
 	}
 
 	if err := staticRouterProvider.StartFRRRestartWatcher(ctx, func() {
@@ -700,6 +738,27 @@ func fanOut(ctx context.Context, in <-chan event.GenericEvent, outs ...chan<- ev
 			for _, out := range outs {
 				out <- evt
 			}
+		}
+	}
+}
+
+func triggerKubernetesReconcile(
+	triggerChan chan event.GenericEvent,
+	name types.NamespacedName,
+) func() {
+	return func() {
+		select {
+		case triggerChan <- event.GenericEvent{
+			Object: &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name.Name,
+					Namespace: name.Namespace,
+				},
+			},
+		}:
+			slog.Info("triggered reconciliation after DHCP daemon restart")
+		default:
+			slog.Debug("reconciliation already queued, skipping DHCP restart trigger")
 		}
 	}
 }

--- a/config/grout/controller_patch.yaml
+++ b/config/grout/controller_patch.yaml
@@ -14,6 +14,8 @@ spec:
           - "--namespace=$(NAMESPACE)"
           - "--frrconfig=/etc/frr/frr.conf"
           - "--reloader-socket=/etc/frr/reload.sock"
+          - "--cni-plugin-dirs=/opt/openperouter/cni/bin/"
+          - "--cni-cache-dir=/var/lib/openperouter/cni/cache"
           - "--datapath=grout"
           - "--grout-socket=/var/run/grout/grout.sock"
           volumeMounts:

--- a/config/samples/underlay-cni-dhcp.yaml
+++ b/config/samples/underlay-cni-dhcp.yaml
@@ -1,0 +1,34 @@
+apiVersion: network.openperouter.io/v1alpha1
+kind: Underlay
+metadata:
+  name: underlay
+  namespace: openperouter-system
+spec:
+  asn: 64514
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/hostname: node-1
+  tunnelEndpoint:
+    cidrs:
+    - 100.65.0.0/24
+  interfaces:
+    - type: CNIDevice
+      cniDevice:
+        type: RawConfig
+        interfaceName: net1
+        rawConfig:
+          cniVersion: "1.0.0"
+          name: macvlan-underlay
+          plugins:
+            - type: macvlan
+              master: eth0
+              mode: bridge
+              capabilities:
+                mac: true
+              ipam:
+                type: dhcp
+        runtimeConfig:
+          mac: "aa:bb:cc:00:00:01"
+  neighbors:
+    - asn: 64512
+      address: 192.168.11.2

--- a/config/samples/underlay-cni-static.yaml
+++ b/config/samples/underlay-cni-static.yaml
@@ -1,0 +1,32 @@
+apiVersion: network.openperouter.io/v1alpha1
+kind: Underlay
+metadata:
+  name: underlay
+  namespace: openperouter-system
+spec:
+  asn: 64514
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/hostname: node-1
+  tunnelEndpoint:
+    cidrs:
+    - 100.65.0.0/24
+  interfaces:
+    - type: CNIDevice
+      cniDevice:
+        type: RawConfig
+        interfaceName: net1
+        rawConfig:
+          cniVersion: "1.0.0"
+          name: macvlan-underlay
+          plugins:
+            - type: macvlan
+              master: eth0
+              mode: bridge
+              ipam:
+                type: static
+                addresses:
+                  - address: 192.168.11.10/24
+  neighbors:
+    - asn: 64512
+      address: 192.168.11.2

--- a/e2etests/pkg/infra/underlay_cni.go
+++ b/e2etests/pkg/infra/underlay_cni.go
@@ -25,6 +25,10 @@ const (
 
 	// CNIUnderlayASN is the local AS number of the CNI provisioned underlays.
 	CNIUnderlayASN = 64514
+
+	// groutUnderlayPortPrefix is the prefix grout adds when it creates a
+	// kernel port for an underlay interface and migrates the addresses to it.
+	groutUnderlayPortPrefix = "u_"
 )
 
 // CNIUnderlayNeighborIP returns the static IP assigned to the CNI-provisioned
@@ -181,7 +185,7 @@ func dhcpCNIUnderlayForNode(nodeIndex int, node corev1.Node, ifName string) v1al
 func ConfigureLeafKind1ForDHCPUnderlay(nodes []corev1.Node, ifName string) error {
 	neighbors := make([]Neighbor, 0, len(nodes))
 	for _, node := range nodes {
-		ip, err := openperouter.InterfaceIPv4InNetns(node.Name, ifName, openperouter.NamedNetns)
+		ip, err := DHCPNeighborIP(node.Name, ifName)
 		if err != nil {
 			return fmt.Errorf("discovering DHCP address on %s: %w", node.Name, err)
 		}
@@ -191,9 +195,15 @@ func ConfigureLeafKind1ForDHCPUnderlay(nodes []corev1.Node, ifName string) error
 }
 
 // DHCPNeighborIP discovers the IPv4 address assigned by DHCP on the CNI
-// interface inside the perouter netns of nodeName.
+// interface inside the perouter netns of nodeName. It checks both the plain
+// interface and the grout port (u_<ifName>), since the grout datapath migrates
+// addresses from the kernel interface to the grout port.
 func DHCPNeighborIP(nodeName, ifName string) (string, error) {
-	return openperouter.InterfaceIPv4InNetns(nodeName, ifName, openperouter.NamedNetns)
+	ip, err := openperouter.InterfaceIPv4InNetns(nodeName, ifName, openperouter.NamedNetns)
+	if err == nil {
+		return ip, nil
+	}
+	return openperouter.InterfaceIPv4InNetns(nodeName, groutUnderlayPortPrefix+ifName, openperouter.NamedNetns)
 }
 
 const dhcpServerContainer = ClabPrefix + "dhcp1"

--- a/e2etests/pkg/infra/underlay_cni.go
+++ b/e2etests/pkg/infra/underlay_cni.go
@@ -3,13 +3,18 @@
 package infra
 
 import (
+	"errors"
 	"fmt"
+	"strconv"
+	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openperouter/openperouter/api/v1alpha1"
+	"github.com/openperouter/openperouter/e2etests/pkg/executor"
 	"github.com/openperouter/openperouter/e2etests/pkg/openperouter"
 )
 
@@ -107,4 +112,124 @@ func ConfigureLeafKind1ForCNIUnderlay(nodes []corev1.Node) error {
 		neighbors = append(neighbors, Neighbor{ID: CNIUnderlayNeighborIP(i)})
 	}
 	return LeafKind1Config.Configure(LeafKindConfiguration{Neighbors: neighbors})
+}
+
+// DHCPCNIUnderlaysForNodes builds one node-scoped Underlay per node, whose
+// interface is provisioned by the macvlan CNI plugin on top of toswitch1
+// with DHCP IPAM. Addresses are acquired from the DHCP server (dhcp1) on
+// the leafkind1-sw bridge segment.
+func DHCPCNIUnderlaysForNodes(nodes []corev1.Node, ifName string) []v1alpha1.Underlay {
+	underlays := make([]v1alpha1.Underlay, 0, len(nodes))
+	for i, node := range nodes {
+		underlays = append(underlays, dhcpCNIUnderlayForNode(i, node, ifName))
+	}
+	return underlays
+}
+
+func dhcpCNIUnderlayForNode(nodeIndex int, node corev1.Node, ifName string) v1alpha1.Underlay {
+	rawConfig := `{
+  "cniVersion": "1.0.0",
+  "name": "macvlan-underlay",
+  "plugins": [
+    {
+      "type": "macvlan",
+      "master": "toswitch1",
+      "mode": "bridge",
+      "ipam": {
+        "type": "dhcp"
+      }
+    }
+  ]
+}`
+	return v1alpha1.Underlay{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("underlay-dhcp-%d", nodeIndex),
+			Namespace: openperouter.Namespace,
+		},
+		Spec: v1alpha1.UnderlaySpec{
+			ASN: CNIUnderlayASN,
+			NodeSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"kubernetes.io/hostname": node.Name},
+			},
+			Interfaces: []v1alpha1.UnderlayInterface{
+				{
+					Type: v1alpha1.UnderlayInterfaceTypeCNIDevice,
+					CNIDevice: &v1alpha1.CNIDevice{
+						Type:          v1alpha1.CNIConfigTypeRawConfig,
+						RawConfig:     &apiextensionsv1.JSON{Raw: []byte(rawConfig)},
+						InterfaceName: new(ifName),
+					},
+				},
+			},
+			Neighbors: []v1alpha1.Neighbor{
+				{
+					ASN:     new(int64(64512)),
+					Address: new("192.168.11.2"),
+				},
+			},
+			TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+				CIDRs: []string{"100.65.0.0/24"},
+			},
+		},
+	}
+}
+
+// ConfigureLeafKind1ForDHCPUnderlay discovers the DHCP-assigned addresses on
+// each node's CNI interface in the perouter netns and configures leafkind1 to
+// peer with them. Call this after the underlay is provisioned and the
+// interfaces have acquired their leases.
+func ConfigureLeafKind1ForDHCPUnderlay(nodes []corev1.Node, ifName string) error {
+	neighbors := make([]Neighbor, 0, len(nodes))
+	for _, node := range nodes {
+		ip, err := openperouter.InterfaceIPv4InNetns(node.Name, ifName, openperouter.NamedNetns)
+		if err != nil {
+			return fmt.Errorf("discovering DHCP address on %s: %w", node.Name, err)
+		}
+		neighbors = append(neighbors, Neighbor{ID: ip})
+	}
+	return LeafKind1Config.Configure(LeafKindConfiguration{Neighbors: neighbors})
+}
+
+// DHCPNeighborIP discovers the IPv4 address assigned by DHCP on the CNI
+// interface inside the perouter netns of nodeName.
+func DHCPNeighborIP(nodeName, ifName string) (string, error) {
+	return openperouter.InterfaceIPv4InNetns(nodeName, ifName, openperouter.NamedNetns)
+}
+
+const dhcpServerContainer = ClabPrefix + "dhcp1"
+
+var (
+	ErrLeaseNotFound = errors.New("no lease found")
+	ErrLeaseExpired  = errors.New("lease expired")
+)
+
+// DHCPServerLeaseValid checks the dnsmasq server's leases file for the
+// given IP address. It returns nil when a valid (non-expired) lease exists,
+// ErrLeaseNotFound when no lease entry is present, and ErrLeaseExpired
+// when the lease exists but its expiry is in the past.
+func DHCPServerLeaseValid(ip string) error {
+	exec := executor.ForContainer(dhcpServerContainer)
+	out, err := exec.Exec("cat", "/var/lib/misc/dnsmasq.leases")
+	if err != nil {
+		return fmt.Errorf("reading dnsmasq leases: %w", err)
+	}
+	now := time.Now().Unix()
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		if fields[2] != ip {
+			continue
+		}
+		expiry, err := strconv.ParseInt(fields[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("parsing lease expiry %q: %w", fields[0], err)
+		}
+		if expiry <= now {
+			return ErrLeaseExpired
+		}
+		return nil
+	}
+	return ErrLeaseNotFound
 }

--- a/e2etests/pkg/openperouter/interface.go
+++ b/e2etests/pkg/openperouter/interface.go
@@ -3,6 +3,7 @@
 package openperouter
 
 import (
+	"fmt"
 	"regexp"
 	"sort"
 	"strings"
@@ -50,6 +51,31 @@ func InterfaceIPAddresses(nodeName, intf string) (string, error) {
 	}
 	sort.Strings(addrs)
 	return strings.Join(addrs, "\n"), nil
+}
+
+// InterfaceIPv4InNetns returns the first global-scope IPv4 address (without
+// prefix length) assigned to intf inside the named netns on nodeName, or an
+// error if none is found.
+func InterfaceIPv4InNetns(nodeName, intf, ns string) (string, error) {
+	exec := executor.ForContainer(nodeName)
+	out, err := exec.Exec("ip", "netns", "exec", ns, "ip", "-4", "-o", "a", "ls", "dev", intf, "scope", "global")
+	if err != nil {
+		return "", err
+	}
+	for line := range strings.SplitSeq(out, "\n") {
+		m := addrRegexp.FindStringSubmatch(line)
+		if len(m) < 2 {
+			continue
+		}
+		// m[1] is e.g. "inet 192.168.11.100/24"; extract the bare IP.
+		fields := strings.Fields(m[1])
+		if len(fields) < 2 {
+			continue
+		}
+		ip, _, _ := strings.Cut(fields[1], "/")
+		return ip, nil
+	}
+	return "", fmt.Errorf("no global IPv4 address on %s/%s in netns %s", nodeName, intf, ns)
 }
 
 // InterfaceIsUp checks whether the interface in the default netns

--- a/e2etests/tests/cni_lifecycle.go
+++ b/e2etests/tests/cni_lifecycle.go
@@ -259,8 +259,12 @@ var _ = Describe("DHCP underlay lifecycle", Ordered, func() {
 	validateDHCPSessionUp := func() {
 		leafExec := executor.ForContainer(infra.KindLeaf)
 		for _, node := range nodes {
-			ip, err := infra.DHCPNeighborIP(node.Name, infra.CNIUnderlayInterface)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			var ip string
+			Eventually(func(g Gomega) {
+				var err error
+				ip, err = infra.DHCPNeighborIP(node.Name, infra.CNIUnderlayInterface)
+				g.Expect(err).NotTo(HaveOccurred())
+			}, 3*time.Minute, time.Second).Should(Succeed())
 			validateSessionWithNeighbor(leafExec, validationParameters{
 				fromName:    infra.KindLeaf,
 				toName:      node.Name,

--- a/e2etests/tests/cni_lifecycle.go
+++ b/e2etests/tests/cni_lifecycle.go
@@ -248,6 +248,162 @@ var _ = Describe("CNI underlay lifecycle", Ordered, func() {
 	})
 })
 
+// The DHCP underlay lifecycle coverage exercises the DHCP-specific behaviors:
+// DHCP lease acquisition, controller restart with lease re-acquisition, and
+// teardown with DHCP release. The CNI lifecycle behaviors (cache, reprovisioning)
+// are already covered by the macvlan-static suite above.
+var _ = Describe("DHCP underlay lifecycle", Ordered, func() {
+	var cs clientset.Interface
+	nodes := []corev1.Node{}
+
+	validateDHCPSessionUp := func() {
+		leafExec := executor.ForContainer(infra.KindLeaf)
+		for _, node := range nodes {
+			ip, err := infra.DHCPNeighborIP(node.Name, infra.CNIUnderlayInterface)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			validateSessionWithNeighbor(leafExec, validationParameters{
+				fromName:    infra.KindLeaf,
+				toName:      node.Name,
+				neighborIP:  ip,
+				established: true,
+			})
+		}
+	}
+
+	dhcpAddresses := func() (map[string]string, error) {
+		res := map[string]string{}
+		for _, node := range nodes {
+			ip, err := infra.DHCPNeighborIP(node.Name, infra.CNIUnderlayInterface)
+			if err != nil {
+				return nil, err
+			}
+			res[node.Name] = ip
+		}
+		return res, nil
+	}
+
+	// restartControllers restarts the controller on every node.
+	restartControllers := func() {
+		if HostMode {
+			for _, node := range nodes {
+				restartSystemdUnit(node, controllerPodUnit)
+			}
+			return
+		}
+		oldPods, err := k8s.DeletePodsByLabel(cs, openperouter.Namespace, controllerLabelSelector)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(k8s.WaitPodsRolled(cs, openperouter.Namespace, controllerLabelSelector, oldPods)).To(Succeed())
+	}
+
+	BeforeAll(func() {
+		cs = k8sclient.New()
+		_, err := openperouter.Get(cs, HostMode)
+		Expect(err).NotTo(HaveOccurred())
+		nodesItems, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		nodes = nodesItems.Items
+		sort.Slice(nodes, func(i, j int) bool { return nodes[i].Name < nodes[j].Name })
+	})
+
+	BeforeEach(func() {
+		err := Updater.CleanAll()
+		Expect(err).NotTo(HaveOccurred())
+
+		err = Updater.Update(config.Resources{Underlays: infra.DHCPCNIUnderlaysForNodes(nodes, infra.CNIUnderlayInterface)})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("waiting for DHCP addresses to be acquired")
+		Eventually(func() error {
+			_, err := dhcpAddresses()
+			return err
+		}, 3*time.Minute, time.Second).Should(Succeed())
+
+		By("configuring leafkind1 with the DHCP-assigned addresses")
+		Expect(infra.ConfigureLeafKind1ForDHCPUnderlay(nodes, infra.CNIUnderlayInterface)).To(Succeed())
+
+		By("waiting for the sessions to be established")
+		validateDHCPSessionUp()
+	})
+
+	AfterEach(func() {
+		dumpIfFails(cs)
+
+		err := Updater.CleanAll()
+		Expect(err).NotTo(HaveOccurred())
+		By("waiting for the underlay to be removed from all nodes")
+		for _, node := range nodes {
+			Eventually(func(g Gomega) {
+				isConfigured, err := openperouter.UnderlayConfigured(node.Name)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(isConfigured).To(BeFalse())
+			}, 2*time.Minute, time.Second).Should(Succeed())
+		}
+		By("restoring the standard leaf configuration")
+		Expect(infra.LeafKind1Config.UpdateConfig(nodes, infra.LeafKindConfiguration{})).To(Succeed())
+	})
+
+	It("re-acquires DHCP leases after controller restart", func() {
+		addrsBefore, err := dhcpAddresses()
+		Expect(err).NotTo(HaveOccurred())
+
+		By("restarting the controllers")
+		restartControllers()
+
+		By("checking the DHCP addresses are retained after lease re-acquisition")
+		Eventually(func() (map[string]string, error) {
+			return dhcpAddresses()
+		}, 3*time.Minute, time.Second).Should(Equal(addrsBefore),
+			"DHCP addresses should be the same after controller restart")
+
+		By("checking the DHCP leases remain valid after daemon restart and CNI CHECK")
+		Consistently(func() error {
+			for _, ip := range addrsBefore {
+				if err := infra.DHCPServerLeaseValid(ip); err != nil {
+					return fmt.Errorf("dnsmasq should have a valid lease for %s: %w", ip, err)
+				}
+			}
+			return nil
+		}).
+			WithTimeout(30*time.Second).
+			WithPolling(5*time.Second).
+			Should(Succeed(),
+				"CNI CHECK after DHCP daemon restart should keep leases renewed")
+
+		By("checking the sessions re-establish")
+		validateDHCPSessionUp()
+	})
+
+	It("removes the DHCP interfaces when the underlay is deleted", func() {
+		By("storing the original router IPs")
+		addrsBefore, err := dhcpAddresses()
+		Expect(err).NotTo(HaveOccurred())
+
+		By("removing the underlay")
+		Expect(Updater.CleanAll()).To(Succeed())
+
+		for nodeName, nodeIP := range addrsBefore {
+			By(fmt.Sprintf("checking interface %q is gone from node %q", infra.CNIUnderlayInterface, nodeName))
+			Eventually(func() bool {
+				return openperouter.IsInterfaceInNS(nodeName, infra.CNIUnderlayInterface, openperouter.NamedNetns)
+			}).
+				WithTimeout(time.Minute).
+				WithPolling(5*time.Second).
+				Should(BeFalse(),
+					fmt.Sprintf("interface %s should be gone from the router netns of %s",
+						infra.CNIUnderlayInterface, nodeName))
+
+			// https://github.com/containernetworking/plugins/issues/1278
+			// DHCPRELEASE is sent with 0.0.0.0 source IP; dnsmasq ignores it
+			// and the lease remains valid until it expires.
+			// Once the upstream fix lands, change this to:
+			//   Expect(infra.DHCPServerLeaseValid(nodeIP)).To(MatchError(infra.ErrLeaseNotFound))
+			By(fmt.Sprintf("checking lease for IP %q on node %q is still valid (upstream bug #1278)", nodeIP, nodeName))
+			Expect(infra.DHCPServerLeaseValid(nodeIP)).To(Succeed(),
+				"lease should still be valid — upstream bug containernetworking/plugins#1278")
+		}
+	})
+})
+
 // cniInterfaceIndexes returns the ifindex of the CNI provisioned interface in
 // the router netns of every node. A changed index after an event means the
 // interface was recreated.

--- a/e2etests/tests/evpn_routes.go
+++ b/e2etests/tests/evpn_routes.go
@@ -88,6 +88,21 @@ var (
 			return infra.NeighborIP(infra.KindLeaf, node.Name)
 		},
 	}
+
+	// macvlanDHCPUnderlay is the underlay flavor that provisions per-node
+	// macvlan interfaces on top of toswitch1 through the CNI mode, with DHCP
+	// address acquisition from the dhcp1 dnsmasq server.
+	macvlanDHCPUnderlay = evpnUnderlayParams{
+		Underlays: func(nodes []corev1.Node) []v1alpha1.Underlay {
+			return infra.DHCPCNIUnderlaysForNodes(nodes, infra.CNIUnderlayInterface)
+		},
+		ConfigureLeafKind: func(nodes []corev1.Node) error {
+			return infra.ConfigureLeafKind1ForDHCPUnderlay(nodes, infra.CNIUnderlayInterface)
+		},
+		NeighborIP: func(_ int, node corev1.Node) (string, error) {
+			return infra.DHCPNeighborIP(node.Name, infra.CNIUnderlayInterface)
+		},
+	}
 )
 
 // The EVPN routes ipv4 coverage runs once per underlay mode: the specs
@@ -99,6 +114,7 @@ var _ = DescribeTableSubtree("Routes between bgp and the fabric with Underlay in
 	evpnRoutesOverUnderlay,
 	Entry("NetworkDevice", Ordered, networkDeviceUnderlay),
 	Entry("MacvlanStatic", Ordered, macvlanStaticUnderlay),
+	Entry("MacvlanDHCP", Ordered, macvlanDHCPUnderlay),
 )
 
 func evpnRoutesOverUnderlay(params evpnUnderlayParams) {
@@ -164,13 +180,15 @@ func evpnRoutesOverUnderlay(params evpnUnderlayParams) {
 		nodes = nodesItems.Items
 		sort.Slice(nodes, func(i, j int) bool { return nodes[i].Name < nodes[j].Name })
 
-		By("configuring the kind leaves for the underlay mode")
-		Expect(params.ConfigureLeafKind(nodes)).To(Succeed())
-
 		err = Updater.Update(config.Resources{
 			Underlays: params.Underlays(nodes),
 		})
 		Expect(err).NotTo(HaveOccurred())
+
+		By("configuring the kind leaves for the underlay flavor")
+		Eventually(func() error {
+			return params.ConfigureLeafKind(nodes)
+		}, 3*time.Minute, time.Second).Should(Succeed())
 	})
 
 	AfterAll(func() {

--- a/examples/evpn/cni-underlay/openpe-dhcp.yaml
+++ b/examples/evpn/cni-underlay/openpe-dhcp.yaml
@@ -1,0 +1,108 @@
+apiVersion: network.openperouter.io/v1alpha1
+kind: L3VNI
+metadata:
+  name: red
+  namespace: openperouter-system
+spec:
+  vrf: red
+  hostSession:
+    asn: 64514
+    hostASN: 64515
+    localCIDR:
+      ipv4: 192.169.10.0/24
+  vni: 100
+---
+apiVersion: network.openperouter.io/v1alpha1
+kind: L2VNI
+metadata:
+  name: layer2
+  namespace: openperouter-system
+spec:
+  vni: 110
+  routingDomain:
+    type: L3VNI
+    l3vni:
+      name: red
+  hostMaster:
+    type: LinuxBridge
+    linuxBridge:
+      lifecycle: Managed
+  gatewayIPs: ["192.170.1.1/24"]
+---
+# The underlay interface is provisioned by the macvlan CNI plugin on top of
+# toswitch1, which stays in the host netns. DHCP is used instead of static
+# addressing — the controller starts the DHCP daemon automatically when the
+# CNI config uses DHCP IPAM.
+#
+# A pinned MAC via runtimeConfig ensures the DHCP server assigns a stable
+# IP across netns rebuilds (requires the macvlan plugin to declare the
+# "mac" capability). Each node gets its own Underlay with a unique MAC.
+apiVersion: network.openperouter.io/v1alpha1
+kind: Underlay
+metadata:
+  name: underlay-control-plane
+  namespace: openperouter-system
+spec:
+  asn: 64514
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/hostname: pe-kind-control-plane
+  tunnelEndpoint:
+    cidrs:
+    - 100.65.0.0/24
+  interfaces:
+    - type: CNIDevice
+      cniDevice:
+        type: RawConfig
+        interfaceName: net1
+        rawConfig:
+          cniVersion: "1.0.0"
+          name: macvlan-underlay
+          plugins:
+            - type: macvlan
+              master: toswitch1
+              mode: bridge
+              capabilities:
+                mac: true
+              ipam:
+                type: dhcp
+        runtimeConfig:
+          mac: "aa:bb:cc:00:00:01"
+  neighbors:
+    - asn: 64512
+      address: 192.168.11.2
+---
+apiVersion: network.openperouter.io/v1alpha1
+kind: Underlay
+metadata:
+  name: underlay-worker
+  namespace: openperouter-system
+spec:
+  asn: 64514
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/hostname: pe-kind-worker
+  tunnelEndpoint:
+    cidrs:
+    - 100.65.0.0/24
+  interfaces:
+    - type: CNIDevice
+      cniDevice:
+        type: RawConfig
+        interfaceName: net1
+        rawConfig:
+          cniVersion: "1.0.0"
+          name: macvlan-underlay
+          plugins:
+            - type: macvlan
+              master: toswitch1
+              mode: bridge
+              capabilities:
+                mac: true
+              ipam:
+                type: dhcp
+        runtimeConfig:
+          mac: "aa:bb:cc:00:00:02"
+  neighbors:
+    - asn: 64512
+      address: 192.168.11.2

--- a/internal/cniinvoker/cni.go
+++ b/internal/cniinvoker/cni.go
@@ -15,11 +15,18 @@
 package cniinvoker
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/containernetworking/cni/libcni"
 	"github.com/containernetworking/cni/pkg/version"
 )
+
+// DHCPEnabler starts and waits for the DHCP daemon when a CNI config uses DHCP
+// IPAM. Implementations must be safe for concurrent use.
+type DHCPEnabler interface {
+	EnsureUp(ctx context.Context) error
+}
 
 const (
 	// minSupportedCNIVersion is the minimum CNI spec version accepted for the

--- a/internal/cniinvoker/cni_test.go
+++ b/internal/cniinvoker/cni_test.go
@@ -311,6 +311,114 @@ const (
 	netNS = "/var/run/netns/perouter-test"
 )
 
+const fakeConfListDHCP = `{
+  "cniVersion": "1.0.0",
+  "name": "underlay-dhcp-test",
+  "plugins": [
+    {
+      "type": "fake",
+      "ipam": {"type": "dhcp"}
+    }
+  ]
+}`
+
+type spyDHCPEnabler struct {
+	called int
+	err    error
+}
+
+func (s *spyDHCPEnabler) EnsureUp(_ context.Context) error {
+	s.called++
+	return s.err
+}
+
+func TestAddCallsEnsureUpForDHCPConfig(t *testing.T) {
+	env := newFakePluginEnv(t)
+	spy := &spyDHCPEnabler{}
+
+	inv := env.invokerWithDHCP(spy)
+	params := env.params("net1", nil)
+	params.Config = []byte(fakeConfListDHCP)
+
+	if err := inv.Add(context.Background(), params); err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+	if spy.called != 1 {
+		t.Errorf("EnsureUp called %d times, want 1", spy.called)
+	}
+}
+
+func TestAddSkipsEnsureUpForNonDHCPConfig(t *testing.T) {
+	env := newFakePluginEnv(t)
+	spy := &spyDHCPEnabler{}
+
+	inv := env.invokerWithDHCP(spy)
+	if err := inv.Add(context.Background(), env.params("net1", nil)); err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+	if spy.called != 0 {
+		t.Errorf("EnsureUp called %d times for non-DHCP config, want 0", spy.called)
+	}
+}
+
+func TestAddFailsWhenEnsureUpFails(t *testing.T) {
+	env := newFakePluginEnv(t)
+	spy := &spyDHCPEnabler{err: fmt.Errorf("daemon not starting")}
+
+	inv := env.invokerWithDHCP(spy)
+	params := env.params("net1", nil)
+	params.Config = []byte(fakeConfListDHCP)
+
+	err := inv.Add(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error when EnsureUp fails")
+	}
+}
+
+func TestDelCallsEnsureUpForCachedDHCPConfig(t *testing.T) {
+	env := newFakePluginEnv(t)
+	spy := &spyDHCPEnabler{}
+
+	inv := env.invokerWithDHCP(spy)
+	params := env.params("net1", nil)
+	params.Config = []byte(fakeConfListDHCP)
+
+	if err := inv.Add(context.Background(), params); err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+	spy.called = 0
+
+	if err := inv.Del(context.Background(), "net1"); err != nil {
+		t.Fatalf("Del failed: %v", err)
+	}
+	if spy.called != 1 {
+		t.Errorf("EnsureUp called %d times on Del, want 1", spy.called)
+	}
+}
+
+func TestNilDHCPEnablerErrorsForDHCPConfig(t *testing.T) {
+	env := newFakePluginEnv(t)
+
+	inv := env.invoker()
+	params := env.params("net1", nil)
+	params.Config = []byte(fakeConfListDHCP)
+
+	if err := inv.Add(context.Background(), params); err == nil {
+		t.Fatal("Add should fail with nil dhcpEnabler and DHCP IPAM config")
+	}
+}
+
+func TestNilDHCPEnablerIsHarmlessForNonDHCPConfig(t *testing.T) {
+	env := newFakePluginEnv(t)
+
+	inv := env.invoker()
+	params := env.params("net1", nil)
+
+	if err := inv.Add(context.Background(), params); err != nil {
+		t.Fatalf("Add failed with nil dhcpEnabler and non-DHCP config: %v", err)
+	}
+}
+
 // fakePluginEnv provides a fake CNI plugin executable that records its
 // invocations (command + interface name) and the stdin it received, so tests
 // can assert on how libcni drove it without requiring real plugins or root.
@@ -380,6 +488,14 @@ func (e *fakePluginEnv) invoker() *invoker {
 	return &invoker{
 		cniConfig:   libcni.NewCNIConfigWithCacheDir([]string{e.binDir}, e.cacheDir, nil),
 		containerID: containerIDForNode(fakeNodeName),
+	}
+}
+
+func (e *fakePluginEnv) invokerWithDHCP(enabler DHCPEnabler) *invoker {
+	return &invoker{
+		cniConfig:   libcni.NewCNIConfigWithCacheDir([]string{e.binDir}, e.cacheDir, nil),
+		containerID: containerIDForNode(fakeNodeName),
+		dhcpEnabler: enabler,
 	}
 }
 

--- a/internal/cniinvoker/invoker.go
+++ b/internal/cniinvoker/invoker.go
@@ -13,6 +13,8 @@ import (
 	"github.com/containernetworking/cni/libcni"
 )
 
+const ipamTypeDHCP = "dhcp"
+
 // Invoker is the node-level CNI plugin invoker singleton, nil until Init is
 // called.
 var Invoker *invoker
@@ -22,15 +24,18 @@ var Invoker *invoker
 type invoker struct {
 	cniConfig   *libcni.CNIConfig
 	containerID string
+	dhcpEnabler DHCPEnabler
 }
 
 // Init sets the Invoker singleton. The cache directory must be stable across
 // controller restarts so Del keeps working for attachments created by
-// previous invocations.
-func Init(pluginDirs []string, cacheDir, nodeName string) {
+// previous invocations. If dhcpEnabler is nil, any CNI config that uses DHCP
+// IPAM will fail with an error.
+func Init(pluginDirs []string, cacheDir, nodeName string, dhcpEnabler DHCPEnabler) {
 	Invoker = &invoker{
 		cniConfig:   libcni.NewCNIConfigWithCacheDir(pluginDirs, cacheDir, nil),
 		containerID: containerIDForNode(nodeName),
+		dhcpEnabler: dhcpEnabler,
 	}
 }
 
@@ -78,6 +83,10 @@ func (inv *invoker) Add(ctx context.Context, p AddParams) error {
 	confList, err := libcni.NetworkConfFromBytes(p.Config)
 	if err != nil {
 		return err
+	}
+
+	if err := inv.ensureDHCPForConfList(ctx, confList); err != nil {
+		return fmt.Errorf("ensuring dhcp daemon for add %q: %w", p.IfName, err)
 	}
 
 	rt := &libcni.RuntimeConf{
@@ -132,6 +141,10 @@ func (inv *invoker) Check(ctx context.Context, ifName string) error {
 		return fmt.Errorf("failed to parse cached cni config for network %q: %w", attachment.Network, err)
 	}
 
+	if err := inv.ensureDHCPForConfList(ctx, confList); err != nil {
+		return fmt.Errorf("ensuring dhcp daemon for add %q: %w", ifName, err)
+	}
+
 	if err := inv.cniConfig.CheckNetworkList(ctx, confList, &libcni.RuntimeConf{
 		ContainerID:    attachment.ContainerID,
 		NetNS:          attachment.NetNS,
@@ -155,10 +168,16 @@ func (inv *invoker) Del(ctx context.Context, ifNameToDelete string) error {
 	if attachmentToDelete == nil {
 		return nil
 	}
+
 	confListToDelete, err := libcni.NetworkConfFromBytes(attachmentToDelete.Config)
 	if err != nil {
 		return fmt.Errorf("failed to parse cached cni config for network %q: %w", attachmentToDelete.Network, err)
 	}
+
+	if err := inv.ensureDHCPForConfList(ctx, confListToDelete); err != nil {
+		return fmt.Errorf("ensuring dhcp daemon for del %q: %w", ifNameToDelete, err)
+	}
+
 	if err := inv.cniConfig.DelNetworkList(ctx, confListToDelete, &libcni.RuntimeConf{
 		ContainerID:    attachmentToDelete.ContainerID,
 		NetNS:          attachmentToDelete.NetNS,
@@ -217,4 +236,17 @@ func capabilityArgsEqual(a, b map[string]any) bool {
 		return true
 	}
 	return reflect.DeepEqual(a, b)
+}
+
+func (inv *invoker) ensureDHCPForConfList(ctx context.Context, confList *libcni.NetworkConfigList) error {
+	for _, plugin := range confList.Plugins {
+		if plugin.Network == nil || plugin.Network.IPAM.Type != ipamTypeDHCP {
+			continue
+		}
+		if inv.dhcpEnabler == nil {
+			return fmt.Errorf("IPAM type is %q but DHCP support is not enabled", ipamTypeDHCP)
+		}
+		return inv.dhcpEnabler.EnsureUp(ctx)
+	}
+	return nil
 }

--- a/internal/dhcp/supervisor.go
+++ b/internal/dhcp/supervisor.go
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package dhcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	// DefaultSocketPath is the unix socket the dhcp daemon listens on and the
+	// dhcp plugin connects to. It matches the plugin's compiled-in default, so
+	// EnsureIPAM/ADD reach this daemon without extra config.
+	DefaultSocketPath = "/run/cni/dhcp.sock"
+
+	// DefaultBinPath is the well-known location of the dhcp daemon binary
+	// inside the controller container image.
+	DefaultBinPath = "/opt/openperouter/cni/bin/dhcp"
+
+	// IPAMTypeDHCP is the IPAM type string that triggers DHCP lease management.
+	IPAMTypeDHCP = "dhcp"
+
+	socketReadyTimeout = 10 * time.Second
+	socketPollInterval = 100 * time.Millisecond
+	restartBackoff     = 500 * time.Millisecond
+	shutdownGrace      = 5 * time.Second
+)
+
+// Supervisor runs and supervises the CNI dhcp IPAM daemon. It registers
+// with the controller-runtime manager immediately but blocks in Start until
+// EnsureUp is called — typically when the CNI invoker first processes an
+// ADD/DEL/CHECK for a config using DHCP IPAM. Once started, the daemon runs
+// for the lifetime of the manager; crashes are restarted automatically.
+// The supervisor opts out of leader election so the daemon runs on every node.
+type Supervisor struct {
+	// Logger receives the daemon's stdout/stderr and supervisor events.
+	Logger *slog.Logger
+	// SocketPath is the daemon's listening socket; defaults to DefaultSocketPath.
+	SocketPath string
+	// Broadcast sets the daemon's -broadcast flag (request broadcast replies),
+	// which clients without an address typically need.
+	Broadcast bool
+	// OnRestart is called when the daemon exits unexpectedly (not due to
+	// context cancellation). Callers typically use it to trigger
+	// reconciliation; the reconciler's EnsureUp call handles waiting for
+	// the restarted daemon's socket.
+	OnRestart func()
+
+	binPath string
+	startCh chan struct{}
+	once    sync.Once
+}
+
+// NewLazySupervisor creates a Supervisor. Register it with the manager via
+// mgr.Add(); it will block in Start until EnsureUp is called.
+func NewLazySupervisor(logger *slog.Logger) *Supervisor {
+	return &Supervisor{
+		Logger:  logger,
+		binPath: DefaultBinPath,
+		startCh: make(chan struct{}),
+	}
+}
+
+// NeedLeaderElection returns false so the daemon runs on every node regardless
+// of leader election.
+func (l *Supervisor) NeedLeaderElection() bool { return false }
+
+// Start blocks until EnsureUp is called, then runs the daemon and restarts it
+// on crash. Start only returns when ctx is cancelled (manager shutdown).
+func (l *Supervisor) Start(ctx context.Context) error {
+	logger := l.logger()
+	socketPath := l.socketPath()
+
+	select {
+	case <-l.startCh:
+	case <-ctx.Done():
+		return nil
+	}
+	logger.Info("DHCP supervisor started", "bin", l.binPath, "socket", socketPath)
+
+	return l.runDaemonWithRestart(ctx, logger, socketPath)
+}
+
+func (l *Supervisor) runDaemonWithRestart(ctx context.Context, logger *slog.Logger, socketPath string) error {
+	wait.UntilWithContext(
+		ctx,
+		func(ctx context.Context) {
+			err := l.runDaemon(ctx, logger, socketPath)
+			if ctx.Err() != nil {
+				return
+			}
+
+			logger.Error("dhcp daemon exited, restarting", "error", err, "backoff", restartBackoff)
+
+			if l.OnRestart != nil {
+				l.OnRestart()
+			}
+		},
+		restartBackoff,
+	)
+	logger.Info("DHCP daemon supervisor stopped", "error", ctx.Err())
+	return nil
+}
+
+// EnsureUp enables the supervisor and blocks until the DHCP daemon's socket is
+// accepting connections (or ctx is cancelled). It is safe for concurrent use;
+// when the daemon is already running the socket Dial succeeds immediately.
+func (l *Supervisor) EnsureUp(ctx context.Context) error {
+	// Signal Start() to proceed by closing startCh. sync.Once guarantees
+	// this happens exactly once even when multiple goroutines call EnsureUp
+	// concurrently — a second close would panic.
+	l.once.Do(func() { close(l.startCh) })
+	return l.waitForSocket(ctx)
+}
+
+func (l *Supervisor) waitForSocket(ctx context.Context) error {
+	socketPath := l.socketPath()
+	err := wait.PollUntilContextTimeout(ctx, socketPollInterval, socketReadyTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			dialer := net.Dialer{Timeout: socketPollInterval / 2}
+			conn, err := dialer.DialContext(ctx, "unix", socketPath)
+			if err != nil {
+				return false, nil
+			}
+			if err := conn.Close(); err != nil {
+				l.logger().Warn("failed to close socket", "error", err)
+			}
+			return true, nil
+		})
+	if err != nil {
+		return fmt.Errorf("dhcp daemon socket %s not ready after %s: %w", socketPath, socketReadyTimeout, err)
+	}
+	return nil
+}
+
+func (l *Supervisor) runDaemon(ctx context.Context, logger *slog.Logger, socketPath string) error {
+	if err := os.Remove(socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		logger.Warn("failed to remove stale dhcp socket", "socket", socketPath, "error", err)
+	}
+
+	args := []string{"daemon", "-socketpath", socketPath}
+	if l.Broadcast {
+		args = append(args, "-broadcast=true")
+	}
+	cmd := exec.CommandContext(ctx, l.binPath, args...)
+	cmd.Cancel = func() error { return cmd.Process.Signal(syscall.SIGTERM) }
+	cmd.WaitDelay = shutdownGrace
+	cmd.Stdout = logWriter{logger: logger, level: slog.LevelInfo}
+	cmd.Stderr = logWriter{logger: logger, level: slog.LevelWarn}
+
+	return cmd.Run()
+}
+
+func (l *Supervisor) logger() *slog.Logger {
+	if l.Logger != nil {
+		return l.Logger
+	}
+	return slog.Default()
+}
+
+func (l *Supervisor) socketPath() string {
+	if l.SocketPath != "" {
+		return l.SocketPath
+	}
+	return DefaultSocketPath
+}
+
+// logWriter forwards a subprocess's output to slog, one line per log record.
+type logWriter struct {
+	logger *slog.Logger
+	level  slog.Level
+}
+
+func (w logWriter) Write(p []byte) (int, error) {
+	for line := range strings.SplitSeq(strings.TrimRight(string(p), "\n"), "\n") {
+		if line != "" {
+			w.logger.Log(context.Background(), w.level, "DHCP daemon", "log", line)
+		}
+	}
+	return len(p), nil
+}

--- a/internal/dhcp/supervisor_test.go
+++ b/internal/dhcp/supervisor_test.go
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package dhcp
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func newStartedSupervisor(binPath, socketPath string, logger *slog.Logger) *Supervisor {
+	l := &Supervisor{
+		binPath:    binPath,
+		SocketPath: socketPath,
+		Logger:     logger,
+		startCh:    make(chan struct{}),
+	}
+	l.once.Do(func() { close(l.startCh) })
+	return l
+}
+
+func waitForSocket(t *testing.T, socketPath string, timeout time.Duration) {
+	t.Helper()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	tick := time.NewTicker(50 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		conn, err := net.Dial("unix", socketPath)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		select {
+		case <-timer.C:
+			t.Fatalf("socket %s not ready before timeout", socketPath)
+		case <-tick.C:
+		}
+	}
+}
+
+func TestSupervisorStartStop(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "dhcp.sock")
+
+	sup := newStartedSupervisor(
+		fakeDaemonPath(t), socketPath,
+		slog.New(slog.NewTextHandler(os.Stderr, nil)),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- sup.Start(ctx) }()
+
+	waitForSocket(t, socketPath, 10*time.Second)
+
+	if _, err := os.Stat(socketPath); err != nil {
+		t.Fatalf("socket file not created: %v", err)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start returned error: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for supervisor to stop")
+	}
+}
+
+func TestSupervisorRestartsOnExit(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "dhcp.sock")
+
+	sup := newStartedSupervisor(
+		fakeDaemonPath(t), socketPath,
+		slog.New(slog.NewTextHandler(os.Stderr, nil)),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- sup.Start(ctx) }()
+
+	waitForSocket(t, socketPath, 10*time.Second)
+
+	// Kill the fake daemon to trigger a restart.
+	killFakeDaemon(t, socketPath)
+
+	waitForSocket(t, socketPath, 15*time.Second)
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for supervisor to stop")
+	}
+}
+
+func TestSupervisorOnRestartCallback(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "dhcp.sock")
+
+	restarted := make(chan struct{}, 1)
+	sup := newStartedSupervisor(
+		fakeDaemonPath(t), socketPath,
+		slog.New(slog.NewTextHandler(os.Stderr, nil)),
+	)
+	sup.OnRestart = func() {
+		select {
+		case restarted <- struct{}{}:
+		default:
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- sup.Start(ctx) }()
+
+	waitForSocket(t, socketPath, 10*time.Second)
+
+	// Kill the fake daemon to trigger a restart.
+	killFakeDaemon(t, socketPath)
+
+	select {
+	case <-restarted:
+	case <-time.After(15 * time.Second):
+		t.Fatal("OnRestart callback was not called after daemon restart")
+	}
+
+	cancel()
+	<-done
+}
+
+func TestSupervisorOnRestartNotCalledOnFirstStart(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "dhcp.sock")
+
+	restarted := make(chan struct{}, 1)
+	sup := newStartedSupervisor(
+		fakeDaemonPath(t), socketPath,
+		slog.New(slog.NewTextHandler(os.Stderr, nil)),
+	)
+	sup.OnRestart = func() {
+		select {
+		case restarted <- struct{}{}:
+		default:
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- sup.Start(ctx) }()
+
+	waitForSocket(t, socketPath, 10*time.Second)
+
+	// Give enough time for a spurious callback to fire.
+	select {
+	case <-restarted:
+		t.Fatal("OnRestart callback was called on initial start")
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	cancel()
+	<-done
+}
+
+func TestSupervisorStaleSocketRemoved(t *testing.T) {
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "dhcp.sock")
+
+	if err := os.WriteFile(socketPath, []byte("stale"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	sup := newStartedSupervisor(
+		fakeDaemonPath(t), socketPath,
+		slog.New(slog.NewTextHandler(os.Stderr, nil)),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- sup.Start(ctx) }()
+
+	waitForSocket(t, socketPath, 10*time.Second)
+
+	cancel()
+	<-done
+}
+
+func TestSupervisorDefaultSocketPath(t *testing.T) {
+	sup := &Supervisor{startCh: make(chan struct{})}
+	if sup.socketPath() != DefaultSocketPath {
+		t.Errorf("default socket path = %q, want %q", sup.socketPath(), DefaultSocketPath)
+	}
+}
+
+func TestSupervisorCustomSocketPath(t *testing.T) {
+	sup := &Supervisor{SocketPath: "/custom/path.sock", startCh: make(chan struct{})}
+	if sup.socketPath() != "/custom/path.sock" {
+		t.Errorf("custom socket path = %q, want /custom/path.sock", sup.socketPath())
+	}
+}
+
+func TestSupervisorNeedLeaderElection(t *testing.T) {
+	sup := &Supervisor{startCh: make(chan struct{})}
+	if sup.NeedLeaderElection() {
+		t.Error("NeedLeaderElection() should return false")
+	}
+}
+
+func TestEnsureUpBlocksUntilReady(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "dhcp.sock")
+
+	sup := &Supervisor{
+		binPath:    fakeDaemonPath(t),
+		SocketPath: socketPath,
+		Logger:     slog.New(slog.NewTextHandler(os.Stderr, nil)),
+		startCh:    make(chan struct{}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- sup.Start(ctx) }()
+
+	if err := sup.EnsureUp(ctx); err != nil {
+		t.Fatalf("EnsureUp failed: %v", err)
+	}
+
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("socket not accepting connections after EnsureUp: %v", err)
+	}
+	_ = conn.Close()
+
+	cancel()
+	<-done
+}
+
+func TestEnsureUpReturnsImmediatelyWhenAlreadyRunning(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "dhcp.sock")
+
+	sup := newStartedSupervisor(
+		fakeDaemonPath(t), socketPath,
+		slog.New(slog.NewTextHandler(os.Stderr, nil)),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- sup.Start(ctx) }()
+
+	waitForSocket(t, socketPath, 10*time.Second)
+
+	start := time.Now()
+	if err := sup.EnsureUp(ctx); err != nil {
+		t.Fatalf("EnsureUp failed: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("EnsureUp took %v on an already-running daemon, expected immediate return", elapsed)
+	}
+
+	cancel()
+	<-done
+}
+
+func TestEnsureUpRespectsContextCancellation(t *testing.T) {
+	sup := &Supervisor{
+		binPath:    "/nonexistent/dhcp",
+		SocketPath: filepath.Join(t.TempDir(), "never.sock"),
+		Logger:     slog.New(slog.NewTextHandler(os.Stderr, nil)),
+		startCh:    make(chan struct{}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _ = sup.Start(ctx) }()
+
+	cancel()
+	err := sup.EnsureUp(ctx)
+	if err == nil {
+		t.Fatal("EnsureUp should have returned an error when context is cancelled")
+	}
+}
+
+func TestLogWriter(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	w := logWriter{logger: logger}
+
+	n, err := w.Write([]byte("line one\nline two\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 18 {
+		t.Errorf("Write returned %d, want 18", n)
+	}
+	out := buf.String()
+	if !bytes.Contains([]byte(out), []byte("line one")) {
+		t.Errorf("output missing 'line one': %s", out)
+	}
+	if !bytes.Contains([]byte(out), []byte("line two")) {
+		t.Errorf("output missing 'line two': %s", out)
+	}
+}

--- a/internal/dhcp/testhelpers_test.go
+++ b/internal/dhcp/testhelpers_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package dhcp
+
+import (
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// fakeDaemonPath compiles a tiny Go program that listens on a unix socket at
+// the path given by -socketpath and exits when the socket file is removed (used
+// by killFakeDaemon). The "daemon" sub-command prefix is consumed to match the
+// real dhcp binary invocation ("dhcp daemon -socketpath <path>").
+func fakeDaemonPath(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "fakedaemon.go")
+
+	program := `package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"time"
+)
+
+func main() {
+	socketPath := ""
+	args := os.Args[1:]
+	// Skip "daemon" sub-command.
+	if len(args) > 0 && args[0] == "daemon" {
+		args = args[1:]
+	}
+	for i := 0; i < len(args); i++ {
+		if args[i] == "-socketpath" && i+1 < len(args) {
+			socketPath = args[i+1]
+			break
+		}
+	}
+	if socketPath == "" {
+		fmt.Fprintln(os.Stderr, "missing -socketpath")
+		os.Exit(1)
+	}
+
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "listen: %v\n", err)
+		os.Exit(1)
+	}
+	defer ln.Close()
+
+	// Accept connections in a goroutine so readiness polling succeeds.
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+
+	// Stay alive until the socket file is deleted (test kills us this way).
+	for {
+		if _, err := os.Stat(socketPath); os.IsNotExist(err) {
+			os.Exit(0)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+`
+	if err := os.WriteFile(src, []byte(program), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	bin := filepath.Join(dir, "fakedaemon")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to compile fake daemon: %v\n%s", err, out)
+	}
+	return bin
+}
+
+// killFakeDaemon removes the socket file, causing the fake daemon to exit.
+func killFakeDaemon(t *testing.T, socketPath string) {
+	t.Helper()
+	// Wait for the socket file to exist before removing it.
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+	tick := time.NewTicker(50 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		if _, err := os.Stat(socketPath); err == nil {
+			break
+		}
+		select {
+		case <-deadline.C:
+			t.Fatal("socket file never appeared")
+		case <-tick.C:
+		}
+	}
+
+	// Close any listeners by connecting and then removing the file.
+	if conn, err := net.Dial("unix", socketPath); err == nil {
+		_ = conn.Close()
+	}
+	if err := os.Remove(socketPath); err != nil {
+		t.Fatalf("failed to remove socket to kill fake daemon: %v", err)
+	}
+}

--- a/internal/hostnetwork/underlay_cnidev_test.go
+++ b/internal/hostnetwork/underlay_cnidev_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Underlay CNI configuration", func() {
 		logPath = filepath.Join(testDir, "invocations.log")
 		Expect(os.Setenv("CNI_TEST_LOG", logPath)).To(Succeed())
 
-		cniinvoker.Init([]string{binDir}, filepath.Join(testDir, "cache"), "testnode")
+		cniinvoker.Init([]string{binDir}, filepath.Join(testDir, "cache"), "testnode", nil)
 	})
 
 	AfterEach(func() {

--- a/website/content/docs/architecture.md
+++ b/website/content/docs/architecture.md
@@ -103,6 +103,7 @@ The controller pod handles all the complex network configuration logic and is re
 - **EVPNVNI Setup**: Creates and configures network interfaces for each VNI
 - **Configuration Generation**: Generates and applies FRR configuration
 - **State Management**: Maintains the desired state of network configurations
+- **DHCP Daemon Supervision**: Automatically starts the CNI DHCP daemon when the CNI config uses DHCP IPAM, running it as a supervised child process that restarts on exit
 
 #### Reconciliation Process
 

--- a/website/content/docs/configuration/_index.md
+++ b/website/content/docs/configuration/_index.md
@@ -174,6 +174,52 @@ the target. The plugin binaries are looked up in the directories passed
 via the controller's `--cni-plugin-dirs` flag; a set of reference plugins is
 bundled in the controller image.
 
+#### DHCP IPAM
+
+To use DHCP instead of static addressing, set `ipam.type` to `dhcp`.
+The controller automatically starts and supervises the DHCP daemon when
+it detects a CNI config with DHCP IPAM — no additional configuration is
+needed.
+
+The controller supervises the DHCP daemon as a child process — starting
+it on demand, restarting it automatically on exit, and triggering lease
+re-acquisition for all DHCP-backed underlay interfaces after each daemon
+restart.
+
+```yaml
+apiVersion: network.openperouter.io/v1alpha1
+kind: Underlay
+metadata:
+  name: underlay
+  namespace: openperouter-system
+spec:
+  asn: 64514
+  interfaces:
+    - type: CNIDevice
+      cniDevice:
+        type: RawConfig
+        interfaceName: net1
+        rawConfig:
+          cniVersion: "1.0.0"
+          name: macvlan-underlay
+          plugins:
+            - type: macvlan
+              master: toswitch
+              mode: bridge
+              ipam:
+                type: dhcp
+        runtimeConfig:
+          mac: "aa:bb:cc:00:00:01"
+  neighbors:
+    - asn: 64512
+      address: 192.168.11.2
+```
+
+MAC pinning via `runtimeConfig` (requires the macvlan plugin to declare
+`capabilities: {"mac": true}`) ensures the interface keeps the same MAC
+across netns rebuilds, which helps DHCP servers with MAC-based
+reservations assign a stable IP address.
+
 Key behaviors to be aware of:
 
 - **Interface types cannot be mixed**: all the entries of `interfaces`


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup

/kind feature

> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
Add DHCP IPAM support for CNI-provisioned underlay interfaces. 

The controller now supervises the upstream CNI dhcp daemon as a child process, re-acquires leases after daemon restarts, and reconciles the assigned addresses onto the correct kernel (or grout) interface. 

Includes a `dnsmasq` DHCP server in the containerlab topology and e2e tests covering lease acquisition, controller restart, and interface cleanup.

**Special notes for your reviewer**:
Depends-on: #543 

The controller restart scenario will be handled in a follow-up PR, which will issue CNI checks on the reconcile loop - right now, we rely exclusively on the CNI cache to know if an interface is configured. We also want to assure that the kernel state is appropriate, by issuing CNI CHECKs. On DHCP CNI, a CHECK cmd when the lease is not present in memory (this is what happens on controller restart) will lead to lease re-acquisition. 

The DHCP server will then reply with the same IP - if configured with sticky leases (a limitation / requirement we must document) and if the client has the same MAC address (which we currently document how for macvlan / ipvlan plugins). 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
The controller now manages a DHCP daemon subprocess that handles lease acquisition and renewal for CNI-provisioned underlay interfaces, with automatic lease re-acquisition after controller restarts.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for CNI-provisioned underlay interfaces, including raw CNI configuration, runtime options, and DHCP-based addressing.
  * Added validation to prevent mixing interface provisioning modes and protect CNI settings from in-place changes.
  * Added DHCP lease recovery and improved interface lifecycle handling across restarts.
  * Added an EVPN CNI-underlay example and lifecycle coverage.

* **Configuration**
  * Replaced the single CNI binary directory setting with configurable plugin directories.
  * Added optional DHCP plugin configuration.

* **Documentation**
  * Updated API, configuration, and Helm documentation for CNI underlays and related settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->