### PR TITLE
Feature: support mixed L3VPNs and L3VNIs in different VRFs

### DIFF
--- a/e2etests/tests/mixed_l3vpn_l3vni.go
+++ b/e2etests/tests/mixed_l3vpn_l3vni.go
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package tests
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openperouter/openperouter/api/v1alpha1"
+	"github.com/openperouter/openperouter/e2etests/pkg/config"
+	"github.com/openperouter/openperouter/e2etests/pkg/executor"
+	"github.com/openperouter/openperouter/e2etests/pkg/frrk8s"
+	"github.com/openperouter/openperouter/e2etests/pkg/infra"
+	"github.com/openperouter/openperouter/e2etests/pkg/k8s"
+	"github.com/openperouter/openperouter/e2etests/pkg/k8sclient"
+	"github.com/openperouter/openperouter/e2etests/pkg/openperouter"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+var _ = Describe("Mixed L3VPN and L3VNI coexistence in different VRFs", Ordered, func() {
+	var (
+		cs    clientset.Interface
+		nodes []corev1.Node
+	)
+
+	const (
+		linuxBridgeHostAttachment = v1alpha1.LinuxBridge
+		testNamespace             = "test-mixed-ns"
+
+		l3vpnRDAssignedNumber = 100
+		l3vpnL2VNI            = 110
+		l3vniVNI              = 200
+		l3vniL2VNI            = 210
+
+		l3vpnL2GatewayIP = "192.171.24.1/24"
+		firstPodIP       = "192.171.24.2/24"
+		secondPodIP      = "192.171.24.3/24"
+
+		l3vniL2GatewayIP = "192.172.24.1/24"
+		thirdPodIP       = "192.172.24.2/24"
+		fourthPodIP      = "192.172.24.3/24"
+	)
+
+	l3vpnRed := v1alpha1.L3VPN{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "red",
+			Namespace: openperouter.Namespace,
+		},
+		Spec: v1alpha1.L3VPNSpec{
+			VRF: "red",
+			HostSession: &v1alpha1.HostSession{
+				ASN:     64514,
+				HostASN: new(int64(64515)),
+				LocalCIDR: v1alpha1.LocalCIDRConfig{
+					IPv4: new("192.169.10.0/24"),
+				},
+			},
+			RDAssignedNumber: l3vpnRDAssignedNumber,
+			ExportRTs: []v1alpha1.RouteTarget{
+				v1alpha1.RouteTarget(fmt.Sprintf("64514:%d", l3vpnRDAssignedNumber)),
+			},
+			ImportRTs: []v1alpha1.RouteTarget{
+				v1alpha1.RouteTarget(fmt.Sprintf("64520:%d", l3vpnRDAssignedNumber)),
+			},
+		},
+	}
+
+	l2vniForL3VPN := v1alpha1.L2VNI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("red%d", l3vpnL2VNI),
+			Namespace: openperouter.Namespace,
+		},
+		Spec: v1alpha1.L2VNISpec{
+			RoutingDomain: l3vpnRoutingDomain("red"),
+			VNI:           l3vpnL2VNI,
+			HostMaster: &v1alpha1.HostMaster{
+				Type: linuxBridgeHostAttachment,
+				LinuxBridge: &v1alpha1.LinuxBridgeConfig{
+					Lifecycle: v1alpha1.BridgeLifecycleManaged,
+				},
+			},
+			GatewayIPs: []string{l3vpnL2GatewayIP},
+		},
+	}
+
+	l3vniBlue := v1alpha1.L3VNI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "blue",
+			Namespace: openperouter.Namespace,
+		},
+		Spec: v1alpha1.L3VNISpec{
+			VRF: "blue",
+			HostSession: &v1alpha1.HostSession{
+				ASN:     64514,
+				HostASN: new(int64(64515)),
+				LocalCIDR: v1alpha1.LocalCIDRConfig{
+					IPv4: new("192.169.11.0/24"),
+				},
+			},
+			VNI: l3vniVNI,
+		},
+	}
+
+	l2vniForL3VNI := v1alpha1.L2VNI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("blue%d", l3vniL2VNI),
+			Namespace: openperouter.Namespace,
+		},
+		Spec: v1alpha1.L2VNISpec{
+			RoutingDomain: l3vniRoutingDomain("blue"),
+			VNI:           l3vniL2VNI,
+			HostMaster: &v1alpha1.HostMaster{
+				Type: linuxBridgeHostAttachment,
+				LinuxBridge: &v1alpha1.LinuxBridgeConfig{
+					Lifecycle: v1alpha1.BridgeLifecycleManaged,
+				},
+			},
+			GatewayIPs: []string{l3vniL2GatewayIP},
+		},
+	}
+
+	BeforeAll(func() {
+		Expect(Updater.CleanAll()).To(Succeed())
+
+		cs = k8sclient.New()
+
+		By("creating the underlay")
+		Expect(Updater.Update(config.Resources{
+			Underlays: []v1alpha1.Underlay{
+				infra.UnderlayEVPNandSRv6,
+			},
+		})).To(Succeed())
+
+		_, err := openperouter.Get(cs, HostMode)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("getting the nodes")
+		nodes, err = k8s.GetNodes(cs)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(nodes)).To(BeNumerically(">=", 2), "Expected at least 2 nodes, but got fewer")
+
+		By("resetting the leaf kind nodes")
+		Expect(infra.LeafKind1Config.UpdateConfig(nodes, infra.LeafKindConfiguration{})).To(Succeed())
+		Expect(infra.LeafKind2Config.UpdateConfig(nodes, infra.LeafKindConfiguration{})).To(Succeed())
+
+		By("setting redistribute connected on leaves")
+		Expect(infra.LeafAConfig.RedistributeConnected()).To(Succeed())
+		Expect(infra.LeafSRV6Config.RedistributeConnected()).To(Succeed())
+
+		By("cleaning all but the underlay")
+		Expect(Updater.CleanButUnderlay()).To(Succeed())
+	})
+
+	AfterAll(func() {
+		dumpIfFails(cs, testNamespace)
+		Expect(infra.LeafAConfig.Reset()).To(Succeed())
+		Expect(infra.LeafSRV6Config.Reset()).To(Succeed())
+		Expect(Updater.CleanButUnderlay()).To(Succeed())
+		Expect(k8s.DeleteNamespace(cs, testNamespace)).To(Succeed())
+
+		By("cleaning all resources")
+		Expect(Updater.CleanAll()).To(Succeed())
+
+		By("waiting for all router pods to be ready after removing the underlay")
+		Eventually(func() error {
+			routers, err := openperouter.Get(cs, HostMode)
+			if err != nil {
+				return err
+			}
+			return openperouter.AreReady(routers)
+		}, 2*time.Minute, time.Second).ShouldNot(HaveOccurred())
+	})
+
+	It("should support traffic in different VRFs", func() {
+		By("deriving the FRR K8s configuration from the hostsessions")
+		frrK8sConfigRed, err := frrk8s.ConfigFromHostSession(*l3vpnRed.Spec.HostSession, l3vpnRed.Name)
+		Expect(err).NotTo(HaveOccurred())
+		frrK8sConfigBlue, err := frrk8s.ConfigFromHostSession(*l3vniBlue.Spec.HostSession, l3vniBlue.Name)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating L3VPN, L3VNI, and L2VNIs alongside FRR K8s configuration for red and blue peers")
+		Expect(Updater.Update(config.Resources{
+			L3VPNs:            []v1alpha1.L3VPN{l3vpnRed},
+			L3VNIs:            []v1alpha1.L3VNI{l3vniBlue},
+			L2VNIs:            []v1alpha1.L2VNI{l2vniForL3VNI, l2vniForL3VPN},
+			FRRConfigurations: append(frrK8sConfigRed, frrK8sConfigBlue...),
+		})).To(Succeed())
+
+		By("creating the namespace")
+		_, err = k8s.CreateNamespace(cs, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating the MacVLAN Network Attachment Definitions for L3VPN")
+		nadMasterL3VPN := fmt.Sprintf("br-hs-%d", l3vpnL2VNI)
+		netAttachDefL3VPN, err := k8s.CreateMacvlanNad(
+			fmt.Sprintf("%d", l3vpnL2VNI), testNamespace, nadMasterL3VPN, []string{l3vpnL2GatewayIP})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating the MacVLAN Network Attachment Definitions for L3VNI")
+		nadMasterL3VNI := fmt.Sprintf("br-hs-%d", l3vniL2VNI)
+		netAttachDefL3VNI, err := k8s.CreateMacvlanNad(
+			fmt.Sprintf("%d", l3vniL2VNI), testNamespace, nadMasterL3VNI, []string{l3vniL2GatewayIP})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating the pods connected to L3VPN")
+		firstPod, err := k8s.CreateAgnhostPod(cs, "pod1", testNamespace,
+			k8s.WithNad(netAttachDefL3VPN.Name, testNamespace, []string{firstPodIP}),
+			k8s.OnNode(nodes[0].Name))
+		Expect(err).NotTo(HaveOccurred())
+		secondPod, err := k8s.CreateAgnhostPod(cs, "pod2", testNamespace,
+			k8s.WithNad(netAttachDefL3VPN.Name, testNamespace, []string{secondPodIP}),
+			k8s.OnNode(nodes[1].Name))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating the pods connected to L3VNI")
+		thirdPod, err := k8s.CreateAgnhostPod(cs, "pod3", testNamespace,
+			k8s.WithNad(netAttachDefL3VNI.Name, testNamespace, []string{thirdPodIP}),
+			k8s.OnNode(nodes[0].Name))
+		Expect(err).NotTo(HaveOccurred())
+		fourthPod, err := k8s.CreateAgnhostPod(cs, "pod4", testNamespace,
+			k8s.WithNad(netAttachDefL3VNI.Name, testNamespace, []string{fourthPodIP}),
+			k8s.OnNode(nodes[1].Name))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("removing the default gateway via the primary interface for pods connected to L3VPN")
+		Expect(removeGatewayFromPod(firstPod)).To(Succeed())
+		Expect(removeGatewayFromPod(secondPod)).To(Succeed())
+
+		By("removing the default gateway via the primary interface for pods connected to L3VNI")
+		Expect(removeGatewayFromPod(thirdPod)).To(Succeed())
+		Expect(removeGatewayFromPod(fourthPod)).To(Succeed())
+
+		By("getting the pod executors for pods connected to L3VPN")
+		firstPodExecutor := executor.ForPod(firstPod.Namespace, firstPod.Name, "agnhost")
+		secondPodExecutor := executor.ForPod(secondPod.Namespace, secondPod.Name, "agnhost")
+
+		By("getting the pod executors for pods connected to L3VNI")
+		thirdPodExecutor := executor.ForPod(thirdPod.Namespace, thirdPod.Name, "agnhost")
+		fourthPodExecutor := executor.ForPod(fourthPod.Namespace, fourthPod.Name, "agnhost")
+
+		By("checking east/west reachability between pods via L3VPN's L2VNI")
+		from := discardAddressLength(firstPodIP)
+		to := discardAddressLength(secondPodIP)
+		checkPodIsReachable(firstPodExecutor, from, to)
+		checkPodIsReachable(secondPodExecutor, to, from)
+
+		By("checking east/west reachability between pods via L3VNI's L2VNI")
+		from = discardAddressLength(thirdPodIP)
+		to = discardAddressLength(fourthPodIP)
+		checkPodIsReachable(thirdPodExecutor, from, to)
+		checkPodIsReachable(fourthPodExecutor, to, from)
+
+		By("checking north/south reachability via L3VPN to hostSRV6Red")
+		from = discardAddressLength(firstPodIP)
+		to = infra.HostSRV6RedIPv4
+		checkPodIsReachable(firstPodExecutor, from, to)
+
+		By("checking north/south reachability via L3VNI to hostABlue")
+		from = discardAddressLength(thirdPodIP)
+		to = infra.HostABlueIPv4
+		checkPodIsReachable(thirdPodExecutor, from, to)
+	})
+})

