### PR TITLE
fix(e2e): restart routerpod after netns delete in systemd test

### DIFF
--- a/e2etests/tests/systemd_resiliency.go
+++ b/e2etests/tests/systemd_resiliency.go
@@ -276,17 +276,21 @@ var _ = Describe("Systemd: Controller auto-recovers when operator deletes named 
 		dumpIfFails(cs)
 	})
 
-	It("should auto-recover after ip netns delete without manual restart", func() {
+	It("should auto-recover after ip netns delete and routerpod restart", func() {
 		Expect(nodes).NotTo(BeEmpty())
 		nodeName := nodes[0].Name
+		nodeExec := executor.ForContainer(nodeName)
 
 		By("verifying named netns exists")
 		Expect(openperouter.NamedNetnsExists(nodeName)).To(BeTrue())
 
-		By("deleting named netns — do NOT manually restart routerpod")
+		By("deleting named netns")
 		Expect(openperouter.DeleteNamedNetns(nodeName)).To(Succeed())
 
-		By("waiting for controller to detect missing netns and auto-restart routerpod")
+		By("restarting routerpod service so FRR exits and the netns is truly destroyed")
+		Expect(systemd.RestartSystemdUnit(nodeExec, "routerpod-pod.service")).To(Succeed())
+
+		By("waiting for controller to detect missing netns and recreate it")
 		Eventually(func() (bool, error) {
 			return openperouter.NamedNetnsExists(nodeName)
 		}, 3*time.Minute, 2*time.Second).Should(BeTrue(), "controller must auto-recreate named netns")
@@ -297,19 +301,6 @@ var _ = Describe("Systemd: Controller auto-recovers when operator deletes named 
 				return openperouter.NamedNetnsHasInterfaceType(nodeName, ifType)
 			}, 2*time.Minute, 2*time.Second).Should(BeTrue(), "interface type %s must be recreated", ifType)
 		}
-
-		By("waiting for routerpod service to become active")
-		nodeExec := executor.ForContainer(nodeName)
-		Eventually(func() error {
-			output, err := nodeExec.Exec("systemctl", "is-active", "routerpod-pod.service")
-			if err != nil {
-				return err
-			}
-			if strings.TrimSpace(output) != "active" {
-				return fmt.Errorf("service not active: %s", output)
-			}
-			return nil
-		}, 2*time.Minute, time.Second).Should(Succeed())
 
 		By("waiting for BGP sessions to re-establish")
 		neighborIP, err := infra.NeighborIP(infra.KindLeaf, nodeName)

--- a/enhancements/router-resiliency.md
+++ b/enhancements/router-resiliency.md
@@ -135,7 +135,7 @@ so that existing traffic flows are not interrupted during the upgrade.
 | Named netns is not cleaned up on node shutdown | `/var/run` is a tmpfs, so the bind mount is automatically removed on reboot. The controller can also explicitly delete the netns during graceful shutdown. |
 | FRR restarts too quickly before interfaces are ready | Interfaces persist in the named netns; FRR always finds them ready |
 | BGP Graceful Restart not supported by all peers | GR is widely supported (FRR, BIRD, Cisco, Arista); document peer requirements |
-| Router netns drifts out of sync with desired config (controller bug, partial failure, manual interference) | The system is designed for full netns teardown and rebuild: `ip netns delete perouter` followed by a restart of the router process deterministically recreates a correct state. The controller detects the missing netns, recreates it, and re-provisions all interfaces from CRD state. See [Recovery from a Deleted or Emptied Namespace](#recovery-from-a-deleted-or-emptied-namespace). |
+| Router netns drifts out of sync with desired config (controller bug, partial failure, manual interference) | The system is designed for full netns teardown and rebuild: `ip netns delete perouter` followed by a router pod restart deterministically recreates a correct state. Both steps are needed — the netns delete removes the bind mount, and the pod restart releases the open handles so the kernel actually destroys the namespace. The controller then detects the missing netns, recreates it, and re-provisions all interfaces from CRD state. See [Recovery from a Deleted or Emptied Namespace](#recovery-from-a-deleted-or-emptied-namespace). |
 
 ## Design Details
 
@@ -512,42 +512,63 @@ trash the router namespace and let the system rebuild it. This can happen when:
 - An underlay change triggers `HandleNonRecoverableError`, which needs to
   rebuild the namespace from scratch.
 
-The design must ensure this is a **safe, deterministic, single-command
+The design must ensure this is a **safe, deterministic, two-step
 operation** that always converges to the correct state.
 
 #### Recovery Procedure
 
-The admin (or operator) deletes the netns to force a clean slate:
+The admin (or operator) deletes the netns and restarts the router pod to
+force a clean slate:
 
 ```bash
-# Delete the netns (destroys all interfaces, routes, FDB inside it)
+# 1. Delete the netns (marks it for destruction)
 ip netns delete perouter
+
+# 2. Restart the router pod (releases the open handles so the kernel
+#    actually destroys the namespace and all objects inside it)
+#    For K8s: delete the router pod on the affected node (DaemonSet recreates it)
+kubectl delete pod -n openperouter-system <router-pod-name>
+#    For Podman quadlet: restart the systemd unit
+#    systemctl restart routerpod-pod.service
 ```
 
-No further manual steps are required. On the next reconciliation loop, the
-controller detects the missing netns, recreates it via `EnsureNamespace()`,
-re-provisions all interfaces from CRD state, and restarts the FRR process.
-The recovery is fully automatic once the netns is removed.
+Both steps are required. The kernel keeps a network namespace alive as long
+as any process holds an open file descriptor or mount reference to it.
+Because FRR (and the reloader) are running inside the namespace, `ip netns
+delete` alone only removes the bind mount at `/var/run/netns/perouter` — the
+namespace and all its kernel objects continue to exist until the router
+processes exit. Restarting the router pod closes those handles, which lets
+the kernel destroy the namespace and all interfaces, routes, and FDB entries
+inside it.
 
-Equivalently, `HandleNonRecoverableError` can perform this programmatically
-when it detects an unrecoverable divergence.
+After the router pod restarts, namespace recreation depends on the
+deployment model. In the Podman Quadlet deployment, the pod unit's
+`ExecStartPre` recreates the `perouter` netns before the containers start,
+so the namespace may already exist by the time the controller reconciles.
+In the Kubernetes deployment, the controller detects the missing netns and
+recreates it via `EnsureNamespace()`. In both cases, the controller
+subsequently reconciles and re-provisions all interfaces from CRD state,
+and the restarted FRR process enters the recovered namespace. The recovery
+converges automatically from that point.
 
 Improving the recovery procedure (e.g. have an API for it) would be nice to
 have. It would be investigated in a separate enhancement though.
 
 #### Why This Works
 
-Deleting the named netns destroys all kernel objects inside it — VRFs, bridges,
-VXLANs, veth endpoints (which also destroys the host-side peer), the underlay
-NIC (returned to the host netns), and the `lound` dummy interface. This is a
-clean slate. The system then follows the exact same sequence as a fresh start:
+Deleting the bind mount (`ip netns delete`) and restarting the router pod
+together cause the kernel to destroy the namespace and all kernel objects
+inside it — VRFs, bridges, VXLANs, veth endpoints (which also destroys the
+host-side peer), the underlay NIC (returned to the host netns), and the
+`lound` dummy interface. This is a clean slate. The system then follows the
+exact same sequence as a fresh start:
 
 1. The controller detects the missing netns and calls `EnsureNamespace()` to
    create a new empty netns
 2. The controller runs a full reconciliation — re-creating all interfaces from
    CRD state
-3. The controller restarts the FRR process, which enters the new netns, finds
-   interfaces configured by the controller, and re-establishes BGP sessions
+3. The restarted FRR process enters the new netns, finds interfaces configured
+   by the controller, and re-establishes BGP sessions
 
 The controller is already idempotent — it creates interfaces only if they don't
 exist, and `RemoveNonConfigured()` cleans up anything not in the desired state.
@@ -587,8 +608,11 @@ sequenceDiagram
 
     rect rgb(70, 25, 25)
         Note right of op: Phase 1: Tear Down
-        op->>netns: ip netns delete perouter
-        Note over netns: All kernel objects destroyed:<br/>VRFs, bridges, VXLANs, veths, lound<br/>Underlay NIC returned to host netns
+        op->>netns: ip netns delete perouter<br/>(removes bind mount)
+        op->>frr: Restart router pod<br/>(kubectl delete pod / systemctl restart)
+        deactivate frr
+        deactivate reloader
+        Note over netns: Router processes exit →<br/>last handle released →<br/>kernel destroys netns and all objects:<br/>VRFs, bridges, VXLANs, veths, lound<br/>Underlay NIC returned to host netns
         Note over tor: BGP sessions drop<br/>(underlay NIC gone)
         Note over hostBGP: BGP sessions drop<br/>(veth peers destroyed)
         tor->>tor: Graceful Restart activated<br/>Preserve stale routes
@@ -617,12 +641,12 @@ sequenceDiagram
     end
 
     rect rgb(70, 45, 15)
-        Note right of ctrl: Phase 4: Restart FRR
-        ctrl->>ctrl: restartRouter():<br/>Restart FRR process<br/>(systemd or pod recreation)
-        ctrl->>frr: FRR enters new netns
+        Note right of frr: Phase 4: Router Pod Restarts
+        Note over frr: Router pod restarted by operator<br/>in Phase 1 — Kubelet/systemd<br/>recreates it
+        frr->>netns: FRR enters new netns
         activate frr
-        ctrl->>reloader: Reloader starts
         activate reloader
+        reloader-->>reloader: Listen on Unix socket<br/>Health endpoint :9080/healthz
         Note over frr: FRR finds all interfaces<br/>already configured by controller
     end
 
@@ -846,7 +870,8 @@ disruption.
 - `HandleNonRecoverableError` extended to delete and trigger a full rebuild of
   the named netns.
 - Recovery procedure tested end-to-end: `ip netns delete perouter` followed by
-  automatic controller reconciliation returns the system to a correct state.
+  router pod restart and automatic controller reconciliation returns the system
+  to a correct state.
 - Full test suite covering resilience, namespace rebuild, and non-disruptive
   FRR upgrade scenarios.
 

--- a/website/content/docs/architecture.md
+++ b/website/content/docs/architecture.md
@@ -171,7 +171,7 @@ The kernel continues forwarding packets throughout because all networking state 
 
 ### Full Namespace Rebuild
 
-When the named namespace is deleted — either manually (`ip netns delete perouter`) or by the controller via non-recoverable error handling — a full rebuild occurs:
+When the named namespace is torn down — manually via `ip netns delete perouter` + router pod restart — a full rebuild occurs. Both steps are needed for manual recovery: the netns delete removes the bind mount, and the pod restart releases the open handles so the kernel actually destroys the namespace.
 
 | Phase | Duration |
 |-------|----------|

--- a/website/content/docs/concepts/resiliency.md
+++ b/website/content/docs/concepts/resiliency.md
@@ -79,13 +79,19 @@ When the router pod is replaced with a new image (e.g., during a rolling update)
 
 ### Manual Namespace Rebuild
 
-When the node's networking state is out of sync — stale interfaces, wrong IPs, partial failures — the operator can delete the namespace to trigger a full rebuild:
+When the node's networking state is out of sync — stale interfaces, wrong IPs, partial failures — the operator deletes the namespace and restarts the router pod to trigger a full rebuild:
 
 ```bash
+# 1. Remove the bind mount (marks the namespace for destruction)
 ip netns delete perouter
+
+# 2. Restart the router pod to release open handles — without this,
+#    the kernel keeps the namespace alive because FRR holds file
+#    descriptors to it
+kubectl delete pod -n openperouter-system <router-pod-name>
 ```
 
-The controller detects the missing namespace on its next reconciliation, recreates it, re-provisions all interfaces from CRD state, and the DaemonSet starts a new router pod.
+Both steps are required. After the router pod exits, the kernel destroys the namespace and all objects inside it. The controller detects the missing namespace on its next reconciliation, recreates it, and re-provisions all interfaces from CRD state. The new router pod enters the fresh namespace.
 
 - **Total outage (data + control plane)**: ~10-25 seconds
 

--- a/website/content/docs/configuration/troubleshooting-resiliency.md
+++ b/website/content/docs/configuration/troubleshooting-resiliency.md
@@ -40,11 +40,13 @@ kubectl exec -n openperouter-system <router-pod> -c frr -- \
 **Impact**: Data-plane disruption (~10-25 seconds). All traffic through VNIs on that node is interrupted during the rebuild.
 
 ```bash
-# 1. Delete the named namespace (destroys all kernel objects inside it).
-#    The underlay NIC is returned to the host namespace.
+# 1. Remove the bind mount (marks the namespace for destruction, but the
+#    kernel keeps it alive while FRR holds open file descriptors to it).
 ip netns delete perouter
 
-# 2. Delete the router pod on the affected node to trigger a DaemonSet replacement.
+# 2. Restart the router pod to release those handles — only then does
+#    the kernel destroy the namespace and all objects inside it
+#    (VRFs, bridges, VXLANs, veths, underlay NIC returned to host).
 kubectl delete pod -n openperouter-system <router-pod-name>
 
 # 3. The controller will automatically:


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>

/kind cleanup

> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
The systemd resiliency test deleted the netns bind mount but did not restart the routerpod service, leaving FRR holding the namespace open via /proc/<pid>/ns/net. Without a service restart, no reconcile was triggered and the test timed out after 3 minutes.

Align with the K8s lane (resiliency.go:437) which deletes the router pod after the netns deletion so FRR exits and the namespace is truly destroyed. The ExecStartPre in the routerpod quadlet recreates the netns on service restart.

**Special notes for your reviewer**:
Another option would be to actually monitor the netns path, and re-trigger reconciliation when the netns path is removed. Given we have open handles, it'll be trickier - since the netns is NOT actually removed until there aren't any open handles left.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of Changes

- **Bug Fixes**
  - Improved system resiliency coverage for named network namespace deletion by restarting the router pod/service as part of the validation flow.
  - Strengthened recovery checks to confirm the namespace and all expected interface types (VRF, bridge, VXLAN) are recreated, then proceeds to BGP/session validation.

- **Documentation**
  - Updated resiliency guidance across troubleshooting and architecture materials to specify deterministic manual recovery: delete the named netns, then restart the router pod, and clarified the resulting controller reconciliation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->