### PR TITLE
docs: correct hostmaster.linuxBridge.autoCreate field path in kubevirt examples

### DIFF
--- a/website/content/docs/examples/evpnexamples/kubevirt-multi-cluster.md
+++ b/website/content/docs/examples/evpnexamples/kubevirt-multi-cluster.md
@@ -91,7 +91,7 @@ spec:
 **Key Configuration Points:**
 
 - The L2VNI references the L3VNI via the `routingDomain` field, enabling routed traffic
-- `hostmaster.autocreate: true` creates a `br-hs-110` bridge on the host
+- `hostmaster.linuxBridge.autoCreate: true` creates a `br-hs-110` bridge on the host
 - `gatewayIPs` defines the gateway IP for the VM subnet
 
 ### 2. Network Attachment Definition
@@ -301,7 +301,7 @@ We see that the packet comes from the veth interface towards the bridge associat
 
 ### Common Issues
 
-1. **Bridge not created**: Verify the L2VNI has `hostmaster.autocreate: true`
+1. **Bridge not created**: Verify the L2VNI has `hostmaster.linuxBridge.autoCreate: true`
 2. **VM cannot reach gateway**: Check that the VM's IP is in the same subnet as `gatewayIPs`
 3. **No VM-to-VM connectivity**: Ensure both VMs are connected to the same bridge (`br-hs-110`)
 

--- a/website/content/docs/examples/evpnexamples/kubevirt.md
+++ b/website/content/docs/examples/evpnexamples/kubevirt.md
@@ -88,7 +88,7 @@ spec:
 **Key Configuration Points:**
 
 - The L2VNI references the L3VNI via the `routingDomain` field, enabling routed traffic
-- `hostmaster.autocreate: true` creates a `br-hs-110` bridge on the host
+- `hostmaster.linuxBridge.autoCreate: true` creates a `br-hs-110` bridge on the host
 - `gatewayIPs` defines the gateway IP for the VM subnet
 
 ### 2. Network Attachment Definition
@@ -263,7 +263,7 @@ The ping should continue working throughout the migration process.
 
 ### Common Issues
 
-1. **Bridge not created**: Verify the L2VNI has `hostmaster.autocreate: true`
+1. **Bridge not created**: Verify the L2VNI has `hostmaster.linuxBridge.autoCreate: true`
 2. **VM cannot reach gateway**: Check that the VM's IP is in the same subnet as `gatewayIPs`
 3. **No VM-to-VM connectivity**: Ensure both VMs are connected to the same bridge (`br-hs-110`)
 


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind documentation

**What this PR does / why we need it**:

The "Key Configuration Points" and troubleshooting bullets in both kubevirt EVPN examples describe the field as `hostmaster.autocreate`, but the YAML in those same examples uses the nested path `hostmaster.linuxBridge.autoCreate`. This updates the prose to match the actual field path so readers following the docs reference the right key.

**Special notes for your reviewer**:

Fixes #583

**Release note**:

```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated KubeVirt EVPN examples with the correct L2VNI Linux bridge auto-creation setting.
  * Revised troubleshooting guidance for cases where the bridge is not created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->