--- a/e2etests/tests/mixed_l3vpn_l3vni.go
+++ b/e2etests/tests/mixed_l3vpn_l3vni.go
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package tests
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openperouter/openperouter/api/v1alpha1"
+	"github.com/openperouter/openperouter/e2etests/pkg/config"
+	"github.com/openperouter/openperouter/e2etests/pkg/executor"
+	"github.com/openperouter/openperouter/e2etests/pkg/frrk8s"
+	"github.com/openperouter/openperouter/e2etests/pkg/infra"
+	"github.com/openperouter/openperouter/e2etests/pkg/k8s"
+	"github.com/openperouter/openperouter/e2etests/pkg/k8sclient"
+	"github.com/openperouter/openperouter/e2etests/pkg/openperouter"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+var _ = Describe("Mixed L3VPN and L3VNI coexistence in different VRFs", Ordered, func() {
+	var (
+		cs    clientset.Interface
+		nodes []corev1.Node
+	)
+
+	const (
+		linuxBridgeHostAttachment = v1alpha1.LinuxBridge
+		testNamespace             = "test-mixed-ns"
+
+		l3vpnRDAssignedNumber = 100
+		l3vpnL2VNI            = 110
+		l3vniVNI              = 200
+		l3vniL2VNI            = 210
+
+		l3vpnL2GatewayIP = "192.171.24.1/24"
+		l3vpnClientPodIP = "192.171.24.2/24"
+		l3vpnServerPodIP = "192.171.24.3/24"
+
+		l3vniL2GatewayIP = "192.172.24.1/24"
+		l3vniClientPodIP = "192.172.24.2/24"
+		l3vniServerPodIP = "192.172.24.3/24"
+
+		l3vpnClientPodName = "l3vpn-client-pod"
+		l3vpnServerPodName = "l3vpn-server-pod"
+		l3vniClientPodName = "l3vni-client-pod"
+		l3vniServerPodName = "l3vni-server-pod"
+	)
+
+	l3vpnRed := v1alpha1.L3VPN{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "red",
+			Namespace: openperouter.Namespace,
+		},
+		Spec: v1alpha1.L3VPNSpec{
+			VRF: "red",
+			HostSession: &v1alpha1.HostSession{
+				ASN:     64514,
+				HostASN: new(int64(64515)),
+				LocalCIDR: v1alpha1.LocalCIDRConfig{
+					IPv4: new("192.169.10.0/24"),
+				},
+			},
+			RDAssignedNumber: l3vpnRDAssignedNumber,
+			ExportRTs: []v1alpha1.RouteTarget{
+				v1alpha1.RouteTarget(fmt.Sprintf("64514:%d", l3vpnRDAssignedNumber)),
+			},
+			ImportRTs: []v1alpha1.RouteTarget{
+				v1alpha1.RouteTarget(fmt.Sprintf("64520:%d", l3vpnRDAssignedNumber)),
+			},
+		},
+	}
+
+	l2vniForL3VPN := v1alpha1.L2VNI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("red%d", l3vpnL2VNI),
+			Namespace: openperouter.Namespace,
+		},
+		Spec: v1alpha1.L2VNISpec{
+			RoutingDomain: l3vpnRoutingDomain("red"),
+			VNI:           l3vpnL2VNI,
+			HostMaster: &v1alpha1.HostMaster{
+				Type: linuxBridgeHostAttachment,
+				LinuxBridge: &v1alpha1.LinuxBridgeConfig{
+					Lifecycle: v1alpha1.BridgeLifecycleManaged,
+				},
+			},
+			GatewayIPs: []string{l3vpnL2GatewayIP},
+		},
+	}
+
+	l3vniBlue := v1alpha1.L3VNI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "blue",
+			Namespace: openperouter.Namespace,
+		},
+		Spec: v1alpha1.L3VNISpec{
+			VRF: "blue",
+			HostSession: &v1alpha1.HostSession{
+				ASN:     64514,
+				HostASN: new(int64(64515)),
+				LocalCIDR: v1alpha1.LocalCIDRConfig{
+					IPv4: new("192.169.11.0/24"),
+				},
+			},
+			VNI: l3vniVNI,
+		},
+	}
+
+	l2vniForL3VNI := v1alpha1.L2VNI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("blue%d", l3vniL2VNI),
+			Namespace: openperouter.Namespace,
+		},
+		Spec: v1alpha1.L2VNISpec{
+			RoutingDomain: l3vniRoutingDomain("blue"),
+			VNI:           l3vniL2VNI,
+			HostMaster: &v1alpha1.HostMaster{
+				Type: linuxBridgeHostAttachment,
+				LinuxBridge: &v1alpha1.LinuxBridgeConfig{
+					Lifecycle: v1alpha1.BridgeLifecycleManaged,
+				},
+			},
+			GatewayIPs: []string{l3vniL2GatewayIP},
+		},
+	}
+
+	BeforeAll(func() {
+		Expect(Updater.CleanAll()).To(Succeed())
+
+		cs = k8sclient.New()
+
+		By("creating the underlay")
+		Expect(Updater.Update(config.Resources{
+			Underlays: []v1alpha1.Underlay{
+				infra.UnderlayEVPNandSRv6,
+			},
+		})).To(Succeed())
+
+		_, err := openperouter.Get(cs, HostMode)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("getting the nodes")
+		nodes, err = k8s.GetNodes(cs)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(nodes)).To(BeNumerically(">=", 2), "Expected at least 2 nodes, but got fewer")
+
+		By("resetting the leaf kind nodes")
+		Expect(infra.LeafKind1Config.UpdateConfig(nodes, infra.LeafKindConfiguration{})).To(Succeed())
+		Expect(infra.LeafKind2Config.UpdateConfig(nodes, infra.LeafKindConfiguration{})).To(Succeed())
+
+		By("setting redistribute connected on leaves")
+		Expect(infra.LeafAConfig.RedistributeConnected()).To(Succeed())
+		Expect(infra.LeafSRV6Config.RedistributeConnected()).To(Succeed())
+
+		By("cleaning all but the underlay")
+		Expect(Updater.CleanButUnderlay()).To(Succeed())
+	})
+
+	AfterAll(func() {
+		dumpIfFails(cs, testNamespace)
+		Expect(infra.LeafAConfig.Reset()).To(Succeed())
+		Expect(infra.LeafSRV6Config.Reset()).To(Succeed())
+		Expect(Updater.CleanButUnderlay()).To(Succeed())
+		Expect(k8s.DeleteNamespace(cs, testNamespace)).To(Succeed())
+
+		By("cleaning all resources")
+		Expect(Updater.CleanAll()).To(Succeed())
+
+		By("waiting for all router pods to be ready after removing the underlay")
+		Eventually(func() error {
+			routers, err := openperouter.Get(cs, HostMode)
+			if err != nil {
+				return err
+			}
+			return openperouter.AreReady(routers)
+		}, 2*time.Minute, time.Second).ShouldNot(HaveOccurred())
+	})
+
+	It("should support traffic in different VRFs", func() {
+		By("deriving the FRR K8s configuration from the hostsessions")
+		frrK8sConfigRed, err := frrk8s.ConfigFromHostSession(*l3vpnRed.Spec.HostSession, l3vpnRed.Name)
+		Expect(err).NotTo(HaveOccurred())
+		frrK8sConfigBlue, err := frrk8s.ConfigFromHostSession(*l3vniBlue.Spec.HostSession, l3vniBlue.Name)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating L3VPN, L3VNI, and L2VNIs alongside FRR K8s configuration for red and blue peers")
+		Expect(Updater.Update(config.Resources{
+			L3VPNs:            []v1alpha1.L3VPN{l3vpnRed},
+			L3VNIs:            []v1alpha1.L3VNI{l3vniBlue},
+			L2VNIs:            []v1alpha1.L2VNI{l2vniForL3VNI, l2vniForL3VPN},
+			FRRConfigurations: append(frrK8sConfigRed, frrK8sConfigBlue...),
+		})).To(Succeed())
+
+		By("creating the namespace")
+		_, err = k8s.CreateNamespace(cs, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating the MacVLAN Network Attachment Definitions for L3VPN")
+		nadMasterL3VPN := fmt.Sprintf("br-hs-%d", l3vpnL2VNI)
+		netAttachDefL3VPN, err := k8s.CreateMacvlanNad(
+			fmt.Sprintf("%d", l3vpnL2VNI), testNamespace, nadMasterL3VPN, []string{l3vpnL2GatewayIP})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating the MacVLAN Network Attachment Definitions for L3VNI")
+		nadMasterL3VNI := fmt.Sprintf("br-hs-%d", l3vniL2VNI)
+		netAttachDefL3VNI, err := k8s.CreateMacvlanNad(
+			fmt.Sprintf("%d", l3vniL2VNI), testNamespace, nadMasterL3VNI, []string{l3vniL2GatewayIP})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating the pods connected to L3VPN")
+		l3vpnClientPod, err := k8s.CreateAgnhostPod(cs, l3vpnClientPodName, testNamespace,
+			k8s.WithNad(netAttachDefL3VPN.Name, testNamespace, []string{l3vpnClientPodIP}),
+			k8s.OnNode(nodes[0].Name))
+		Expect(err).NotTo(HaveOccurred())
+		l3vpnServerPod, err := k8s.CreateAgnhostPod(cs, l3vpnServerPodName, testNamespace,
+			k8s.WithNad(netAttachDefL3VPN.Name, testNamespace, []string{l3vpnServerPodIP}),
+			k8s.OnNode(nodes[1].Name))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating the pods connected to L3VNI")
+		l3vniClientPod, err := k8s.CreateAgnhostPod(cs, l3vniClientPodName, testNamespace,
+			k8s.WithNad(netAttachDefL3VNI.Name, testNamespace, []string{l3vniClientPodIP}),
+			k8s.OnNode(nodes[0].Name))
+		Expect(err).NotTo(HaveOccurred())
+		l3vniServerPod, err := k8s.CreateAgnhostPod(cs, l3vniServerPodName, testNamespace,
+			k8s.WithNad(netAttachDefL3VNI.Name, testNamespace, []string{l3vniServerPodIP}),
+			k8s.OnNode(nodes[1].Name))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("removing the default gateway via the primary interface for pods connected to L3VPN")
+		Expect(removeGatewayFromPod(l3vpnClientPod)).To(Succeed())
+		Expect(removeGatewayFromPod(l3vpnServerPod)).To(Succeed())
+
+		By("removing the default gateway via the primary interface for pods connected to L3VNI")
+		Expect(removeGatewayFromPod(l3vniClientPod)).To(Succeed())
+		Expect(removeGatewayFromPod(l3vniServerPod)).To(Succeed())
+
+		By("getting the pod executors for pods connected to L3VPN")
+		l3vpnClientPodExecutor := executor.ForPod(l3vpnClientPod.Namespace, l3vpnClientPod.Name, "agnhost")
+		l3vpnServerPodExecutor := executor.ForPod(l3vpnServerPod.Namespace, l3vpnServerPod.Name, "agnhost")
+
+		By("getting the pod executors for pods connected to L3VNI")
+		l3vniClientPodExecutor := executor.ForPod(l3vniClientPod.Namespace, l3vniClientPod.Name, "agnhost")
+		l3vniServerPodExecutor := executor.ForPod(l3vniServerPod.Namespace, l3vniServerPod.Name, "agnhost")
+
+		By("checking east/west reachability between pods via L3VPN's L2VNI")
+		fromL3vpnClientPod := discardAddressLength(l3vpnClientPodIP)
+		toL3vpnServerPod := discardAddressLength(l3vpnServerPodIP)
+		checkPodIsReachable(l3vpnClientPodExecutor, fromL3vpnClientPod, toL3vpnServerPod)
+		checkPodIsReachable(l3vpnServerPodExecutor, toL3vpnServerPod, fromL3vpnClientPod)
+
+		By("checking east/west reachability between pods via L3VNI's L2VNI")
+		fromL3vniClientPod := discardAddressLength(l3vniClientPodIP)
+		toL3vniServerPod := discardAddressLength(l3vniServerPodIP)
+		checkPodIsReachable(l3vniClientPodExecutor, fromL3vniClientPod, toL3vniServerPod)
+		checkPodIsReachable(l3vniServerPodExecutor, toL3vniServerPod, fromL3vniClientPod)
+
+		By("checking north/south reachability via L3VPN to hostSRV6Red")
+		toSRV6Host := infra.HostSRV6RedIPv4
+		checkPodIsReachable(l3vpnClientPodExecutor, fromL3vpnClientPod, toSRV6Host)
+
+		By("checking north/south reachability via L3VNI to hostABlue")
+		toEVPNHost := infra.HostABlueIPv4
+		checkPodIsReachable(l3vniClientPodExecutor, fromL3vniClientPod, toEVPNHost)
+	})
+})

