### PR TITLE
fix(e2e): wait for config helper daemonset rollout

### DIFF
--- a/e2etests/pkg/k8s/daemonset.go
+++ b/e2etests/pkg/k8s/daemonset.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+// DaemonSetRolledOut returns nil when the daemonset rollout is complete,
+// mirroring the checks performed by kubectl rollout status.
+func DaemonSetRolledOut(cs clientset.Interface, namespace, name string) error {
+	ds, err := cs.AppsV1().DaemonSets(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if ds.Spec.UpdateStrategy.Type != appsv1.RollingUpdateDaemonSetStrategyType {
+		return fmt.Errorf("daemonset %s/%s: rollout status not watchable for strategy %s", namespace, name, ds.Spec.UpdateStrategy.Type)
+	}
+	if ds.Generation > ds.Status.ObservedGeneration {
+		return fmt.Errorf("daemonset %s/%s: observed generation %d behind generation %d", namespace, name, ds.Status.ObservedGeneration, ds.Generation)
+	}
+	if ds.Status.UpdatedNumberScheduled < ds.Status.DesiredNumberScheduled {
+		return fmt.Errorf("daemonset %s/%s: %d of %d pods updated", namespace, name, ds.Status.UpdatedNumberScheduled, ds.Status.DesiredNumberScheduled)
+	}
+	if ds.Status.NumberAvailable < ds.Status.DesiredNumberScheduled {
+		return fmt.Errorf("daemonset %s/%s: %d of %d pods available", namespace, name, ds.Status.NumberAvailable, ds.Status.DesiredNumberScheduled)
+	}
+	return nil
+}
+
+// DaemonSetPods returns the ready pods of the daemonset, erroring if their
+// number does not match the desired number of scheduled pods.
+func DaemonSetPods(cs clientset.Interface, namespace, name string) ([]*corev1.Pod, error) {
+	ds, err := cs.AppsV1().DaemonSets(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	podList, err := cs.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{
+		LabelSelector: metav1.FormatLabelSelector(ds.Spec.Selector),
+	})
+	if err != nil {
+		return nil, err
+	}
+	var readyPods []*corev1.Pod
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if PodIsReady(pod) {
+			readyPods = append(readyPods, pod)
+		}
+	}
+	if len(readyPods) != int(ds.Status.DesiredNumberScheduled) {
+		return nil, fmt.Errorf("daemonset %s/%s: expected %d ready pods, got %d", namespace, name, ds.Status.DesiredNumberScheduled, len(readyPods))
+	}
+	return readyPods, nil
+}

--- a/e2etests/tests/static_and_api.go
+++ b/e2etests/tests/static_and_api.go
@@ -322,42 +322,14 @@ func createConfigHelperDaemonSet(cs clientset.Interface) ([]*corev1.Pod, error) 
 		return nil, err
 	}
 
-	// Wait for pods to be ready
-	var readyPods []*corev1.Pod
+	// Wait for the rollout to complete: returning early with a partial set of
+	// pods means static files would be written only on a subset of the nodes,
+	// making the tests flaky.
 	Eventually(func() error {
-		pods, err := getConfigHelperPods(cs)
-		if err != nil {
-			return err
-		}
-		if len(pods) == 0 {
-			return fmt.Errorf("no config helper pods found")
-		}
-		readyPods = pods
-		return nil
+		return k8s.DaemonSetRolledOut(cs, openperouter.Namespace, "config-helper")
 	}, "2m", "5s").Should(Succeed())
 
-	return readyPods, nil
-}
-
-// getConfigHelperPods returns all pods created by the config-helper DaemonSet that are ready.
-func getConfigHelperPods(cs clientset.Interface) ([]*corev1.Pod, error) {
-	podList, err := cs.CoreV1().Pods(openperouter.Namespace).List(
-		context.Background(), metav1.ListOptions{
-			LabelSelector: "app=config-helper",
-		})
-	if err != nil {
-		return nil, err
-	}
-
-	var readyPods []*corev1.Pod
-	for i := range podList.Items {
-		pod := &podList.Items[i]
-		if k8s.PodIsReady(pod) {
-			readyPods = append(readyPods, pod)
-		}
-	}
-
-	return readyPods, nil
+	return k8s.DaemonSetPods(cs, openperouter.Namespace, "config-helper")
 }
 
 // execInConfigPod executes a shell command in the config helper pod


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind flake

**What this PR does / why we need it**:

The `Hybrid mode: static files and API configuration` and `Mirror static config to Kubernetes` tests in the `ci / e2etests (systemdmode)` lane proceeded as soon as one config-helper pod was ready, so with the daemonset rollout still in progress the static `openpe_*.yaml` files were only written on a subset of the nodes and the sessions on the other nodes never established.

In the [Jul 10 nightly](https://github.com/openperouter/openperouter/actions/runs/29063549595) the worker pod became ready 90ms after the test moved on with only the control-plane pod, and the worker controller logged `no openpe_*.yaml configuration files found` for the whole 5 minute timeout. Same signature in the [Jul 4](https://github.com/openperouter/openperouter/actions/runs/28691442469), [Jul 8](https://github.com/openperouter/openperouter/actions/runs/28911515992), [Jul 11](https://github.com/openperouter/openperouter/actions/runs/29135206577) and [Jul 16](https://github.com/openperouter/openperouter/actions/runs/29464872504) nightlies.

Add daemonset rollout helpers to `pkg/k8s` (same checks as `kubectl rollout status`) and wait for a ready pod on every node before writing the files.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration helper readiness by waiting for the full DaemonSet rollout to complete before proceeding.
  * Ensured the expected number of ready helper pods is available across cluster nodes before writing static files.
  * Reduced test flakiness by preventing progress when only a partial set of pods was ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->