--- a/internal/controller/routerconfiguration/reconcile.go
+++ b/internal/controller/routerconfiguration/reconcile.go
@@ -49,12 +49,6 @@ func Reconcile(ctx context.Context, apiConfig conversion.APIConfigData, nodeInde
 	validL3VPNs, err = conversion.FilterValidL3VPNs(apiConfig.L3VPNs)
 	resourceErrors = append(resourceErrors, err)
 
-	if err := conversion.DetectMutuallyExclusiveOverlays(validL3VNIs, validL3VPNs); err != nil {
-		validL3VNIs = []v1alpha1.L3VNI{}
-		validL3VPNs = []v1alpha1.L3VPN{}
-		resourceErrors = append(resourceErrors, err)
-	}
-
 	if conversion.HasMissingSRv6ForL3VPNs(apiConfig.Underlays, validL3VPNs) {
 		resourceErrors = append(
 			resourceErrors,
@@ -72,19 +66,15 @@ func Reconcile(ctx context.Context, apiConfig conversion.APIConfigData, nodeInde
 	resourceErrors = append(resourceErrors, err)
 
 	var rdAssignedNumbers map[int32]string
-	validL3VPNs, rdAssignedNumbers, err = conversion.FilterUniqueL3VPNs(validL3VPNs)
+	validL3VPNs, rdAssignedNumbers, err = conversion.FilterUniqueL3VPNs(validL3VPNs, vnis)
 	resourceErrors = append(resourceErrors, err)
-	// TODO: This is safe today, but may cause issues when we change to per-VRF mutual exclusivity
-	// for L3VNI and L3VPN.
+	// The following action is safe: vnis and rdAssignedNumbers are guaranteed to have unique indexes.
 	maps.Copy(vnis, rdAssignedNumbers)
 
 	validL2VNIs, err = conversion.FilterUniqueL2VNIs(validL2VNIs, vnis)
 	resourceErrors = append(resourceErrors, err)
 
-	validL3VNIs, err = conversion.FilterUniqueVRFsForL3VNIs(validL3VNIs)
-	resourceErrors = append(resourceErrors, err)
-
-	validL3VPNs, err = conversion.FilterUniqueVRFsForL3VPNs(validL3VPNs)
+	validL3VNIs, validL3VPNs, err = conversion.FilterUniqueVRFs(validL3VNIs, validL3VPNs)
 	resourceErrors = append(resourceErrors, err)
 
 	validL2VNIs, err = filterL2VNIsWithInvalidRoutingDomain(validL2VNIs, validL3VNIs, validL3VPNs)

--- a/internal/controller/routerconfiguration/reconcile.go
+++ b/internal/controller/routerconfiguration/reconcile.go
@@ -10,6 +10,7 @@ import (
 	"maps"
 	"slices"
 
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -49,12 +50,6 @@ func Reconcile(ctx context.Context, apiConfig conversion.APIConfigData, nodeInde
 	validL3VPNs, err = conversion.FilterValidL3VPNs(apiConfig.L3VPNs)
 	resourceErrors = append(resourceErrors, err)
 
-	if err := conversion.DetectMutuallyExclusiveOverlays(validL3VNIs, validL3VPNs); err != nil {
-		validL3VNIs = []v1alpha1.L3VNI{}
-		validL3VPNs = []v1alpha1.L3VPN{}
-		resourceErrors = append(resourceErrors, err)
-	}
-
 	if conversion.HasMissingSRv6ForL3VPNs(apiConfig.Underlays, validL3VPNs) {
 		resourceErrors = append(
 			resourceErrors,
@@ -67,24 +62,23 @@ func Reconcile(ctx context.Context, apiConfig conversion.APIConfigData, nodeInde
 	validL2VNIs, err = conversion.FilterValidL2VNIs(apiConfig.L2VNIs)
 	resourceErrors = append(resourceErrors, err)
 
-	var vnis map[int32]string
-	validL3VNIs, vnis, err = conversion.FilterUniqueL3VNIs(validL3VNIs)
+	var allocatedRDAssignedNumberToOwner map[int32]string
+	validL3VNIs, allocatedRDAssignedNumberToOwner, err = conversion.FilterUniqueL3VNIs(validL3VNIs)
 	resourceErrors = append(resourceErrors, err)
 
-	var rdAssignedNumbers map[int32]string
-	validL3VPNs, rdAssignedNumbers, err = conversion.FilterUniqueL3VPNs(validL3VPNs)
+	var allocatedRDAssignedNumberToVPN map[int32]string
+	validL3VPNs, allocatedRDAssignedNumberToVPN, err = conversion.FilterUniqueL3VPNs(validL3VPNs, allocatedRDAssignedNumberToOwner)
 	resourceErrors = append(resourceErrors, err)
-	// TODO: This is safe today, but may cause issues when we change to per-VRF mutual exclusivity
-	// for L3VNI and L3VPN.
-	maps.Copy(vnis, rdAssignedNumbers)
+	maps.Copy(allocatedRDAssignedNumberToOwner, allocatedRDAssignedNumberToVPN)
 
-	validL2VNIs, err = conversion.FilterUniqueL2VNIs(validL2VNIs, vnis)
+	validL2VNIs, err = conversion.FilterUniqueL2VNIs(validL2VNIs, allocatedRDAssignedNumberToOwner)
 	resourceErrors = append(resourceErrors, err)
 
-	validL3VNIs, err = conversion.FilterUniqueVRFsForL3VNIs(validL3VNIs)
+	var vrfToVNI map[string]types.NamespacedName
+	validL3VNIs, vrfToVNI, err = conversion.FilterUniqueVRFsForL3VNIs(validL3VNIs)
 	resourceErrors = append(resourceErrors, err)
 
-	validL3VPNs, err = conversion.FilterUniqueVRFsForL3VPNs(validL3VPNs)
+	validL3VPNs, err = conversion.FilterUniqueVRFsForL3VPNs(validL3VPNs, vrfToVNI)
 	resourceErrors = append(resourceErrors, err)
 
 	validL2VNIs, err = filterL2VNIsWithInvalidRoutingDomain(validL2VNIs, validL3VNIs, validL3VPNs)

--- a/internal/controller/routerconfiguration/reconcile_test.go
+++ b/internal/controller/routerconfiguration/reconcile_test.go
@@ -361,23 +361,77 @@ func TestReconcilePerResourceErrors(t *testing.T) {
 			},
 		},
 		{
-			name: "L3VPN with L3VNI reports failure but reconciles other resources",
+			name:      "L3VPN with L3VNI in same VRF reports failure but reconciles other resources (L2VNI ref: L3VNI)",
+			underlays: srv6Underlays(),
 			l3VNIs: []v1alpha1.L3VNI{
-				l3VNI("bad-l3-vni", "vrfA", 100),
+				l3VNI("good-l3-vni", "vrfA", 100),
 			},
 			l3VPNs: []v1alpha1.L3VPN{
-				l3VPN("bad-l3-vpn", "vrfB", 101),
+				l3VPN("bad-l3-vpn", "vrfA", 101),
+			},
+			l2VNIs: []v1alpha1.L2VNI{
+				l2VNI("good-l2", l3vniRoutingDomain("good-l3-vni"), 200),
+			},
+			expectedFailures: []v1alpha1.FailedResource{
+				{Kind: openpeerrors.KindL3VPN, Name: "bad-l3-vpn", Reason: v1alpha1.FailedResourceReasonValidationFailed,
+					Message: `conflict with L3VNI detected in VRF "vrfA": "/good-l3-vni" already exists`},
+			},
+			wantConfig: conversion.APIConfigData{
+				Underlays: srv6Underlays(),
+				L3VNIs: []v1alpha1.L3VNI{
+					l3VNI("good-l3-vni", "vrfA", 100),
+				},
+				L2VNIs: []v1alpha1.L2VNI{
+					l2VNI("good-l2", l3vniRoutingDomain("good-l3-vni"), 200),
+				},
+			},
+		},
+		{
+			name:      "L3VPN with L3VNI in same VRF reports failure but reconciles other resources (L2VNI ref: L3VPN)",
+			underlays: srv6Underlays(),
+			l3VNIs: []v1alpha1.L3VNI{
+				l3VNI("good-l3-vni", "vrfA", 100),
+			},
+			l3VPNs: []v1alpha1.L3VPN{
+				l3VPN("bad-l3-vpn", "vrfA", 101),
+			},
+			l2VNIs: []v1alpha1.L2VNI{
+				l2VNI("bad-l2", l3vpnRoutingDomain("bad-l3-vpn"), 200),
+			},
+			expectedFailures: []v1alpha1.FailedResource{
+				{Kind: openpeerrors.KindL3VPN, Name: "bad-l3-vpn", Reason: v1alpha1.FailedResourceReasonValidationFailed,
+					Message: `conflict with L3VNI detected in VRF "vrfA": "/good-l3-vni" already exists`},
+				{Kind: openpeerrors.KindL2VNI, Name: "bad-l2", Reason: v1alpha1.FailedResourceReasonDependencyFailed,
+					Message: `referenced L3VPN "bad-l3-vpn" not found`},
+			},
+			wantConfig: conversion.APIConfigData{
+				Underlays: srv6Underlays(),
+				L3VNIs: []v1alpha1.L3VNI{
+					l3VNI("good-l3-vni", "vrfA", 100),
+				},
+				L2VNIs: []v1alpha1.L2VNI{},
+			},
+		},
+		{
+			name:      "L3VPN with L3VNI in different VRFs succeeds",
+			underlays: srv6Underlays(),
+			l3VNIs: []v1alpha1.L3VNI{
+				l3VNI("good-vni", "vrfA", 100),
+			},
+			l3VPNs: []v1alpha1.L3VPN{
+				l3VPN("good-vpn", "vrfB", 101),
 			},
 			l2VNIs: []v1alpha1.L2VNI{
 				l2VNI("good-l2", nil, 200),
 			},
-			expectedFailures: []v1alpha1.FailedResource{
-				{Kind: openpeerrors.KindL3VNI, Name: "bad-l3-vni", Reason: v1alpha1.FailedResourceReasonValidationFailed,
-					Message: "cannot specify L3VNI resources and L3VPN resources at the same time"},
-				{Kind: openpeerrors.KindL3VPN, Name: "bad-l3-vpn", Reason: v1alpha1.FailedResourceReasonValidationFailed,
-					Message: "cannot specify L3VPN resources and L3VNI resources at the same time"},
-			},
 			wantConfig: conversion.APIConfigData{
+				Underlays: srv6Underlays(),
+				L3VNIs: []v1alpha1.L3VNI{
+					l3VNI("good-vni", "vrfA", 100),
+				},
+				L3VPNs: []v1alpha1.L3VPN{
+					l3VPN("good-vpn", "vrfB", 101),
+				},
 				L2VNIs: []v1alpha1.L2VNI{
 					l2VNI("good-l2", nil, 200),
 				},

--- a/internal/controller/routerconfiguration/reconcile_test.go
+++ b/internal/controller/routerconfiguration/reconcile_test.go
@@ -361,23 +361,77 @@ func TestReconcilePerResourceErrors(t *testing.T) {
 			},
 		},
 		{
-			name: "L3VPN with L3VNI reports failure but reconciles other resources",
+			name:      "L3VPN with L3VNI in same VRF reports failure but reconciles other resources (L2VNI ref: L3VNI)",
+			underlays: srv6Underlays(),
 			l3VNIs: []v1alpha1.L3VNI{
-				l3VNI("bad-l3-vni", "vrfA", 100),
+				l3VNI("good-l3-vni", "vrfA", 100),
 			},
 			l3VPNs: []v1alpha1.L3VPN{
-				l3VPN("bad-l3-vpn", "vrfB", 101),
+				l3VPN("bad-l3-vpn", "vrfA", 101),
+			},
+			l2VNIs: []v1alpha1.L2VNI{
+				l2VNI("good-l2", l3vniRoutingDomain("good-l3-vni"), 200),
+			},
+			expectedFailures: []v1alpha1.FailedResource{
+				{Kind: openpeerrors.KindL3VPN, Name: "bad-l3-vpn", Reason: v1alpha1.FailedResourceReasonValidationFailed,
+					Message: `conflict with L3VNI "/good-l3-vni" detected in VRF "vrfA"`},
+			},
+			wantConfig: conversion.APIConfigData{
+				Underlays: srv6Underlays(),
+				L3VNIs: []v1alpha1.L3VNI{
+					l3VNI("good-l3-vni", "vrfA", 100),
+				},
+				L2VNIs: []v1alpha1.L2VNI{
+					l2VNI("good-l2", l3vniRoutingDomain("good-l3-vni"), 200),
+				},
+			},
+		},
+		{
+			name:      "L3VPN with L3VNI in same VRF reports failure but reconciles other resources (L2VNI ref: L3VPN)",
+			underlays: srv6Underlays(),
+			l3VNIs: []v1alpha1.L3VNI{
+				l3VNI("good-l3-vni", "vrfA", 100),
+			},
+			l3VPNs: []v1alpha1.L3VPN{
+				l3VPN("bad-l3-vpn", "vrfA", 101),
+			},
+			l2VNIs: []v1alpha1.L2VNI{
+				l2VNI("bad-l2", l3vpnRoutingDomain("bad-l3-vpn"), 200),
+			},
+			expectedFailures: []v1alpha1.FailedResource{
+				{Kind: openpeerrors.KindL3VPN, Name: "bad-l3-vpn", Reason: v1alpha1.FailedResourceReasonValidationFailed,
+					Message: `conflict with L3VNI "/good-l3-vni" detected in VRF "vrfA"`},
+				{Kind: openpeerrors.KindL2VNI, Name: "bad-l2", Reason: v1alpha1.FailedResourceReasonDependencyFailed,
+					Message: `referenced L3VPN "bad-l3-vpn" not found`},
+			},
+			wantConfig: conversion.APIConfigData{
+				Underlays: srv6Underlays(),
+				L3VNIs: []v1alpha1.L3VNI{
+					l3VNI("good-l3-vni", "vrfA", 100),
+				},
+				L2VNIs: []v1alpha1.L2VNI{},
+			},
+		},
+		{
+			name:      "L3VPN with L3VNI in different VRFs succeeds",
+			underlays: srv6Underlays(),
+			l3VNIs: []v1alpha1.L3VNI{
+				l3VNI("good-vni", "vrfA", 100),
+			},
+			l3VPNs: []v1alpha1.L3VPN{
+				l3VPN("good-vpn", "vrfB", 101),
 			},
 			l2VNIs: []v1alpha1.L2VNI{
 				l2VNI("good-l2", nil, 200),
 			},
-			expectedFailures: []v1alpha1.FailedResource{
-				{Kind: openpeerrors.KindL3VNI, Name: "bad-l3-vni", Reason: v1alpha1.FailedResourceReasonValidationFailed,
-					Message: "cannot specify L3VNI resources and L3VPN resources at the same time"},
-				{Kind: openpeerrors.KindL3VPN, Name: "bad-l3-vpn", Reason: v1alpha1.FailedResourceReasonValidationFailed,
-					Message: "cannot specify L3VPN resources and L3VNI resources at the same time"},
-			},
 			wantConfig: conversion.APIConfigData{
+				Underlays: srv6Underlays(),
+				L3VNIs: []v1alpha1.L3VNI{
+					l3VNI("good-vni", "vrfA", 100),
+				},
+				L3VPNs: []v1alpha1.L3VPN{
+					l3VPN("good-vpn", "vrfB", 101),
+				},
 				L2VNIs: []v1alpha1.L2VNI{
 					l2VNI("good-l2", nil, 200),
 				},

--- a/internal/conversion/api.go
+++ b/internal/conversion/api.go
@@ -56,12 +56,6 @@ func validateAPIConfigData(config APIConfigData) error {
 		return errors.New("multiple passthroughs defined, can only have one")
 	}
 
-	// TODO: This is a shortcut. We do not want L3VNIs and L3VPNs coexisting inside the same VRF. But across different
-	// VRFs, this should work, in theory, subject to testing.
-	if len(config.L3VNIs) > 0 && len(config.L3VPNs) > 0 {
-		return errors.New("cannot specify L3 VNI configuration and VPN configuration at the same time")
-	}
-
 	if len(config.Underlays) > 1 {
 		return errors.New("multiple underlays defined")
 	}

--- a/internal/conversion/validate_l3vpn.go
+++ b/internal/conversion/validate_l3vpn.go
@@ -11,7 +11,6 @@ import (
 	openpeerrors "github.com/openperouter/openperouter/internal/errors"
 	"github.com/openperouter/openperouter/internal/filter"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 )
 
@@ -38,7 +37,13 @@ func FilterValidL3VPNs(l3vpns []v1alpha1.L3VPN) ([]v1alpha1.L3VPN, error) {
 // FilterUniqueL3VPNs removes L3VPNs with duplicate RD assigned numbers. It returns
 // the filtered L3VPNs as well as a map containing the unique RD assigned numbers
 // and the name of the corresponding L3VPN.
-func FilterUniqueL3VPNs(l3Vpns []v1alpha1.L3VPN) ([]v1alpha1.L3VPN, map[int32]string, error) {
+// L3VPNs that collide with an existing VNI from FilterUniqueL3VNIs are
+// discarded, too.
+func FilterUniqueL3VPNs(l3Vpns []v1alpha1.L3VPN, existingVNIs map[int32]string,
+) ([]v1alpha1.L3VPN, map[int32]string, error) {
+	if existingVNIs == nil {
+		existingVNIs = map[int32]string{}
+	}
 	existingRDAssignedNumber := map[int32]string{}
 	reason := v1alpha1.FailedResourceReasonValidationFailed
 	var allErrors []error
@@ -54,70 +59,21 @@ func FilterUniqueL3VPNs(l3Vpns []v1alpha1.L3VPN) ([]v1alpha1.L3VPN, map[int32]st
 			})
 			continue
 		}
+		if existing, duplicateFound := existingVNIs[l3.Spec.RDAssignedNumber]; duplicateFound {
+			allErrors = append(allErrors, &openpeerrors.ResourceError{
+				Obj: v1alpha1.FailedResource{
+					Kind: "L3VPN", Name: l3.Name, Reason: reason,
+					Message: fmt.Sprintf("duplicate rdAssignedNumber %d cannot be the same as VNI in L3VNI: %s",
+						l3.Spec.RDAssignedNumber, existing),
+				},
+			})
+			continue
+		}
 		existingRDAssignedNumber[l3.Spec.RDAssignedNumber] = "L3VPN/" + l3.Name
 		validL3VPN = append(validL3VPN, l3)
 	}
 
 	return validL3VPN, existingRDAssignedNumber, errors.Join(allErrors...)
-}
-
-// FilterUniqueVRFsForL3VPNs checks VRF uniqueness among L3VPNs and returns the valid
-// L3VPNs alongside per-resource errors for duplicates.
-func FilterUniqueVRFsForL3VPNs(l3vpns []v1alpha1.L3VPN) ([]v1alpha1.L3VPN, error) {
-	reason := v1alpha1.FailedResourceReasonValidationFailed
-	var allErrors []error
-
-	vrfToVPN := map[string]types.NamespacedName{}
-	var valid []v1alpha1.L3VPN
-	for _, l3vpn := range l3vpns {
-		namespaceName := types.NamespacedName{Namespace: l3vpn.Namespace, Name: l3vpn.Name}
-		if existing, duplicateFound := vrfToVPN[l3vpn.Spec.VRF]; duplicateFound {
-			allErrors = append(allErrors, &openpeerrors.ResourceError{
-				Obj: v1alpha1.FailedResource{
-					Kind: "L3VPN", Name: l3vpn.Name, Reason: reason,
-					Message: fmt.Sprintf("more than one L3VPN detected in VRF %q: %q already exists", l3vpn.Spec.VRF, existing),
-				},
-			})
-			continue
-		}
-		vrfToVPN[l3vpn.Spec.VRF] = namespaceName
-		valid = append(valid, l3vpn)
-	}
-
-	return valid, errors.Join(allErrors...)
-}
-
-// DetectMutuallyExclusiveOverlays returns a joined error for each conflicting resource if L3VNIs and L3VPNs
-// coexist.
-// TODO: This is a shortcut. We do not want L3VNIs and L3VPNs coexisting inside the same VRF. But across different
-// VRFs, this should work, in theory, subject to testing, and must be changed in the future.
-func DetectMutuallyExclusiveOverlays(l3vnis []v1alpha1.L3VNI, l3vpns []v1alpha1.L3VPN) error {
-	if len(l3vnis) == 0 || len(l3vpns) == 0 {
-		return nil
-	}
-
-	var errs []error
-	for _, l3vni := range l3vnis {
-		errs = append(errs, &openpeerrors.ResourceError{
-			Obj: v1alpha1.FailedResource{
-				Kind:    v1alpha1.FailedResourceKind("L3VNI"),
-				Name:    l3vni.Name,
-				Reason:  v1alpha1.FailedResourceReasonValidationFailed,
-				Message: "cannot specify L3VNI resources and L3VPN resources at the same time",
-			},
-		})
-	}
-	for _, l3vpn := range l3vpns {
-		errs = append(errs, &openpeerrors.ResourceError{
-			Obj: v1alpha1.FailedResource{
-				Kind:    v1alpha1.FailedResourceKind("L3VPN"),
-				Name:    l3vpn.Name,
-				Reason:  v1alpha1.FailedResourceReasonValidationFailed,
-				Message: "cannot specify L3VPN resources and L3VNI resources at the same time",
-			},
-		})
-	}
-	return errors.Join(errs...)
 }
 
 // ValidateSRv6ForNodes returns an error if, for any node, the L3VPN resources are present without

--- a/internal/conversion/validate_l3vpn.go
+++ b/internal/conversion/validate_l3vpn.go
@@ -38,14 +38,17 @@ func FilterValidL3VPNs(l3vpns []v1alpha1.L3VPN) ([]v1alpha1.L3VPN, error) {
 // FilterUniqueL3VPNs removes L3VPNs with duplicate RD assigned numbers. It returns
 // the filtered L3VPNs as well as a map containing the unique RD assigned numbers
 // and the name of the corresponding L3VPN.
-func FilterUniqueL3VPNs(l3Vpns []v1alpha1.L3VPN) ([]v1alpha1.L3VPN, map[int32]string, error) {
-	existingRDAssignedNumber := map[int32]string{}
+// L3VPNs that collide with an existing VNI from FilterUniqueL3VNIs are
+// discarded, too.
+func FilterUniqueL3VPNs(l3Vpns []v1alpha1.L3VPN, allocatedRDAssignedNumberToOwner map[int32]string,
+) ([]v1alpha1.L3VPN, map[int32]string, error) {
+	allocatedRDAssignedNumberToVPN := map[int32]string{}
 	reason := v1alpha1.FailedResourceReasonValidationFailed
 	var allErrors []error
 
 	var validL3VPN []v1alpha1.L3VPN
 	for _, l3 := range l3Vpns {
-		if existing, duplicateFound := existingRDAssignedNumber[l3.Spec.RDAssignedNumber]; duplicateFound {
+		if existing, duplicateFound := allocatedRDAssignedNumberToVPN[l3.Spec.RDAssignedNumber]; duplicateFound {
 			allErrors = append(allErrors, &openpeerrors.ResourceError{
 				Obj: v1alpha1.FailedResource{
 					Kind: "L3VPN", Name: l3.Name, Reason: reason,
@@ -54,21 +57,32 @@ func FilterUniqueL3VPNs(l3Vpns []v1alpha1.L3VPN) ([]v1alpha1.L3VPN, map[int32]st
 			})
 			continue
 		}
-		existingRDAssignedNumber[l3.Spec.RDAssignedNumber] = "L3VPN/" + l3.Name
+		if vniName, duplicateFound := allocatedRDAssignedNumberToOwner[l3.Spec.RDAssignedNumber]; duplicateFound {
+			allErrors = append(allErrors, &openpeerrors.ResourceError{
+				Obj: v1alpha1.FailedResource{
+					Kind: "L3VPN", Name: l3.Name, Reason: reason,
+					Message: fmt.Sprintf("duplicate rdAssignedNumber %d cannot be the same as VNI in: %s",
+						l3.Spec.RDAssignedNumber, vniName),
+				},
+			})
+			continue
+		}
+		allocatedRDAssignedNumberToVPN[l3.Spec.RDAssignedNumber] = "L3VPN/" + l3.Name
 		validL3VPN = append(validL3VPN, l3)
 	}
 
-	return validL3VPN, existingRDAssignedNumber, errors.Join(allErrors...)
+	return validL3VPN, allocatedRDAssignedNumberToVPN, errors.Join(allErrors...)
 }
 
 // FilterUniqueVRFsForL3VPNs checks VRF uniqueness among L3VPNs and returns the valid
-// L3VPNs alongside per-resource errors for duplicates.
-func FilterUniqueVRFsForL3VPNs(l3vpns []v1alpha1.L3VPN) ([]v1alpha1.L3VPN, error) {
+// L3VPNs alongside per-resource errors for duplicates. It also receives a list of
+// VRF to L3VNI mappings to flag conflicts with those resources.
+func FilterUniqueVRFsForL3VPNs(l3vpns []v1alpha1.L3VPN, vrfToVNI map[string]types.NamespacedName) ([]v1alpha1.L3VPN, error) {
 	reason := v1alpha1.FailedResourceReasonValidationFailed
 	var allErrors []error
 
 	vrfToVPN := map[string]types.NamespacedName{}
-	var valid []v1alpha1.L3VPN
+	var validL3VPNs []v1alpha1.L3VPN
 	for _, l3vpn := range l3vpns {
 		namespaceName := types.NamespacedName{Namespace: l3vpn.Namespace, Name: l3vpn.Name}
 		if existing, duplicateFound := vrfToVPN[l3vpn.Spec.VRF]; duplicateFound {
@@ -80,44 +94,20 @@ func FilterUniqueVRFsForL3VPNs(l3vpns []v1alpha1.L3VPN) ([]v1alpha1.L3VPN, error
 			})
 			continue
 		}
+		if existing, duplicateFound := vrfToVNI[l3vpn.Spec.VRF]; duplicateFound {
+			allErrors = append(allErrors, &openpeerrors.ResourceError{
+				Obj: v1alpha1.FailedResource{
+					Kind: "L3VPN", Name: l3vpn.Name, Reason: reason,
+					Message: fmt.Sprintf("conflict with L3VNI %q detected in VRF %q", existing, l3vpn.Spec.VRF),
+				},
+			})
+			continue
+		}
 		vrfToVPN[l3vpn.Spec.VRF] = namespaceName
-		valid = append(valid, l3vpn)
+		validL3VPNs = append(validL3VPNs, l3vpn)
 	}
 
-	return valid, errors.Join(allErrors...)
-}
-
-// DetectMutuallyExclusiveOverlays returns a joined error for each conflicting resource if L3VNIs and L3VPNs
-// coexist.
-// TODO: This is a shortcut. We do not want L3VNIs and L3VPNs coexisting inside the same VRF. But across different
-// VRFs, this should work, in theory, subject to testing, and must be changed in the future.
-func DetectMutuallyExclusiveOverlays(l3vnis []v1alpha1.L3VNI, l3vpns []v1alpha1.L3VPN) error {
-	if len(l3vnis) == 0 || len(l3vpns) == 0 {
-		return nil
-	}
-
-	var errs []error
-	for _, l3vni := range l3vnis {
-		errs = append(errs, &openpeerrors.ResourceError{
-			Obj: v1alpha1.FailedResource{
-				Kind:    v1alpha1.FailedResourceKind("L3VNI"),
-				Name:    l3vni.Name,
-				Reason:  v1alpha1.FailedResourceReasonValidationFailed,
-				Message: "cannot specify L3VNI resources and L3VPN resources at the same time",
-			},
-		})
-	}
-	for _, l3vpn := range l3vpns {
-		errs = append(errs, &openpeerrors.ResourceError{
-			Obj: v1alpha1.FailedResource{
-				Kind:    v1alpha1.FailedResourceKind("L3VPN"),
-				Name:    l3vpn.Name,
-				Reason:  v1alpha1.FailedResourceReasonValidationFailed,
-				Message: "cannot specify L3VPN resources and L3VNI resources at the same time",
-			},
-		})
-	}
-	return errors.Join(errs...)
+	return validL3VPNs, errors.Join(allErrors...)
 }
 
 // ValidateSRv6ForNodes returns an error if, for any node, the L3VPN resources are present without

--- a/internal/conversion/validate_l3vpn_test.go
+++ b/internal/conversion/validate_l3vpn_test.go
@@ -185,6 +185,7 @@ func TestFilterUniqueL3VPNs(t *testing.T) {
 	tcs := []struct {
 		name      string
 		l3vpns    []v1alpha1.L3VPN
+		vnis      map[int32]string
 		wantValid []v1alpha1.L3VPN
 		wantMap   map[int32]string
 		wantErr   string
@@ -242,11 +243,35 @@ func TestFilterUniqueL3VPNs(t *testing.T) {
 			wantMap: map[int32]string{1001: "L3VPN/vpn1", 1002: "L3VPN/vpn2"},
 			wantErr: "L3VPN/vpn3: duplicate rdAssignedNumber 1001:L3VPN/vpn1",
 		},
+		{
+			name: "conflict with L3VNI",
+			l3vpns: []v1alpha1.L3VPN{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn1"},
+					Spec:       v1alpha1.L3VPNSpec{RDAssignedNumber: 1001, VRF: "vrf1"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn2"},
+					Spec:       v1alpha1.L3VPNSpec{RDAssignedNumber: 1002, VRF: "vrf2"},
+				},
+			},
+			vnis: map[int32]string{
+				1001: "L3VNI/vni1",
+			},
+			wantValid: []v1alpha1.L3VPN{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn2"},
+					Spec:       v1alpha1.L3VPNSpec{RDAssignedNumber: 1002, VRF: "vrf2"},
+				},
+			},
+			wantMap: map[int32]string{1002: "L3VPN/vpn2"},
+			wantErr: "L3VPN/vpn1: duplicate rdAssignedNumber 1001 cannot be the same as VNI in L3VNI: L3VNI/vni1",
+		},
 	}
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			valid, gotMap, err := FilterUniqueL3VPNs(tc.l3vpns)
+			valid, gotMap, err := FilterUniqueL3VPNs(tc.l3vpns, tc.vnis)
 			if diff := cmp.Diff(tc.wantValid, valid); diff != "" {
 				t.Fatalf("valid items mismatch (-want +got):\n%s", diff)
 			}
@@ -265,186 +290,6 @@ func TestFilterUniqueL3VPNs(t *testing.T) {
 			}
 			if err != nil {
 				t.Fatalf("expected no error but got %q", err)
-			}
-		})
-	}
-}
-
-func TestFilterUniqueVRFsForL3VPNs(t *testing.T) {
-	tcs := []struct {
-		name      string
-		l3vpns    []v1alpha1.L3VPN
-		wantValid []v1alpha1.L3VPN
-
-		wantErr string
-	}{
-		{
-			name: "all resources in different VRFs",
-			l3vpns: []v1alpha1.L3VPN{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"},
-					Spec: v1alpha1.L3VPNSpec{
-						RDAssignedNumber: 1001,
-						VRF:              "vrf1",
-						HostSession:      &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
-					},
-					Status: &v1alpha1.L3VPNStatus{},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "vni2", Namespace: "test"},
-					Spec: v1alpha1.L3VPNSpec{
-						RDAssignedNumber: 1002,
-						VRF:              "vrf2",
-						HostSession:      &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
-					},
-					Status: &v1alpha1.L3VPNStatus{},
-				},
-			},
-			wantValid: []v1alpha1.L3VPN{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"},
-					Spec: v1alpha1.L3VPNSpec{
-						RDAssignedNumber: 1001,
-						VRF:              "vrf1",
-						HostSession:      &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
-					},
-					Status: &v1alpha1.L3VPNStatus{},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "vni2", Namespace: "test"},
-					Spec: v1alpha1.L3VPNSpec{
-						RDAssignedNumber: 1002,
-						VRF:              "vrf2",
-						HostSession:      &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
-					},
-					Status: &v1alpha1.L3VPNStatus{},
-				},
-			},
-		},
-		{
-			name: "filters duplicate VRFs",
-			l3vpns: []v1alpha1.L3VPN{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"},
-					Spec: v1alpha1.L3VPNSpec{
-						RDAssignedNumber: 1001,
-						VRF:              "vrf1",
-						HostSession:      &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
-					},
-					Status: &v1alpha1.L3VPNStatus{},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "vni2", Namespace: "test"},
-					Spec: v1alpha1.L3VPNSpec{
-						RDAssignedNumber: 1002,
-						VRF:              "vrf2",
-						HostSession:      &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
-					},
-					Status: &v1alpha1.L3VPNStatus{},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "vni3", Namespace: "test"},
-					Spec: v1alpha1.L3VPNSpec{
-						RDAssignedNumber: 1003,
-						HostSession:      &v1alpha1.HostSession{ASN: 65005, HostASN: new(int64(65006)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.3.0/24")}},
-						VRF:              "vrf1",
-					},
-					Status: &v1alpha1.L3VPNStatus{},
-				},
-			},
-			wantValid: []v1alpha1.L3VPN{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"},
-					Spec: v1alpha1.L3VPNSpec{
-						RDAssignedNumber: 1001,
-						VRF:              "vrf1",
-						HostSession:      &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
-					},
-					Status: &v1alpha1.L3VPNStatus{},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "vni2", Namespace: "test"},
-					Spec: v1alpha1.L3VPNSpec{
-						RDAssignedNumber: 1002,
-						VRF:              "vrf2",
-						HostSession:      &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
-					},
-					Status: &v1alpha1.L3VPNStatus{},
-				},
-			},
-
-			wantErr: "L3VPN/vni3: more than one L3VPN detected in VRF \"vrf1\": \"test/vni1\" already exists",
-		},
-	}
-
-	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			valid, err := FilterUniqueVRFsForL3VPNs(tc.l3vpns)
-			if diff := cmp.Diff(tc.wantValid, valid); diff != "" {
-				t.Fatalf("valid items mismatch (-want +got):\n%s", diff)
-			}
-
-			if tc.wantErr != "" {
-				if err == nil {
-					t.Fatalf("expected error %q but got nil", tc.wantErr)
-				}
-				if !strings.Contains(err.Error(), tc.wantErr) {
-					t.Errorf("got error = %q, but want error %q", err, tc.wantErr)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("expected no error but got error %q", err)
-			}
-		})
-	}
-}
-
-func TestDetectMutuallyExclusiveOverlays(t *testing.T) {
-	tcs := []struct {
-		name     string
-		l3vnis   []v1alpha1.L3VNI
-		l3vpns   []v1alpha1.L3VPN
-		wantErrs []string
-	}{
-		{
-			name: "both empty",
-		},
-		{
-			name:   "only L3VNIs",
-			l3vnis: []v1alpha1.L3VNI{{ObjectMeta: metav1.ObjectMeta{Name: "vni1"}}},
-		},
-		{
-			name:   "only L3VPNs",
-			l3vpns: []v1alpha1.L3VPN{{ObjectMeta: metav1.ObjectMeta{Name: "vpn1"}}},
-		},
-		{
-			name:   "both present",
-			l3vnis: []v1alpha1.L3VNI{{ObjectMeta: metav1.ObjectMeta{Name: "vni1"}}},
-			l3vpns: []v1alpha1.L3VPN{{ObjectMeta: metav1.ObjectMeta{Name: "vpn1"}}},
-			wantErrs: []string{
-				"L3VNI/vni1: cannot specify L3VNI resources and L3VPN resources at the same time",
-				"L3VPN/vpn1: cannot specify L3VPN resources and L3VNI resources at the same time",
-			},
-		},
-	}
-
-	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			err := DetectMutuallyExclusiveOverlays(tc.l3vnis, tc.l3vpns)
-			if len(tc.wantErrs) == 0 {
-				if err != nil {
-					t.Fatalf("expected no error but got %q", err)
-				}
-				return
-			}
-			if err == nil {
-				t.Fatalf("expected error but got nil")
-			}
-			for _, wantErr := range tc.wantErrs {
-				if !strings.Contains(err.Error(), wantErr) {
-					t.Errorf("got error = %q, want it to contain %q", err, wantErr)
-				}
 			}
 		})
 	}

--- a/internal/conversion/validate_l3vpn_test.go
+++ b/internal/conversion/validate_l3vpn_test.go
@@ -185,6 +185,7 @@ func TestFilterUniqueL3VPNs(t *testing.T) {
 	tcs := []struct {
 		name      string
 		l3vpns    []v1alpha1.L3VPN
+		vnis      map[int32]string
 		wantValid []v1alpha1.L3VPN
 		wantMap   map[int32]string
 		wantErr   string
@@ -242,11 +243,35 @@ func TestFilterUniqueL3VPNs(t *testing.T) {
 			wantMap: map[int32]string{1001: "L3VPN/vpn1", 1002: "L3VPN/vpn2"},
 			wantErr: "L3VPN/vpn3: duplicate rdAssignedNumber 1001:L3VPN/vpn1",
 		},
+		{
+			name: "conflict with L3VNI",
+			l3vpns: []v1alpha1.L3VPN{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn1"},
+					Spec:       v1alpha1.L3VPNSpec{RDAssignedNumber: 1001, VRF: "vrf1"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn2"},
+					Spec:       v1alpha1.L3VPNSpec{RDAssignedNumber: 1002, VRF: "vrf2"},
+				},
+			},
+			vnis: map[int32]string{
+				1001: "L3VNI/vni1",
+			},
+			wantValid: []v1alpha1.L3VPN{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn2"},
+					Spec:       v1alpha1.L3VPNSpec{RDAssignedNumber: 1002, VRF: "vrf2"},
+				},
+			},
+			wantMap: map[int32]string{1002: "L3VPN/vpn2"},
+			wantErr: "L3VPN/vpn1: duplicate rdAssignedNumber 1001 cannot be the same as VNI in: L3VNI/vni1",
+		},
 	}
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			valid, gotMap, err := FilterUniqueL3VPNs(tc.l3vpns)
+			valid, gotMap, err := FilterUniqueL3VPNs(tc.l3vpns, tc.vnis)
 			if diff := cmp.Diff(tc.wantValid, valid); diff != "" {
 				t.Fatalf("valid items mismatch (-want +got):\n%s", diff)
 			}
@@ -265,186 +290,6 @@ func TestFilterUniqueL3VPNs(t *testing.T) {
 			}
 			if err != nil {
 				t.Fatalf("expected no error but got %q", err)
-			}
-		})
-	}
-}
-
-func TestFilterUniqueVRFsForL3VPNs(t *testing.T) {
-	tcs := []struct {
-		name      string
-		l3vpns    []v1alpha1.L3VPN
-		wantValid []v1alpha1.L3VPN
-
-		wantErr string
-	}{
-		{
-			name: "all resources in different VRFs",
-			l3vpns: []v1alpha1.L3VPN{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"},
-					Spec: v1alpha1.L3VPNSpec{
-						RDAssignedNumber: 1001,
-						VRF:              "vrf1",
-						HostSession:      &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
-					},
-					Status: &v1alpha1.L3VPNStatus{},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "vni2", Namespace: "test"},
-					Spec: v1alpha1.L3VPNSpec{
-						RDAssignedNumber: 1002,
-						VRF:              "vrf2",
-						HostSession:      &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
-					},
-					Status: &v1alpha1.L3VPNStatus{},
-				},
-			},
-			wantValid: []v1alpha1.L3VPN{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"},
-					Spec: v1alpha1.L3VPNSpec{
-						RDAssignedNumber: 1001,
-						VRF:              "vrf1",
-						HostSession:      &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
-					},
-					Status: &v1alpha1.L3VPNStatus{},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "vni2", Namespace: "test"},
-					Spec: v1alpha1.L3VPNSpec{
-						RDAssignedNumber: 1002,
-						VRF:              "vrf2",
-						HostSession:      &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
-					},
-					Status: &v1alpha1.L3VPNStatus{},
-				},
-			},
-		},
-		{
-			name: "filters duplicate VRFs",
-			l3vpns: []v1alpha1.L3VPN{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"},
-					Spec: v1alpha1.L3VPNSpec{
-						RDAssignedNumber: 1001,
-						VRF:              "vrf1",
-						HostSession:      &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
-					},
-					Status: &v1alpha1.L3VPNStatus{},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "vni2", Namespace: "test"},
-					Spec: v1alpha1.L3VPNSpec{
-						RDAssignedNumber: 1002,
-						VRF:              "vrf2",
-						HostSession:      &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
-					},
-					Status: &v1alpha1.L3VPNStatus{},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "vni3", Namespace: "test"},
-					Spec: v1alpha1.L3VPNSpec{
-						RDAssignedNumber: 1003,
-						HostSession:      &v1alpha1.HostSession{ASN: 65005, HostASN: new(int64(65006)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.3.0/24")}},
-						VRF:              "vrf1",
-					},
-					Status: &v1alpha1.L3VPNStatus{},
-				},
-			},
-			wantValid: []v1alpha1.L3VPN{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"},
-					Spec: v1alpha1.L3VPNSpec{
-						RDAssignedNumber: 1001,
-						VRF:              "vrf1",
-						HostSession:      &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
-					},
-					Status: &v1alpha1.L3VPNStatus{},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "vni2", Namespace: "test"},
-					Spec: v1alpha1.L3VPNSpec{
-						RDAssignedNumber: 1002,
-						VRF:              "vrf2",
-						HostSession:      &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
-					},
-					Status: &v1alpha1.L3VPNStatus{},
-				},
-			},
-
-			wantErr: "L3VPN/vni3: more than one L3VPN detected in VRF \"vrf1\": \"test/vni1\" already exists",
-		},
-	}
-
-	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			valid, err := FilterUniqueVRFsForL3VPNs(tc.l3vpns)
-			if diff := cmp.Diff(tc.wantValid, valid); diff != "" {
-				t.Fatalf("valid items mismatch (-want +got):\n%s", diff)
-			}
-
-			if tc.wantErr != "" {
-				if err == nil {
-					t.Fatalf("expected error %q but got nil", tc.wantErr)
-				}
-				if !strings.Contains(err.Error(), tc.wantErr) {
-					t.Errorf("got error = %q, but want error %q", err, tc.wantErr)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("expected no error but got error %q", err)
-			}
-		})
-	}
-}
-
-func TestDetectMutuallyExclusiveOverlays(t *testing.T) {
-	tcs := []struct {
-		name     string
-		l3vnis   []v1alpha1.L3VNI
-		l3vpns   []v1alpha1.L3VPN
-		wantErrs []string
-	}{
-		{
-			name: "both empty",
-		},
-		{
-			name:   "only L3VNIs",
-			l3vnis: []v1alpha1.L3VNI{{ObjectMeta: metav1.ObjectMeta{Name: "vni1"}}},
-		},
-		{
-			name:   "only L3VPNs",
-			l3vpns: []v1alpha1.L3VPN{{ObjectMeta: metav1.ObjectMeta{Name: "vpn1"}}},
-		},
-		{
-			name:   "both present",
-			l3vnis: []v1alpha1.L3VNI{{ObjectMeta: metav1.ObjectMeta{Name: "vni1"}}},
-			l3vpns: []v1alpha1.L3VPN{{ObjectMeta: metav1.ObjectMeta{Name: "vpn1"}}},
-			wantErrs: []string{
-				"L3VNI/vni1: cannot specify L3VNI resources and L3VPN resources at the same time",
-				"L3VPN/vpn1: cannot specify L3VPN resources and L3VNI resources at the same time",
-			},
-		},
-	}
-
-	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			err := DetectMutuallyExclusiveOverlays(tc.l3vnis, tc.l3vpns)
-			if len(tc.wantErrs) == 0 {
-				if err != nil {
-					t.Fatalf("expected no error but got %q", err)
-				}
-				return
-			}
-			if err == nil {
-				t.Fatalf("expected error but got nil")
-			}
-			for _, wantErr := range tc.wantErrs {
-				if !strings.Contains(err.Error(), wantErr) {
-					t.Errorf("got error = %q, want it to contain %q", err, wantErr)
-				}
 			}
 		})
 	}

--- a/internal/conversion/validate_vni.go
+++ b/internal/conversion/validate_vni.go
@@ -201,10 +201,11 @@ func validateOverlayResourcesForNode(node corev1.Node, l2vnis []v1alpha1.L2VNI, 
 	}
 
 	var rdAssignedNumbers map[int32]string
-	validL3VPNs, rdAssignedNumbers, err = FilterUniqueL3VPNs(validL3VPNs)
+	validL3VPNs, rdAssignedNumbers, err = FilterUniqueL3VPNs(validL3VPNs, vnis)
 	if err != nil {
 		return fmt.Errorf("duplicate L3VPNs found for node %q: %w", node.Name, err)
 	}
+	// The following action is safe: vnis and rdAssignedNumbers are guaranteed to have unique indexes.
 	maps.Copy(vnis, rdAssignedNumbers)
 
 	validL2VNIs, err = FilterUniqueL2VNIs(validL2VNIs, vnis)
@@ -212,14 +213,9 @@ func validateOverlayResourcesForNode(node corev1.Node, l2vnis []v1alpha1.L2VNI, 
 		return fmt.Errorf("duplicate VNIs found in L2VNIs for node %q: %w", node.Name, err)
 	}
 
-	validL3VNIs, err = FilterUniqueVRFsForL3VNIs(validL3VNIs)
+	validL3VNIs, validL3VPNs, err = FilterUniqueVRFs(validL3VNIs, validL3VPNs)
 	if err != nil {
-		return fmt.Errorf("duplicate L3VNI VRFs found for node %q: %w", node.Name, err)
-	}
-
-	validL3VPNs, err = FilterUniqueVRFsForL3VPNs(validL3VPNs)
-	if err != nil {
-		return fmt.Errorf("duplicate L3VPN VRFs found for node %q: %w", node.Name, err)
+		return fmt.Errorf("duplicate L3 resources found in VRFs for node %q: %w", node.Name, err)
 	}
 
 	_, _, _, err = FilterValidVRFSubnets(validL3VNIs, validL3VPNs, validL2VNIs)
@@ -228,33 +224,6 @@ func validateOverlayResourcesForNode(node corev1.Node, l2vnis []v1alpha1.L2VNI, 
 	}
 
 	return nil
-}
-
-// FilterUniqueVRFsForL3VNIs checks VRF uniqueness among L3VNIs and returns the valid
-// L3VNIs alongside per-resource errors for duplicates.
-func FilterUniqueVRFsForL3VNIs(l3Vnis []v1alpha1.L3VNI) ([]v1alpha1.L3VNI, error) {
-	reason := v1alpha1.FailedResourceReasonValidationFailed
-	var allErrors []error
-
-	vrfToVNI := map[string]types.NamespacedName{}
-	var valid []v1alpha1.L3VNI
-	for _, l3Vni := range l3Vnis {
-		namespaceName := types.NamespacedName{Namespace: l3Vni.Namespace, Name: l3Vni.Name}
-		existing, ok := vrfToVNI[l3Vni.Spec.VRF]
-		if ok {
-			allErrors = append(allErrors, &openpeerrors.ResourceError{
-				Obj: v1alpha1.FailedResource{
-					Kind: "L3VNI", Name: l3Vni.Name, Reason: reason,
-					Message: fmt.Sprintf("more than one L3VNI detected in VRF %q: %q already exists", l3Vni.Spec.VRF, existing),
-				},
-			})
-			continue
-		}
-		vrfToVNI[l3Vni.Spec.VRF] = namespaceName
-		valid = append(valid, l3Vni)
-	}
-
-	return valid, errors.Join(allErrors...)
 }
 
 // FilterValidVRFSubnets checks for subnet overlaps per VRF and returns valid

--- a/internal/conversion/validate_vni.go
+++ b/internal/conversion/validate_vni.go
@@ -86,7 +86,8 @@ func FilterValidL2VNIs(l2Vnis []v1alpha1.L2VNI) ([]v1alpha1.L2VNI, error) {
 }
 
 // FilterUniqueL3VNIs removes L3VNIs with duplicate VNI numbers. It returns
-// the filtered L3VNIs as well as a map containing the unique VNI numbers and the
+// the filtered L3VNIs as well as a map containing the unique VNI numbers
+// (which is also the allocated Route Distinguisher Assigned Number) and the
 // name of the corresponding L3VNI.
 func FilterUniqueL3VNIs(l3Vnis []v1alpha1.L3VNI) ([]v1alpha1.L3VNI, map[int32]string, error) {
 	existingVNIs := map[int32]string{}
@@ -95,7 +96,7 @@ func FilterUniqueL3VNIs(l3Vnis []v1alpha1.L3VNI) ([]v1alpha1.L3VNI, map[int32]st
 
 	var validL3VNI []v1alpha1.L3VNI
 	for _, l3 := range l3Vnis {
-		if existing, ok := existingVNIs[l3.Spec.VNI]; ok {
+		if existing, duplicateFound := existingVNIs[l3.Spec.VNI]; duplicateFound {
 			allErrors = append(allErrors, &openpeerrors.ResourceError{
 				Obj: v1alpha1.FailedResource{
 					Kind: "L3VNI", Name: l3.Name, Reason: reason,
@@ -112,14 +113,18 @@ func FilterUniqueL3VNIs(l3Vnis []v1alpha1.L3VNI) ([]v1alpha1.L3VNI, map[int32]st
 }
 
 // FilterUniqueL2VNIs removes L2VNIs with duplicate VNI numbers.
-// L2VNIs that collide with an existing VNI or RDAssignedNumber are discarded.
-func FilterUniqueL2VNIs(l2Vnis []v1alpha1.L2VNI, existingVNIs map[int32]string) ([]v1alpha1.L2VNI, error) {
+// L2VNIs that collide with an existing L3VNI or L3VPN Route Distinguisher
+// AssignedNumber are discarded.
+func FilterUniqueL2VNIs(
+	l2Vnis []v1alpha1.L2VNI,
+	allocatedRDAssignedNumberToOwner map[int32]string,
+) ([]v1alpha1.L2VNI, error) {
 	reason := v1alpha1.FailedResourceReasonValidationFailed
 	var allErrors []error
 
 	var validL2 []v1alpha1.L2VNI
 	for _, l2 := range l2Vnis {
-		if existing, ok := existingVNIs[l2.Spec.VNI]; ok {
+		if existing, duplicateFound := allocatedRDAssignedNumberToOwner[l2.Spec.VNI]; duplicateFound {
 			allErrors = append(allErrors, &openpeerrors.ResourceError{
 				Obj: v1alpha1.FailedResource{
 					Kind: "L2VNI", Name: l2.Name, Reason: reason,
@@ -128,7 +133,7 @@ func FilterUniqueL2VNIs(l2Vnis []v1alpha1.L2VNI, existingVNIs map[int32]string) 
 			})
 			continue
 		}
-		existingVNIs[l2.Spec.VNI] = "L2VNI/" + l2.Name
+		allocatedRDAssignedNumberToOwner[l2.Spec.VNI] = "L2VNI/" + l2.Name
 		validL2 = append(validL2, l2)
 	}
 
@@ -194,32 +199,33 @@ func validateOverlayResourcesForNode(node corev1.Node, l2vnis []v1alpha1.L2VNI, 
 		return fmt.Errorf("failed to validate l2vnis for node %q: %w", node.Name, err)
 	}
 
-	var vnis map[int32]string
-	validL3VNIs, vnis, err = FilterUniqueL3VNIs(validL3VNIs)
+	var allocatedRDAssignedNumberToOwner map[int32]string
+	validL3VNIs, allocatedRDAssignedNumberToOwner, err = FilterUniqueL3VNIs(validL3VNIs)
 	if err != nil {
 		return fmt.Errorf("duplicate L3VNIs found for node %q: %w", node.Name, err)
 	}
 
-	var rdAssignedNumbers map[int32]string
-	validL3VPNs, rdAssignedNumbers, err = FilterUniqueL3VPNs(validL3VPNs)
+	var allocatedRDAssignedNumberToVPN map[int32]string
+	validL3VPNs, allocatedRDAssignedNumberToVPN, err = FilterUniqueL3VPNs(validL3VPNs, allocatedRDAssignedNumberToOwner)
 	if err != nil {
 		return fmt.Errorf("duplicate L3VPNs found for node %q: %w", node.Name, err)
 	}
-	maps.Copy(vnis, rdAssignedNumbers)
+	maps.Copy(allocatedRDAssignedNumberToOwner, allocatedRDAssignedNumberToVPN)
 
-	validL2VNIs, err = FilterUniqueL2VNIs(validL2VNIs, vnis)
+	validL2VNIs, err = FilterUniqueL2VNIs(validL2VNIs, allocatedRDAssignedNumberToOwner)
 	if err != nil {
 		return fmt.Errorf("duplicate VNIs found in L2VNIs for node %q: %w", node.Name, err)
 	}
 
-	validL3VNIs, err = FilterUniqueVRFsForL3VNIs(validL3VNIs)
+	var vrfToVNI map[string]types.NamespacedName
+	validL3VNIs, vrfToVNI, err = FilterUniqueVRFsForL3VNIs(validL3VNIs)
 	if err != nil {
-		return fmt.Errorf("duplicate L3VNI VRFs found for node %q: %w", node.Name, err)
+		return fmt.Errorf("duplicate L3VNIs found in VRFs for node %q: %w", node.Name, err)
 	}
 
-	validL3VPNs, err = FilterUniqueVRFsForL3VPNs(validL3VPNs)
+	validL3VPNs, err = FilterUniqueVRFsForL3VPNs(validL3VPNs, vrfToVNI)
 	if err != nil {
-		return fmt.Errorf("duplicate L3VPN VRFs found for node %q: %w", node.Name, err)
+		return fmt.Errorf("duplicate L3VPNs found in VRFs for node %q: %w", node.Name, err)
 	}
 
 	_, _, _, err = FilterValidVRFSubnets(validL3VNIs, validL3VPNs, validL2VNIs)
@@ -231,30 +237,30 @@ func validateOverlayResourcesForNode(node corev1.Node, l2vnis []v1alpha1.L2VNI, 
 }
 
 // FilterUniqueVRFsForL3VNIs checks VRF uniqueness among L3VNIs and returns the valid
-// L3VNIs alongside per-resource errors for duplicates.
-func FilterUniqueVRFsForL3VNIs(l3Vnis []v1alpha1.L3VNI) ([]v1alpha1.L3VNI, error) {
+// L3VNIs alongside per-resource errors for duplicates. Collects and returns
+// VRFs used by L3VNIs for duplicate detection by FilterUniqueVRFsForL3VPNs.
+func FilterUniqueVRFsForL3VNIs(l3vnis []v1alpha1.L3VNI) ([]v1alpha1.L3VNI, map[string]types.NamespacedName, error) {
 	reason := v1alpha1.FailedResourceReasonValidationFailed
 	var allErrors []error
 
 	vrfToVNI := map[string]types.NamespacedName{}
-	var valid []v1alpha1.L3VNI
-	for _, l3Vni := range l3Vnis {
-		namespaceName := types.NamespacedName{Namespace: l3Vni.Namespace, Name: l3Vni.Name}
-		existing, ok := vrfToVNI[l3Vni.Spec.VRF]
-		if ok {
+	var validL3VNIs []v1alpha1.L3VNI
+	for _, l3vni := range l3vnis {
+		namespaceName := types.NamespacedName{Namespace: l3vni.Namespace, Name: l3vni.Name}
+		if existing, duplicateFound := vrfToVNI[l3vni.Spec.VRF]; duplicateFound {
 			allErrors = append(allErrors, &openpeerrors.ResourceError{
 				Obj: v1alpha1.FailedResource{
-					Kind: "L3VNI", Name: l3Vni.Name, Reason: reason,
-					Message: fmt.Sprintf("more than one L3VNI detected in VRF %q: %q already exists", l3Vni.Spec.VRF, existing),
+					Kind: "L3VNI", Name: l3vni.Name, Reason: reason,
+					Message: fmt.Sprintf("more than one L3VNI detected in VRF %q: %q already exists", l3vni.Spec.VRF, existing),
 				},
 			})
 			continue
 		}
-		vrfToVNI[l3Vni.Spec.VRF] = namespaceName
-		valid = append(valid, l3Vni)
+		vrfToVNI[l3vni.Spec.VRF] = namespaceName
+		validL3VNIs = append(validL3VNIs, l3vni)
 	}
 
-	return valid, errors.Join(allErrors...)
+	return validL3VNIs, vrfToVNI, errors.Join(allErrors...)
 }
 
 // FilterValidVRFSubnets checks for subnet overlaps per VRF and returns valid

--- a/internal/conversion/validate_vni_l3vpn.go
+++ b/internal/conversion/validate_vni_l3vpn.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package conversion
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/openperouter/openperouter/api/v1alpha1"
+	openpeerrors "github.com/openperouter/openperouter/internal/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// FilterUniqueVRFs checks VRF uniqueness among L3VNIs and L3VPNs and returns the valid
+// L3VNIs and L3VPNs alongside per-resource errors for duplicates. L3VNIs are processed
+// first, meaning that in case of VRF duplicates between L3VNIs and L3VPNs, the corresponding
+// L3VPNs will report an error.
+func FilterUniqueVRFs(l3vnis []v1alpha1.L3VNI, l3vpns []v1alpha1.L3VPN) ([]v1alpha1.L3VNI, []v1alpha1.L3VPN, error) {
+	reason := v1alpha1.FailedResourceReasonValidationFailed
+	var allErrors []error
+
+	vrfToVNI := map[string]types.NamespacedName{}
+	var validL3VNIs []v1alpha1.L3VNI
+	for _, l3vni := range l3vnis {
+		namespaceName := types.NamespacedName{Namespace: l3vni.Namespace, Name: l3vni.Name}
+		if existing, duplicateFound := vrfToVNI[l3vni.Spec.VRF]; duplicateFound {
+			allErrors = append(allErrors, &openpeerrors.ResourceError{
+				Obj: v1alpha1.FailedResource{
+					Kind: "L3VNI", Name: l3vni.Name, Reason: reason,
+					Message: fmt.Sprintf("more than one L3VNI detected in VRF %q: %q already exists", l3vni.Spec.VRF, existing),
+				},
+			})
+			continue
+		}
+		vrfToVNI[l3vni.Spec.VRF] = namespaceName
+		validL3VNIs = append(validL3VNIs, l3vni)
+	}
+
+	vrfToVPN := map[string]types.NamespacedName{}
+	var validL3VPNs []v1alpha1.L3VPN
+	for _, l3vpn := range l3vpns {
+		namespaceName := types.NamespacedName{Namespace: l3vpn.Namespace, Name: l3vpn.Name}
+		if existing, duplicateFound := vrfToVPN[l3vpn.Spec.VRF]; duplicateFound {
+			allErrors = append(allErrors, &openpeerrors.ResourceError{
+				Obj: v1alpha1.FailedResource{
+					Kind: "L3VPN", Name: l3vpn.Name, Reason: reason,
+					Message: fmt.Sprintf("more than one L3VPN detected in VRF %q: %q already exists", l3vpn.Spec.VRF, existing),
+				},
+			})
+			continue
+		}
+		if existing, duplicateFound := vrfToVNI[l3vpn.Spec.VRF]; duplicateFound {
+			allErrors = append(allErrors, &openpeerrors.ResourceError{
+				Obj: v1alpha1.FailedResource{
+					Kind: "L3VPN", Name: l3vpn.Name, Reason: reason,
+					Message: fmt.Sprintf("conflict with L3VNI detected in VRF %q: %q already exists", l3vpn.Spec.VRF, existing),
+				},
+			})
+			continue
+		}
+		vrfToVPN[l3vpn.Spec.VRF] = namespaceName
+		validL3VPNs = append(validL3VPNs, l3vpn)
+	}
+
+	return validL3VNIs, validL3VPNs, errors.Join(allErrors...)
+}

--- a/internal/conversion/validate_vni_l3vpn_test.go
+++ b/internal/conversion/validate_vni_l3vpn_test.go
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package conversion
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openperouter/openperouter/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestFilterUniqueVRFs(t *testing.T) {
+	tcs := []struct {
+		name     string
+		l3vnis   []v1alpha1.L3VNI
+		l3vpns   []v1alpha1.L3VPN
+		wantVNIs []v1alpha1.L3VNI
+		wantVPNs []v1alpha1.L3VPN
+		wantErrs []string
+	}{
+		{
+			name: "all L3VNIs in different VRFs",
+			l3vnis: []v1alpha1.L3VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"},
+					Spec: v1alpha1.L3VNISpec{
+						VNI:         1001,
+						VRF:         "vrf1",
+						HostSession: &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
+					},
+					Status: &v1alpha1.L3VNIStatus{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni2", Namespace: "test"},
+					Spec: v1alpha1.L3VNISpec{
+						VNI:         1002,
+						VRF:         "vrf2",
+						HostSession: &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
+					},
+					Status: &v1alpha1.L3VNIStatus{},
+				},
+			},
+			wantVNIs: []v1alpha1.L3VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"},
+					Spec: v1alpha1.L3VNISpec{
+						VNI:         1001,
+						VRF:         "vrf1",
+						HostSession: &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
+					},
+					Status: &v1alpha1.L3VNIStatus{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni2", Namespace: "test"},
+					Spec: v1alpha1.L3VNISpec{
+						VNI:         1002,
+						VRF:         "vrf2",
+						HostSession: &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
+					},
+					Status: &v1alpha1.L3VNIStatus{},
+				},
+			},
+		},
+		{
+			name: "duplicate VRF across L3VNIs",
+			l3vnis: []v1alpha1.L3VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"},
+					Spec: v1alpha1.L3VNISpec{
+						VNI:         1001,
+						VRF:         "vrf1",
+						HostSession: &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
+					},
+					Status: &v1alpha1.L3VNIStatus{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni2", Namespace: "test"},
+					Spec: v1alpha1.L3VNISpec{
+						VNI:         1002,
+						VRF:         "vrf1",
+						HostSession: &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
+					},
+					Status: &v1alpha1.L3VNIStatus{},
+				},
+			},
+			wantVNIs: []v1alpha1.L3VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"},
+					Spec: v1alpha1.L3VNISpec{
+						VNI:         1001,
+						VRF:         "vrf1",
+						HostSession: &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
+					},
+					Status: &v1alpha1.L3VNIStatus{},
+				},
+			},
+			wantErrs: []string{
+				`L3VNI/vni2: more than one L3VNI detected in VRF "vrf1": "test/vni1" already exists`,
+			},
+		},
+		{
+			name: "all L3VPNs in different VRFs",
+			l3vpns: []v1alpha1.L3VPN{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn1", Namespace: "test"},
+					Spec: v1alpha1.L3VPNSpec{
+						RDAssignedNumber: 1001,
+						VRF:              "vrf1",
+						HostSession:      &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
+					},
+					Status: &v1alpha1.L3VPNStatus{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn2", Namespace: "test"},
+					Spec: v1alpha1.L3VPNSpec{
+						RDAssignedNumber: 1002,
+						VRF:              "vrf2",
+						HostSession:      &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
+					},
+					Status: &v1alpha1.L3VPNStatus{},
+				},
+			},
+			wantVPNs: []v1alpha1.L3VPN{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn1", Namespace: "test"},
+					Spec: v1alpha1.L3VPNSpec{
+						RDAssignedNumber: 1001,
+						VRF:              "vrf1",
+						HostSession:      &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
+					},
+					Status: &v1alpha1.L3VPNStatus{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn2", Namespace: "test"},
+					Spec: v1alpha1.L3VPNSpec{
+						RDAssignedNumber: 1002,
+						VRF:              "vrf2",
+						HostSession:      &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
+					},
+					Status: &v1alpha1.L3VPNStatus{},
+				},
+			},
+		},
+		{
+			name: "duplicate VRF across L3VPNs",
+			l3vpns: []v1alpha1.L3VPN{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn1", Namespace: "test"},
+					Spec: v1alpha1.L3VPNSpec{
+						RDAssignedNumber: 1001,
+						VRF:              "vrf1",
+						HostSession:      &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
+					},
+					Status: &v1alpha1.L3VPNStatus{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn2", Namespace: "test"},
+					Spec: v1alpha1.L3VPNSpec{
+						RDAssignedNumber: 1002,
+						VRF:              "vrf2",
+						HostSession:      &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
+					},
+					Status: &v1alpha1.L3VPNStatus{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn3", Namespace: "test"},
+					Spec: v1alpha1.L3VPNSpec{
+						RDAssignedNumber: 1003,
+						VRF:              "vrf1",
+						HostSession:      &v1alpha1.HostSession{ASN: 65005, HostASN: new(int64(65006)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.3.0/24")}},
+					},
+					Status: &v1alpha1.L3VPNStatus{},
+				},
+			},
+			wantVPNs: []v1alpha1.L3VPN{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn1", Namespace: "test"},
+					Spec: v1alpha1.L3VPNSpec{
+						RDAssignedNumber: 1001,
+						VRF:              "vrf1",
+						HostSession:      &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
+					},
+					Status: &v1alpha1.L3VPNStatus{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn2", Namespace: "test"},
+					Spec: v1alpha1.L3VPNSpec{
+						RDAssignedNumber: 1002,
+						VRF:              "vrf2",
+						HostSession:      &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
+					},
+					Status: &v1alpha1.L3VPNStatus{},
+				},
+			},
+			wantErrs: []string{
+				`L3VPN/vpn3: more than one L3VPN detected in VRF "vrf1": "test/vpn1" already exists`,
+			},
+		},
+		{
+			name: "both empty",
+		},
+		{
+			name: "L3VNI and L3VPN in same VRF",
+			l3vnis: []v1alpha1.L3VNI{
+				{ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"}, Spec: v1alpha1.L3VNISpec{VRF: "red"}},
+			},
+			l3vpns: []v1alpha1.L3VPN{
+				{ObjectMeta: metav1.ObjectMeta{Name: "vpn1", Namespace: "test"}, Spec: v1alpha1.L3VPNSpec{VRF: "red"}},
+			},
+			wantVNIs: []v1alpha1.L3VNI{
+				{ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"}, Spec: v1alpha1.L3VNISpec{VRF: "red"}},
+			},
+			wantErrs: []string{
+				`L3VPN/vpn1: conflict with L3VNI detected in VRF "red": "test/vni1" already exists`,
+			},
+		},
+		{
+			name: "L3VNI and L3VPN in different VRFs",
+			l3vnis: []v1alpha1.L3VNI{
+				{ObjectMeta: metav1.ObjectMeta{Name: "vni1"}, Spec: v1alpha1.L3VNISpec{VRF: "red"}},
+			},
+			l3vpns: []v1alpha1.L3VPN{
+				{ObjectMeta: metav1.ObjectMeta{Name: "vpn1"}, Spec: v1alpha1.L3VPNSpec{VRF: "blue"}},
+			},
+			wantVNIs: []v1alpha1.L3VNI{
+				{ObjectMeta: metav1.ObjectMeta{Name: "vni1"}, Spec: v1alpha1.L3VNISpec{VRF: "red"}},
+			},
+			wantVPNs: []v1alpha1.L3VPN{
+				{ObjectMeta: metav1.ObjectMeta{Name: "vpn1"}, Spec: v1alpha1.L3VPNSpec{VRF: "blue"}},
+			},
+		},
+		{
+			name: "mixed: one conflicting VRF and one non-conflicting",
+			l3vnis: []v1alpha1.L3VNI{
+				{ObjectMeta: metav1.ObjectMeta{Name: "vni-green", Namespace: "test"}, Spec: v1alpha1.L3VNISpec{VRF: "green"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "vni-red", Namespace: "test"}, Spec: v1alpha1.L3VNISpec{VRF: "red"}},
+			},
+			l3vpns: []v1alpha1.L3VPN{
+				{ObjectMeta: metav1.ObjectMeta{Name: "vpn-blue", Namespace: "test"}, Spec: v1alpha1.L3VPNSpec{VRF: "blue"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "vpn-red", Namespace: "test"}, Spec: v1alpha1.L3VPNSpec{VRF: "red"}},
+			},
+			wantVNIs: []v1alpha1.L3VNI{
+				{ObjectMeta: metav1.ObjectMeta{Name: "vni-green", Namespace: "test"}, Spec: v1alpha1.L3VNISpec{VRF: "green"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "vni-red", Namespace: "test"}, Spec: v1alpha1.L3VNISpec{VRF: "red"}},
+			},
+			wantVPNs: []v1alpha1.L3VPN{
+				{ObjectMeta: metav1.ObjectMeta{Name: "vpn-blue", Namespace: "test"}, Spec: v1alpha1.L3VPNSpec{VRF: "blue"}},
+			},
+			wantErrs: []string{
+				`L3VPN/vpn-red: conflict with L3VNI detected in VRF "red": "test/vni-red" already exists`,
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			gotVNIs, gotVPNs, err := FilterUniqueVRFs(tc.l3vnis, tc.l3vpns)
+			if diff := cmp.Diff(tc.wantVNIs, gotVNIs); diff != "" {
+				t.Errorf("L3VNIs mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantVPNs, gotVPNs); diff != "" {
+				t.Errorf("L3VPNs mismatch (-want +got):\n%s", diff)
+			}
+
+			if len(tc.wantErrs) == 0 && err != nil {
+				t.Fatalf("expected no error but got %q", err)
+			}
+			if len(tc.wantErrs) == 0 {
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("got nil but expected errors: %+v", tc.wantErrs)
+			}
+			for _, wantErr := range tc.wantErrs {
+				if !strings.Contains(err.Error(), wantErr) {
+					t.Errorf("got error = %q, want it to contain %q", err, wantErr)
+				}
+			}
+		})
+	}
+}

--- a/internal/conversion/validate_vni_l3vpn_test.go
+++ b/internal/conversion/validate_vni_l3vpn_test.go
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package conversion
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openperouter/openperouter/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestFilterUniqueVRFs(t *testing.T) {
+	tcs := []struct {
+		name     string
+		l3vnis   []v1alpha1.L3VNI
+		l3vpns   []v1alpha1.L3VPN
+		wantVNIs []v1alpha1.L3VNI
+		wantVPNs []v1alpha1.L3VPN
+		wantErrs []string
+	}{
+		{
+			name: "all L3VNIs in different VRFs",
+			l3vnis: []v1alpha1.L3VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"},
+					Spec: v1alpha1.L3VNISpec{
+						VNI:         1001,
+						VRF:         "vrf1",
+						HostSession: &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
+					},
+					Status: &v1alpha1.L3VNIStatus{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni2", Namespace: "test"},
+					Spec: v1alpha1.L3VNISpec{
+						VNI:         1002,
+						VRF:         "vrf2",
+						HostSession: &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
+					},
+					Status: &v1alpha1.L3VNIStatus{},
+				},
+			},
+			wantVNIs: []v1alpha1.L3VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"},
+					Spec: v1alpha1.L3VNISpec{
+						VNI:         1001,
+						VRF:         "vrf1",
+						HostSession: &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
+					},
+					Status: &v1alpha1.L3VNIStatus{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni2", Namespace: "test"},
+					Spec: v1alpha1.L3VNISpec{
+						VNI:         1002,
+						VRF:         "vrf2",
+						HostSession: &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
+					},
+					Status: &v1alpha1.L3VNIStatus{},
+				},
+			},
+		},
+		{
+			name: "duplicate VRF across L3VNIs",
+			l3vnis: []v1alpha1.L3VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"},
+					Spec: v1alpha1.L3VNISpec{
+						VNI:         1001,
+						VRF:         "vrf1",
+						HostSession: &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
+					},
+					Status: &v1alpha1.L3VNIStatus{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni2", Namespace: "test"},
+					Spec: v1alpha1.L3VNISpec{
+						VNI:         1002,
+						VRF:         "vrf1",
+						HostSession: &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
+					},
+					Status: &v1alpha1.L3VNIStatus{},
+				},
+			},
+			wantVNIs: []v1alpha1.L3VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"},
+					Spec: v1alpha1.L3VNISpec{
+						VNI:         1001,
+						VRF:         "vrf1",
+						HostSession: &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
+					},
+					Status: &v1alpha1.L3VNIStatus{},
+				},
+			},
+			wantErrs: []string{
+				`L3VNI/vni2: more than one L3VNI detected in VRF "vrf1": "test/vni1" already exists`,
+			},
+		},
+		{
+			name: "all L3VPNs in different VRFs",
+			l3vpns: []v1alpha1.L3VPN{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn1", Namespace: "test"},
+					Spec: v1alpha1.L3VPNSpec{
+						RDAssignedNumber: 1001,
+						VRF:              "vrf1",
+						HostSession:      &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
+					},
+					Status: &v1alpha1.L3VPNStatus{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn2", Namespace: "test"},
+					Spec: v1alpha1.L3VPNSpec{
+						RDAssignedNumber: 1002,
+						VRF:              "vrf2",
+						HostSession:      &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
+					},
+					Status: &v1alpha1.L3VPNStatus{},
+				},
+			},
+			wantVPNs: []v1alpha1.L3VPN{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn1", Namespace: "test"},
+					Spec: v1alpha1.L3VPNSpec{
+						RDAssignedNumber: 1001,
+						VRF:              "vrf1",
+						HostSession:      &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
+					},
+					Status: &v1alpha1.L3VPNStatus{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn2", Namespace: "test"},
+					Spec: v1alpha1.L3VPNSpec{
+						RDAssignedNumber: 1002,
+						VRF:              "vrf2",
+						HostSession:      &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
+					},
+					Status: &v1alpha1.L3VPNStatus{},
+				},
+			},
+		},
+		{
+			name: "duplicate VRF across L3VPNs",
+			l3vpns: []v1alpha1.L3VPN{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn1", Namespace: "test"},
+					Spec: v1alpha1.L3VPNSpec{
+						RDAssignedNumber: 1001,
+						VRF:              "vrf1",
+						HostSession:      &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
+					},
+					Status: &v1alpha1.L3VPNStatus{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn2", Namespace: "test"},
+					Spec: v1alpha1.L3VPNSpec{
+						RDAssignedNumber: 1002,
+						VRF:              "vrf2",
+						HostSession:      &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
+					},
+					Status: &v1alpha1.L3VPNStatus{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn3", Namespace: "test"},
+					Spec: v1alpha1.L3VPNSpec{
+						RDAssignedNumber: 1003,
+						VRF:              "vrf1",
+						HostSession:      &v1alpha1.HostSession{ASN: 65005, HostASN: new(int64(65006)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.3.0/24")}},
+					},
+					Status: &v1alpha1.L3VPNStatus{},
+				},
+			},
+			wantVPNs: []v1alpha1.L3VPN{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn1", Namespace: "test"},
+					Spec: v1alpha1.L3VPNSpec{
+						RDAssignedNumber: 1001,
+						VRF:              "vrf1",
+						HostSession:      &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
+					},
+					Status: &v1alpha1.L3VPNStatus{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn2", Namespace: "test"},
+					Spec: v1alpha1.L3VPNSpec{
+						RDAssignedNumber: 1002,
+						VRF:              "vrf2",
+						HostSession:      &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
+					},
+					Status: &v1alpha1.L3VPNStatus{},
+				},
+			},
+			wantErrs: []string{
+				`L3VPN/vpn3: more than one L3VPN detected in VRF "vrf1": "test/vpn1" already exists`,
+			},
+		},
+		{
+			name: "both empty",
+		},
+		{
+			name: "L3VNI and L3VPN in same VRF",
+			l3vnis: []v1alpha1.L3VNI{
+				{ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"}, Spec: v1alpha1.L3VNISpec{VRF: "red"}},
+			},
+			l3vpns: []v1alpha1.L3VPN{
+				{ObjectMeta: metav1.ObjectMeta{Name: "vpn1", Namespace: "test"}, Spec: v1alpha1.L3VPNSpec{VRF: "red"}},
+			},
+			wantVNIs: []v1alpha1.L3VNI{
+				{ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"}, Spec: v1alpha1.L3VNISpec{VRF: "red"}},
+			},
+			wantErrs: []string{
+				`L3VPN/vpn1: conflict with L3VNI "test/vni1" detected in VRF "red"`,
+			},
+		},
+		{
+			name: "L3VNI and L3VPN in different VRFs",
+			l3vnis: []v1alpha1.L3VNI{
+				{ObjectMeta: metav1.ObjectMeta{Name: "vni1"}, Spec: v1alpha1.L3VNISpec{VRF: "red"}},
+			},
+			l3vpns: []v1alpha1.L3VPN{
+				{ObjectMeta: metav1.ObjectMeta{Name: "vpn1"}, Spec: v1alpha1.L3VPNSpec{VRF: "blue"}},
+			},
+			wantVNIs: []v1alpha1.L3VNI{
+				{ObjectMeta: metav1.ObjectMeta{Name: "vni1"}, Spec: v1alpha1.L3VNISpec{VRF: "red"}},
+			},
+			wantVPNs: []v1alpha1.L3VPN{
+				{ObjectMeta: metav1.ObjectMeta{Name: "vpn1"}, Spec: v1alpha1.L3VPNSpec{VRF: "blue"}},
+			},
+		},
+		{
+			name: "mixed: one conflicting VRF and one non-conflicting",
+			l3vnis: []v1alpha1.L3VNI{
+				{ObjectMeta: metav1.ObjectMeta{Name: "vni-green", Namespace: "test"}, Spec: v1alpha1.L3VNISpec{VRF: "green"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "vni-red", Namespace: "test"}, Spec: v1alpha1.L3VNISpec{VRF: "red"}},
+			},
+			l3vpns: []v1alpha1.L3VPN{
+				{ObjectMeta: metav1.ObjectMeta{Name: "vpn-blue", Namespace: "test"}, Spec: v1alpha1.L3VPNSpec{VRF: "blue"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "vpn-red", Namespace: "test"}, Spec: v1alpha1.L3VPNSpec{VRF: "red"}},
+			},
+			wantVNIs: []v1alpha1.L3VNI{
+				{ObjectMeta: metav1.ObjectMeta{Name: "vni-green", Namespace: "test"}, Spec: v1alpha1.L3VNISpec{VRF: "green"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "vni-red", Namespace: "test"}, Spec: v1alpha1.L3VNISpec{VRF: "red"}},
+			},
+			wantVPNs: []v1alpha1.L3VPN{
+				{ObjectMeta: metav1.ObjectMeta{Name: "vpn-blue", Namespace: "test"}, Spec: v1alpha1.L3VPNSpec{VRF: "blue"}},
+			},
+			wantErrs: []string{
+				`L3VPN/vpn-red: conflict with L3VNI "test/vni-red" detected in VRF "red"`,
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			var vrfToVNI map[string]types.NamespacedName
+
+			resourceErrors := make([]error, 0, 2)
+			gotVNIs, vrfToVNI, err := FilterUniqueVRFsForL3VNIs(tc.l3vnis)
+			resourceErrors = append(resourceErrors, err)
+
+			gotVPNs, err := FilterUniqueVRFsForL3VPNs(tc.l3vpns, vrfToVNI)
+			resourceErrors = append(resourceErrors, err)
+			if diff := cmp.Diff(tc.wantVNIs, gotVNIs); diff != "" {
+				t.Errorf("L3VNIs mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantVPNs, gotVPNs); diff != "" {
+				t.Errorf("L3VPNs mismatch (-want +got):\n%s", diff)
+			}
+
+			err = errors.Join(resourceErrors...)
+			if len(tc.wantErrs) == 0 && err != nil {
+				t.Fatalf("expected no error but got %q", err)
+			}
+			if len(tc.wantErrs) == 0 {
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("got nil but expected errors: %+v", tc.wantErrs)
+			}
+			for _, wantErr := range tc.wantErrs {
+				if !strings.Contains(err.Error(), wantErr) {
+					t.Errorf("got error = %q, want it to contain %q", err, wantErr)
+				}
+			}
+		})
+	}
+}

--- a/internal/conversion/validate_vni_test.go
+++ b/internal/conversion/validate_vni_test.go
@@ -837,41 +837,6 @@ func TestFilterValidVRFSubnets(t *testing.T) {
 	}
 }
 
-func TestFilterUniqueVRFs_DuplicateVRF(t *testing.T) {
-	l3vnis := []v1alpha1.L3VNI{
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"},
-			Spec: v1alpha1.L3VNISpec{
-				VNI:         1001,
-				VRF:         "vni1",
-				HostSession: &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
-			},
-			Status: &v1alpha1.L3VNIStatus{},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: "vni2", Namespace: "test"},
-			Spec: v1alpha1.L3VNISpec{
-				VNI:         1002,
-				HostSession: &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
-				VRF:         "vni1",
-			},
-			Status: &v1alpha1.L3VNIStatus{},
-		},
-	}
-
-	valid, err := FilterUniqueVRFsForL3VNIs(l3vnis)
-	if err == nil {
-		t.Fatal("expected error for duplicate VRF")
-	}
-	wantErr := "more than one L3VNI detected in VRF \"vni1\": \"test/vni1\" already exists"
-	if !strings.Contains(err.Error(), wantErr) {
-		t.Errorf("error = %q, want %q", err, wantErr)
-	}
-	if len(valid) != 1 || valid[0].Name != "vni1" {
-		t.Errorf("expected first L3VNI to be valid, got %v", valid)
-	}
-}
-
 func TestValidateOverlayResourcesForNodes(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -1134,7 +1099,7 @@ func TestValidateOverlayResourcesForNodes(t *testing.T) {
 					Spec:       v1alpha1.L3VNISpec{VNI: 200, VRF: "red"},
 				},
 			},
-			wantErrStr: "duplicate L3VNI VRFs found for node \"node1\": " +
+			wantErrStr: "duplicate L3 resources found in VRFs for node \"node1\": " +
 				"L3VNI/l3vni2: " +
 				"more than one L3VNI detected in VRF \"red\": " +
 				"\"test/l3vni1\" already exists",
@@ -1160,10 +1125,46 @@ func TestValidateOverlayResourcesForNodes(t *testing.T) {
 					},
 				},
 			},
-			wantErrStr: "duplicate L3VPN VRFs found for node \"node1\": " +
+			wantErrStr: "duplicate L3 resources found in VRFs for node \"node1\": " +
 				"L3VPN/vpn2: " +
 				"more than one L3VPN detected in VRF \"red\": " +
 				"\"test/vpn1\" already exists",
+		},
+		{
+			name:  "duplicate VRF across L3VNIs + L3VPNs",
+			nodes: []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}},
+			l3vnis: []v1alpha1.L3VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "l3vni1", Namespace: "test"},
+					Spec:       v1alpha1.L3VNISpec{VNI: 100, VRF: "red"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "l3vni2", Namespace: "test"},
+					Spec:       v1alpha1.L3VNISpec{VNI: 200, VRF: "red"},
+				},
+			},
+			l3vpns: []v1alpha1.L3VPN{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn1", Namespace: "test"},
+					Spec: v1alpha1.L3VPNSpec{
+						RDAssignedNumber: 101,
+						VRF:              "red",
+						ImportRTs:        []v1alpha1.RouteTarget{"65000:100"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn2", Namespace: "test"},
+					Spec: v1alpha1.L3VPNSpec{
+						RDAssignedNumber: 201,
+						VRF:              "red",
+						ImportRTs:        []v1alpha1.RouteTarget{"65000:200"},
+					},
+				},
+			},
+			wantErrStr: "duplicate L3 resources found in VRFs for node \"node1\": " +
+				"L3VNI/l3vni2: more than one L3VNI detected in VRF \"red\": \"test/l3vni1\" already exists\n" +
+				"L3VPN/vpn1: conflict with L3VNI detected in VRF \"red\": \"test/l3vni1\" already exists\n" +
+				"L3VPN/vpn2: conflict with L3VNI detected in VRF \"red\": \"test/l3vni1\" already exists",
 		},
 		{
 			name:  "subnet overlap between L3VNI and L2VNI in same VRF",

--- a/internal/conversion/validate_vni_test.go
+++ b/internal/conversion/validate_vni_test.go
@@ -837,41 +837,6 @@ func TestFilterValidVRFSubnets(t *testing.T) {
 	}
 }
 
-func TestFilterUniqueVRFs_DuplicateVRF(t *testing.T) {
-	l3vnis := []v1alpha1.L3VNI{
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: "vni1", Namespace: "test"},
-			Spec: v1alpha1.L3VNISpec{
-				VNI:         1001,
-				VRF:         "vni1",
-				HostSession: &v1alpha1.HostSession{ASN: 65001, HostASN: new(int64(65002)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.1.0/24")}},
-			},
-			Status: &v1alpha1.L3VNIStatus{},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: "vni2", Namespace: "test"},
-			Spec: v1alpha1.L3VNISpec{
-				VNI:         1002,
-				HostSession: &v1alpha1.HostSession{ASN: 65003, HostASN: new(int64(65004)), LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.168.2.0/24")}},
-				VRF:         "vni1",
-			},
-			Status: &v1alpha1.L3VNIStatus{},
-		},
-	}
-
-	valid, err := FilterUniqueVRFsForL3VNIs(l3vnis)
-	if err == nil {
-		t.Fatal("expected error for duplicate VRF")
-	}
-	wantErr := "more than one L3VNI detected in VRF \"vni1\": \"test/vni1\" already exists"
-	if !strings.Contains(err.Error(), wantErr) {
-		t.Errorf("error = %q, want %q", err, wantErr)
-	}
-	if len(valid) != 1 || valid[0].Name != "vni1" {
-		t.Errorf("expected first L3VNI to be valid, got %v", valid)
-	}
-}
-
 func TestValidateOverlayResourcesForNodes(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -1134,7 +1099,7 @@ func TestValidateOverlayResourcesForNodes(t *testing.T) {
 					Spec:       v1alpha1.L3VNISpec{VNI: 200, VRF: "red"},
 				},
 			},
-			wantErrStr: "duplicate L3VNI VRFs found for node \"node1\": " +
+			wantErrStr: "duplicate L3VNIs found in VRFs for node \"node1\": " +
 				"L3VNI/l3vni2: " +
 				"more than one L3VNI detected in VRF \"red\": " +
 				"\"test/l3vni1\" already exists",
@@ -1160,10 +1125,75 @@ func TestValidateOverlayResourcesForNodes(t *testing.T) {
 					},
 				},
 			},
-			wantErrStr: "duplicate L3VPN VRFs found for node \"node1\": " +
+			wantErrStr: "duplicate L3VPNs found in VRFs for node \"node1\": " +
 				"L3VPN/vpn2: " +
 				"more than one L3VPN detected in VRF \"red\": " +
 				"\"test/vpn1\" already exists",
+		},
+		{
+			name:  "duplicate VRF across L3VNI + L3VPNs",
+			nodes: []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}},
+			l3vnis: []v1alpha1.L3VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "l3vni1", Namespace: "test"},
+					Spec:       v1alpha1.L3VNISpec{VNI: 100, VRF: "red"},
+				},
+			},
+			l3vpns: []v1alpha1.L3VPN{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn1", Namespace: "test"},
+					Spec: v1alpha1.L3VPNSpec{
+						RDAssignedNumber: 101,
+						VRF:              "red",
+						ImportRTs:        []v1alpha1.RouteTarget{"65000:100"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn2", Namespace: "test"},
+					Spec: v1alpha1.L3VPNSpec{
+						RDAssignedNumber: 201,
+						VRF:              "red",
+						ImportRTs:        []v1alpha1.RouteTarget{"65000:200"},
+					},
+				},
+			},
+			wantErrStr: "duplicate L3VPNs found in VRFs for node \"node1\": " +
+				"L3VPN/vpn1: conflict with L3VNI \"test/l3vni1\" detected in VRF \"red\"\n" +
+				"L3VPN/vpn2: conflict with L3VNI \"test/l3vni1\" detected in VRF \"red\"",
+		},
+		{
+			name:  "duplicate VRF across L3VNIs + L3VPNs",
+			nodes: []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}},
+			l3vnis: []v1alpha1.L3VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "l3vni1", Namespace: "test"},
+					Spec:       v1alpha1.L3VNISpec{VNI: 100, VRF: "red"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "l3vni2", Namespace: "test"},
+					Spec:       v1alpha1.L3VNISpec{VNI: 200, VRF: "red"},
+				},
+			},
+			l3vpns: []v1alpha1.L3VPN{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn1", Namespace: "test"},
+					Spec: v1alpha1.L3VPNSpec{
+						RDAssignedNumber: 101,
+						VRF:              "red",
+						ImportRTs:        []v1alpha1.RouteTarget{"65000:100"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vpn2", Namespace: "test"},
+					Spec: v1alpha1.L3VPNSpec{
+						RDAssignedNumber: 201,
+						VRF:              "red",
+						ImportRTs:        []v1alpha1.RouteTarget{"65000:200"},
+					},
+				},
+			},
+			wantErrStr: "duplicate L3VNIs found in VRFs for node \"node1\": " +
+				"L3VNI/l3vni2: more than one L3VNI detected in VRF \"red\": \"test/l3vni1\" already exists",
 		},
 		{
 			name:  "subnet overlap between L3VNI and L2VNI in same VRF",

--- a/internal/webhooks/l3vni_webhook.go
+++ b/internal/webhooks/l3vni_webhook.go
@@ -94,10 +94,15 @@ func validateL3VNICreate(l3vni *v1alpha1.L3VNI) error {
 	if err != nil {
 		return err
 	}
-	if len(existingL3VPNs.Items) > 0 {
-		return fmt.Errorf("cannot create L3VNI %s/%s when L3VPNs already exist",
-			l3vni.GetNamespace(), l3vni.GetName(),
-		)
+	for _, vpn := range existingL3VPNs.Items {
+		if vpn.Spec.VRF == l3vni.Spec.VRF {
+			return fmt.Errorf(
+				"cannot create L3VNI %s/%s: VRF %q is already used by L3VPN %s/%s",
+				l3vni.GetNamespace(), l3vni.GetName(),
+				l3vni.Spec.VRF,
+				vpn.GetNamespace(), vpn.GetName(),
+			)
+		}
 	}
 
 	return validateL3VNI(l3vni)

--- a/internal/webhooks/l3vni_webhook.go
+++ b/internal/webhooks/l3vni_webhook.go
@@ -90,16 +90,6 @@ func validateL3VNICreate(l3vni *v1alpha1.L3VNI) error {
 	Logger.Debug("webhook l3vni", "action", "create", "name", l3vni.Name, "namespace", l3vni.Namespace)
 	defer Logger.Debug("webhook l3vni", "action", "end create", "name", l3vni.Name, "namespace", l3vni.Namespace)
 
-	existingL3VPNs, err := getL3VPNs()
-	if err != nil {
-		return err
-	}
-	if len(existingL3VPNs.Items) > 0 {
-		return fmt.Errorf("cannot create L3VNI %s/%s when L3VPNs already exist",
-			l3vni.GetNamespace(), l3vni.GetName(),
-		)
-	}
-
 	return validateL3VNI(l3vni)
 }
 
@@ -155,7 +145,17 @@ func validateL3VNI(l3vni *v1alpha1.L3VNI) error {
 		return err
 	}
 
-	if err := conversion.ValidateOverlayResourcesForNodes(nodeList.Items, toValidateL2.Items, toValidate, nil); err != nil {
+	l3vpnList, err := getL3VPNs()
+	if err != nil {
+		return err
+	}
+
+	if err := conversion.ValidateOverlayResourcesForNodes(
+		nodeList.Items,
+		toValidateL2.Items,
+		toValidate,
+		l3vpnList.Items,
+	); err != nil {
 		return fmt.Errorf("validation failed: %w", err)
 	}
 

--- a/internal/webhooks/l3vni_webhook_test.go
+++ b/internal/webhooks/l3vni_webhook_test.go
@@ -166,7 +166,7 @@ func TestValidateL3VNICreate(t *testing.T) {
 			errorString: "more than one L3VNI detected in VRF",
 		},
 		{
-			name: "testing L3VNIs and L3VPNs are mutually exclusive",
+			name: "testing L3VNIs and L3VPNs are mutually exclusive per VRF",
 			nodes: []*v1.Node{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -184,7 +184,7 @@ func TestValidateL3VNICreate(t *testing.T) {
 						Name:      "existingL3VPN",
 					},
 					Spec: v1alpha1.L3VPNSpec{
-						VRF: "0123456789abcdefghijkl",
+						VRF: "vrfa",
 						HostSession: &v1alpha1.HostSession{
 							LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.0.4.0/24")},
 						},
@@ -213,7 +213,41 @@ func TestValidateL3VNICreate(t *testing.T) {
 					},
 				},
 			},
-			errorString: "cannot create L3VNI default/newL3VNI when L3VPNs already exist",
+			errorString: `cannot create L3VNI default/newL3VNI: VRF "vrfa" is already used by L3VPN default/existingL3VPN`,
+		},
+		{
+			name: "L3VNI allowed when L3VPN exists in a different VRF",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			l3vpns: []*v1alpha1.L3VPN{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "existingL3VPN",
+					},
+					Spec: v1alpha1.L3VPNSpec{
+						VRF: "vrfa",
+					},
+				},
+			},
+			newL3VNI: &v1alpha1.L3VNI{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newL3VNI",
+				},
+				Spec: v1alpha1.L3VNISpec{
+					VRF: "vrfb",
+					VNI: 100,
+				},
+			},
 		},
 	}
 	for _, tc := range tcs {

--- a/internal/webhooks/l3vni_webhook_test.go
+++ b/internal/webhooks/l3vni_webhook_test.go
@@ -166,7 +166,7 @@ func TestValidateL3VNICreate(t *testing.T) {
 			errorString: "more than one L3VNI detected in VRF",
 		},
 		{
-			name: "testing L3VNIs and L3VPNs are mutually exclusive",
+			name: "testing L3VNIs and L3VPNs are mutually exclusive per VRF",
 			nodes: []*v1.Node{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -184,7 +184,9 @@ func TestValidateL3VNICreate(t *testing.T) {
 						Name:      "existingL3VPN",
 					},
 					Spec: v1alpha1.L3VPNSpec{
-						VRF: "0123456789abcdefghijkl",
+						VRF:              "vrfa",
+						RDAssignedNumber: 200,
+						ImportRTs:        []v1alpha1.RouteTarget{"65000:200"},
 						HostSession: &v1alpha1.HostSession{
 							LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.0.4.0/24")},
 						},
@@ -213,7 +215,43 @@ func TestValidateL3VNICreate(t *testing.T) {
 					},
 				},
 			},
-			errorString: "cannot create L3VNI default/newL3VNI when L3VPNs already exist",
+			errorString: `L3VPN/existingL3VPN: conflict with L3VNI "default/newL3VNI" detected in VRF "vrfa"`,
+		},
+		{
+			name: "L3VNI allowed when L3VPN exists in a different VRF",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			l3vpns: []*v1alpha1.L3VPN{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "existingL3VPN",
+					},
+					Spec: v1alpha1.L3VPNSpec{
+						VRF:              "vrfa",
+						RDAssignedNumber: 200,
+						ImportRTs:        []v1alpha1.RouteTarget{"65000:200"},
+					},
+				},
+			},
+			newL3VNI: &v1alpha1.L3VNI{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newL3VNI",
+				},
+				Spec: v1alpha1.L3VNISpec{
+					VRF: "vrfb",
+					VNI: 100,
+				},
+			},
 		},
 	}
 	for _, tc := range tcs {

--- a/internal/webhooks/l3vpn_webhook.go
+++ b/internal/webhooks/l3vpn_webhook.go
@@ -88,10 +88,15 @@ func validateL3VPNCreate(l3vpn *v1alpha1.L3VPN) error {
 	if err != nil {
 		return err
 	}
-	if len(existingL3VNIs.Items) > 0 {
-		return fmt.Errorf("cannot create L3VPN %s/%s when L3VNIs already exist",
-			l3vpn.GetNamespace(), l3vpn.GetName(),
-		)
+	for _, vni := range existingL3VNIs.Items {
+		if vni.Spec.VRF == l3vpn.Spec.VRF {
+			return fmt.Errorf(
+				"cannot create L3VPN %s/%s: VRF %q is already used by L3VNI %s/%s",
+				l3vpn.GetNamespace(), l3vpn.GetName(),
+				l3vpn.Spec.VRF,
+				vni.GetNamespace(), vni.GetName(),
+			)
+		}
 	}
 
 	return validateL3VPN(l3vpn)

--- a/internal/webhooks/l3vpn_webhook.go
+++ b/internal/webhooks/l3vpn_webhook.go
@@ -84,16 +84,6 @@ func validateL3VPNCreate(l3vpn *v1alpha1.L3VPN) error {
 	Logger.Debug("webhook l3vpn", "action", "create", "name", l3vpn.Name, "namespace", l3vpn.Namespace)
 	defer Logger.Debug("webhook l3vpn", "action", "end create", "name", l3vpn.Name, "namespace", l3vpn.Namespace)
 
-	existingL3VNIs, err := getL3VNIs()
-	if err != nil {
-		return err
-	}
-	if len(existingL3VNIs.Items) > 0 {
-		return fmt.Errorf("cannot create L3VPN %s/%s when L3VNIs already exist",
-			l3vpn.GetNamespace(), l3vpn.GetName(),
-		)
-	}
-
 	return validateL3VPN(l3vpn)
 }
 
@@ -152,8 +142,17 @@ func validateL3VPN(l3vpn *v1alpha1.L3VPN) error {
 		return fmt.Errorf("validation failed: %w", err)
 	}
 
-	if err := conversion.ValidateOverlayResourcesForNodes(nodeList.Items, l2vniList.Items, nil,
-		toValidate); err != nil {
+	l3vniList, err := getL3VNIs()
+	if err != nil {
+		return err
+	}
+
+	if err := conversion.ValidateOverlayResourcesForNodes(
+		nodeList.Items,
+		l2vniList.Items,
+		l3vniList.Items,
+		toValidate,
+	); err != nil {
 		return fmt.Errorf("validation failed: %w", err)
 	}
 

--- a/internal/webhooks/l3vpn_webhook_test.go
+++ b/internal/webhooks/l3vpn_webhook_test.go
@@ -204,7 +204,7 @@ func TestValidateL3VPNCreate(t *testing.T) {
 				"underlay with SRV6 configuration",
 		},
 		{
-			name: "testing L3VNIs and L3VPNs are mutually exclusive",
+			name: "testing L3VNIs and L3VPNs are mutually exclusive per VRF",
 			nodes: []*v1.Node{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -240,7 +240,9 @@ func TestValidateL3VPNCreate(t *testing.T) {
 					Name:      "newL3VPN",
 				},
 				Spec: v1alpha1.L3VPNSpec{
-					VRF: "0123456789abcdefghijkl",
+					VRF:              "vrfa",
+					RDAssignedNumber: 200,
+					ImportRTs:        []v1alpha1.RouteTarget{"65000:200"},
 					HostSession: &v1alpha1.HostSession{
 						LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.0.4.0/24")},
 					},
@@ -251,7 +253,57 @@ func TestValidateL3VPNCreate(t *testing.T) {
 					},
 				},
 			},
-			errorString: "cannot create L3VPN default/newL3VPN when L3VNIs already exist",
+			errorString: `cannot create L3VPN default/newL3VPN: VRF "vrfa" is already used by L3VNI default/existingL3VNI`,
+		},
+		{
+			name: "L3VPN allowed when L3VNI exists in a different VRF",
+			underlays: []*v1alpha1.Underlay{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "underlay1",
+					},
+					Spec: v1alpha1.UnderlaySpec{
+						SRV6: &v1alpha1.SRV6Config{},
+					},
+				},
+			},
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			l3vnis: []*v1alpha1.L3VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "existingL3VNI",
+					},
+					Spec: v1alpha1.L3VNISpec{
+						VRF: "vrfa",
+					},
+				},
+			},
+			newL3VPN: &v1alpha1.L3VPN{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newL3VPN",
+				},
+				Spec: v1alpha1.L3VPNSpec{
+					VRF:              "vrfb",
+					RDAssignedNumber: 200,
+					ImportRTs:        []v1alpha1.RouteTarget{"65000:200"},
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
 		},
 	}
 	for _, tc := range tcs {

--- a/internal/webhooks/l3vpn_webhook_test.go
+++ b/internal/webhooks/l3vpn_webhook_test.go
@@ -204,7 +204,17 @@ func TestValidateL3VPNCreate(t *testing.T) {
 				"underlay with SRV6 configuration",
 		},
 		{
-			name: "testing L3VNIs and L3VPNs are mutually exclusive",
+			name: "testing L3VNIs and L3VPNs are mutually exclusive per VRF",
+			underlays: []*v1alpha1.Underlay{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "underlay1",
+					},
+					Spec: v1alpha1.UnderlaySpec{
+						SRV6: &v1alpha1.SRV6Config{},
+					},
+				},
+			},
 			nodes: []*v1.Node{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -240,7 +250,9 @@ func TestValidateL3VPNCreate(t *testing.T) {
 					Name:      "newL3VPN",
 				},
 				Spec: v1alpha1.L3VPNSpec{
-					VRF: "0123456789abcdefghijkl",
+					VRF:              "vrfa",
+					RDAssignedNumber: 200,
+					ImportRTs:        []v1alpha1.RouteTarget{"65000:200"},
 					HostSession: &v1alpha1.HostSession{
 						LocalCIDR: v1alpha1.LocalCIDRConfig{IPv4: new("192.0.4.0/24")},
 					},
@@ -251,7 +263,57 @@ func TestValidateL3VPNCreate(t *testing.T) {
 					},
 				},
 			},
-			errorString: "cannot create L3VPN default/newL3VPN when L3VNIs already exist",
+			errorString: `L3VPN/newL3VPN: conflict with L3VNI "default/existingL3VNI" detected in VRF "vrfa"`,
+		},
+		{
+			name: "L3VPN allowed when L3VNI exists in a different VRF",
+			underlays: []*v1alpha1.Underlay{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "underlay1",
+					},
+					Spec: v1alpha1.UnderlaySpec{
+						SRV6: &v1alpha1.SRV6Config{},
+					},
+				},
+			},
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
+			l3vnis: []*v1alpha1.L3VNI{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "existingL3VNI",
+					},
+					Spec: v1alpha1.L3VNISpec{
+						VRF: "vrfa",
+					},
+				},
+			},
+			newL3VPN: &v1alpha1.L3VPN{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "newL3VPN",
+				},
+				Spec: v1alpha1.L3VPNSpec{
+					VRF:              "vrfb",
+					RDAssignedNumber: 200,
+					ImportRTs:        []v1alpha1.RouteTarget{"65000:200"},
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"nodeName": "node1",
+						},
+					},
+				},
+			},
 		},
 	}
 	for _, tc := range tcs {

--- a/website/content/docs/configuration/srv6.md
+++ b/website/content/docs/configuration/srv6.md
@@ -255,14 +255,17 @@ spec:
 
 ## Validation Rules
 
-- L3VPNs and L3VNIs **cannot coexist**. Use L3VPNs for
-  SRv6 and L3VNIs for EVPN.
+- L3VPNs and L3VNIs **cannot coexist in the same VRF**.
 - L3VPNs **require** an Underlay with SRv6 configuration on every node
   where they are applied.
 - SRv6 **requires** IS-IS to be configured on the Underlay.
 - SRv6 **requires** at least one IPv6 CIDR in `tunnelEndpoint.cidrs`.
 - L3VPN VRF names must be unique across all L3VPNs on a node.
 - L3VPN `rdAssignedNumber` values must be unique across all L3VPNs.
+- L3VPN `rdAssignedNumber` values **must not overlap** with any L3VNI
+  `vni` value, regardless of the VRF. Depending on the configuration,
+  both values may be used as part of the route distinguisher and route
+  target, so overlaps could cause routing conflicts.
 
 ## Per-Node Configuration
 


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind feature

**What this PR does / why we need it**:

- **feat(srv6): support L3VNI and L3VPN in different VRFs**
- **feat(srv6): update doc for L3VNI/L3VPN mixed VRF support**
- **feat(srv6): add E2E test for mixed L3VPN and L3VNI setups**

**Special notes for your reviewer**:

**Release note**:

```release-note
The OpenPERouter now supports setups with both L3VPNs and L3VNIs across different VRFs.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * L3VPNs and L3VNIs can now coexist when configured in different VRFs.
  * Added support for mixed L3VPN/L3VNI connectivity scenarios, including east-west and north-south traffic validation.

* **Bug Fixes**
  * Prevented conflicting resources in the same VRF.
  * Added validation to prevent overlapping route distinguisher and VNI values.

* **Documentation**
  * Updated SRv6 configuration guidance to reflect the revised coexistence and uniqueness rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->