### PR TITLE
feat(cni): invoke CNI CHECK during underlay reconciliation

### DIFF
--- a/e2etests/tests/cni_lifecycle.go
+++ b/e2etests/tests/cni_lifecycle.go
@@ -46,7 +46,7 @@ const (
 // CNI DEL / ADD reprovisioning on interface changes and the teardown
 // through CNI DEL. The traffic coverage runs in the EVPN routes suites,
 // parameterized by underlay flavor.
-var _ = Describe("CNI underlay lifecycle", GroutSupport, Ordered, func() {
+var _ = Describe("CNI underlay lifecycle", Ordered, func() {
 	var cs clientset.Interface
 	nodes := []corev1.Node{}
 
@@ -184,15 +184,6 @@ var _ = Describe("CNI underlay lifecycle", GroutSupport, Ordered, func() {
 	})
 
 	It("keeps the CNI interfaces when the router pods are restarted", func() {
-		if GroutMode {
-			// Restarting the router wipes the grout state and the underlay
-			// addresses live in grout (they are removed from the kernel
-			// interfaces), so the sessions cannot re-establish. This is a
-			// grout datapath limitation independent of how the underlay
-			// interface is provisioned.
-			Skip("the grout datapath does not recover the underlay addresses after a router restart, " +
-				"see https://github.com/openperouter/openperouter/issues/597")
-		}
 		indexesBefore, err := cniInterfaceIndexes(nodes, infra.CNIUnderlayInterface)
 		Expect(err).NotTo(HaveOccurred())
 

--- a/e2etests/tests/cni_lifecycle.go
+++ b/e2etests/tests/cni_lifecycle.go
@@ -43,9 +43,10 @@ const (
 // The CNI underlay lifecycle coverage exercises the behaviors specific to
 // CNI provisioned underlay interfaces: the libcni result cache driving the
 // reconciliation across controller and router restarts, the in-place
-// CNI DEL / ADD reprovisioning on interface changes and the teardown
-// through CNI DEL. The traffic coverage runs in the EVPN routes suites,
-// parameterized by underlay flavor.
+// CNI DEL / ADD reprovisioning on interface changes, CNI CHECK validation
+// of cached state on every reconciliation, and the teardown through CNI DEL.
+// The traffic coverage runs in the EVPN routes suites, parameterized by
+// underlay flavor.
 var _ = Describe("CNI underlay lifecycle", Ordered, func() {
 	var cs clientset.Interface
 	nodes := []corev1.Node{}
@@ -195,6 +196,35 @@ var _ = Describe("CNI underlay lifecycle", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(indexesAfter).To(Equal(indexesBefore),
 			"the interfaces should survive the router restart untouched")
+
+		By("checking the sessions re-establish")
+		validateSessionUp()
+	})
+
+	It("reprovisions the CNI interface after external drift is caught by the next reconcile", func() {
+		indexesBefore, err := cniInterfaceIndexes(nodes, infra.CNIUnderlayInterface)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("deleting the CNI interface directly, behind the controller's back")
+		for _, node := range nodes {
+			exec := executor.ForContainer(node.Name)
+			_, err := exec.Exec("ip", "netns", "exec", openperouter.NamedNetns, "ip", "link", "del", infra.CNIUnderlayInterface)
+			Expect(err).NotTo(HaveOccurred())
+		}
+		validateCNIInterfacesGone(infra.CNIUnderlayInterface)
+
+		// Reconciliation is event-driven, not on a timer: the dangling cache
+		// entry is only caught on the next reconcile. Restarting the
+		// controllers forces one without touching the Underlay.
+		By("forcing a reconcile by restarting the controllers")
+		restartControllers()
+
+		By("checking cni check detects the drift and the interface is reprovisioned")
+		validateCNIInterfacesPresent(infra.CNIUnderlayInterface)
+		indexesAfter, err := cniInterfaceIndexes(nodes, infra.CNIUnderlayInterface)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(indexesAfter).NotTo(Equal(indexesBefore),
+			"the interface should have been recreated with a new ifindex")
 
 		By("checking the sessions re-establish")
 		validateSessionUp()

--- a/internal/cniinvoker/cni_test.go
+++ b/internal/cniinvoker/cni_test.go
@@ -225,6 +225,47 @@ func TestDelWithEmptyCache(t *testing.T) {
 	env.noCommands(t)
 }
 
+func TestCheckWithNoCachedAttachment(t *testing.T) {
+	env := newFakePluginEnv(t)
+
+	if err := env.invoker().Check(context.Background(), "net1"); err != nil {
+		t.Fatalf("Check with no cached attachment failed: %v", err)
+	}
+
+	env.noCommands(t)
+}
+
+func TestCheckPassesForAHealthyInterface(t *testing.T) {
+	env := newFakePluginEnv(t)
+
+	if err := env.invoker().Add(context.Background(), env.params("net1", nil)); err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+
+	if err := env.invoker().Check(context.Background(), "net1"); err != nil {
+		t.Fatalf("Check failed: %v", err)
+	}
+
+	env.matchCommands(t, "ADD net1", "CHECK net1")
+}
+
+func TestCheckReportsAMisconfiguredInterface(t *testing.T) {
+	env := newFakePluginEnv(t)
+
+	if err := env.invoker().Add(context.Background(), env.params("net1", nil)); err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(env.stdinDir, "FAIL-CHECK"), nil, 0o644); err != nil {
+		t.Fatalf("failed to request the CHECK failure: %v", err)
+	}
+
+	if err := env.invoker().Check(context.Background(), "net1"); err == nil {
+		t.Fatal("expected error for a failed CHECK")
+	}
+
+	env.matchCommands(t, "ADD net1", "CHECK net1")
+}
+
 func TestValidateConfig(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -292,9 +333,10 @@ func newFakePluginEnv(t *testing.T) *fakePluginEnv {
 	// The fake plugin script logs "COMMAND IFNAME", dumps its stdin and, on
 	// ADD, emits a canned CNI result. A repeated ADD for the same interface
 	// fails, so tests catch broken Add idempotency. DEL clears the marker so
-	// a later ADD is allowed again. Environment variables are inherited
-	// from the test process (t.Setenv) since libcni execs plugins with
-	// os.Environ.
+	// a later ADD is allowed again. CHECK fails when FAIL-CHECK is present,
+	// so tests can simulate a drifted/misconfigured interface. Environment
+	// variables are inherited from the test process (t.Setenv) since libcni
+	// execs plugins with os.Environ.
 	script := `#!/bin/sh
 echo "$CNI_COMMAND $CNI_IFNAME" >> "$CNI_TEST_LOG"
 if [ "$CNI_COMMAND" = "ADD" ] && [ -e "$CNI_TEST_STDIN_DIR/FAIL-ADD" ]; then
@@ -303,6 +345,10 @@ if [ "$CNI_COMMAND" = "ADD" ] && [ -e "$CNI_TEST_STDIN_DIR/FAIL-ADD" ]; then
 fi
 if [ "$CNI_COMMAND" = "ADD" ] && [ -e "$CNI_TEST_STDIN_DIR/ADD-$CNI_IFNAME" ]; then
   echo '{"cniVersion":"1.0.0","code":11,"msg":"duplicate ADD for '"$CNI_IFNAME"'"}'
+  exit 1
+fi
+if [ "$CNI_COMMAND" = "CHECK" ] && [ -e "$CNI_TEST_STDIN_DIR/FAIL-CHECK" ]; then
+  echo '{"cniVersion":"1.0.0","code":11,"msg":"CHECK failure requested by the test"}'
   exit 1
 fi
 cat > "$CNI_TEST_STDIN_DIR/$CNI_COMMAND-$CNI_IFNAME"

--- a/internal/cniinvoker/invoker.go
+++ b/internal/cniinvoker/invoker.go
@@ -112,6 +112,37 @@ func validateCachedAttachment(attachment *libcni.NetworkAttachment, p AddParams)
 	return nil
 }
 
+// Check invokes CNI CHECK for the cached attachment matching the interface
+// name, using the config and netns recorded at ADD time. It reports whether
+// the interface is still correctly configured in the kernel, so the caller
+// can detect drift between the libcni cache and the real state of the
+// namespace. When no cached attachment exists for ifName, Check returns nil:
+// there is nothing to validate, Add will provision it.
+func (inv *invoker) Check(ctx context.Context, ifName string) error {
+	attachment, err := inv.findCachedAttachmentByInterfaceName(ifName)
+	if err != nil {
+		return fmt.Errorf("failed finding cni attachment with ifname %q to check: %w", ifName, err)
+	}
+	if attachment == nil {
+		return nil
+	}
+
+	confList, err := libcni.NetworkConfFromBytes(attachment.Config)
+	if err != nil {
+		return fmt.Errorf("failed to parse cached cni config for network %q: %w", attachment.Network, err)
+	}
+
+	if err := inv.cniConfig.CheckNetworkList(ctx, confList, &libcni.RuntimeConf{
+		ContainerID:    attachment.ContainerID,
+		NetNS:          attachment.NetNS,
+		IfName:         attachment.IfName,
+		CapabilityArgs: attachment.CapabilityArgs,
+	}); err != nil {
+		return fmt.Errorf("cni check %q (%s) in %s: %w", attachment.Network, attachment.IfName, attachment.NetNS, err)
+	}
+	return nil
+}
+
 // Del invokes CNI DEL for the cached attachment matching the interface name,
 // using the config and netns recorded at ADD time so teardown works after the
 // defining config is gone. Interfaces without a cached attachment are

--- a/internal/conversion/validate_grout.go
+++ b/internal/conversion/validate_grout.go
@@ -23,6 +23,12 @@ func ValidateGroutL2VNI(l2VNI v1alpha1.L2VNI) error {
 }
 
 func ValidateGroutUnderlay(underlay v1alpha1.Underlay) error {
+	for _, iface := range underlay.Spec.Interfaces {
+		if iface.Type == v1alpha1.UnderlayInterfaceTypeCNIDevice {
+			return fmt.Errorf("CNI dev underlays are not supported with the grout datapath")
+		}
+	}
+
 	// The grout port name is the interface name with the underlay prefix,
 	// so every interface name must leave room for it, regardless of how
 	// the interface is provisioned.

--- a/internal/conversion/validate_grout_test.go
+++ b/internal/conversion/validate_grout_test.go
@@ -32,34 +32,36 @@ func TestValidateGroutL3Passthrough(t *testing.T) {
 
 func TestValidateGroutUnderlayCNI(t *testing.T) {
 	tests := []struct {
-		name          string
-		interfaceName string
-		wantErr       string
+		name    string
+		iface   v1alpha1.UnderlayInterface
+		wantErr string
 	}{
 		{
-			name:          "ValidateGroutUnderlay() with a valid cni interface name should return no error",
-			interfaceName: "underlay0",
+			name: "CNI dev underlay should be rejected on grout",
+			iface: v1alpha1.UnderlayInterface{
+				Type: v1alpha1.UnderlayInterfaceTypeCNIDevice,
+				CNIDevice: &v1alpha1.CNIDevice{
+					Type:      v1alpha1.CNIConfigTypeRawConfig,
+					RawConfig: &apiextensionsv1.JSON{Raw: []byte(`{"cniVersion":"1.0.0","name":"u","type":"macvlan"}`)},
+				},
+			},
+			wantErr: "CNI dev underlays are not supported with the grout datapath",
 		},
 		{
-			name:          "ValidateGroutUnderlay() with a cni interface name should return error",
-			interfaceName: "a2345678901234",
-			wantErr:       "nic name a2345678901234 can't be longer than 14 characters",
+			name: "network device underlay should be accepted on grout",
+			iface: v1alpha1.UnderlayInterface{
+				Type: v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+				NetworkDevice: &v1alpha1.NetworkDevice{
+					InterfaceName: "eth0",
+				},
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underlay := v1alpha1.Underlay{
 				Spec: v1alpha1.UnderlaySpec{
-					Interfaces: []v1alpha1.UnderlayInterface{
-						{
-							Type: v1alpha1.UnderlayInterfaceTypeCNIDevice,
-							CNIDevice: &v1alpha1.CNIDevice{
-								Type:          v1alpha1.CNIConfigTypeRawConfig,
-								RawConfig:     &apiextensionsv1.JSON{Raw: []byte(`{"cniVersion":"1.0.0","name":"u","type":"macvlan"}`)},
-								InterfaceName: &tt.interfaceName,
-							},
-						},
-					},
+					Interfaces: []v1alpha1.UnderlayInterface{tt.iface},
 				},
 			}
 			obtainedErr := ""

--- a/internal/hostnetwork/underlay.go
+++ b/internal/hostnetwork/underlay.go
@@ -133,9 +133,19 @@ func SetupUnderlayNetDevInterface(ctx context.Context, ns netns.NsHandle,
 	return nil
 }
 
-// SetupUnderlayCNIDevInterface provisions a single underlay cni dev interface
+// SetupUnderlayCNIDevInterface provisions a single underlay cni dev interface.
+// A CNI CHECK runs first and, if it fails, the interface is torn down so the
+// subsequent Add provisions it fresh.
 func SetupUnderlayCNIDevInterface(ctx context.Context, ns string,
 	iface UnderlayInterface) error {
+	if err := cniinvoker.Invoker.Check(ctx, iface.InterfaceName); err != nil {
+		slog.WarnContext(ctx, "cni check failed, rebuilding underlay cni device",
+			"interface", iface.InterfaceName, "error", err)
+		if err := cniinvoker.Invoker.Del(ctx, iface.InterfaceName); err != nil {
+			return fmt.Errorf("failed to delete unhealthy underlay cni device %s: %w", iface.InterfaceName, err)
+		}
+	}
+
 	if err := cniinvoker.Invoker.Add(ctx, cniinvoker.AddParams{
 		Config:         iface.CNI.Config,
 		NetNS:          ns,

--- a/internal/hostnetwork/underlay_cnidev_test.go
+++ b/internal/hostnetwork/underlay_cnidev_test.go
@@ -43,9 +43,11 @@ var underlayCNITestConfig = fmt.Sprintf(`{
 }`, underlayCNITestPlugin)
 
 // fakeCNIPlugin creates a dummy link with a fixed address inside CNI_NETNS on
-// ADD and deletes it on DEL, recording every invocation in CNI_TEST_LOG. It
-// lets the tests exercise the full CNI provisioning path without shipping
-// real plugins.
+// ADD and deletes it on DEL, recording every invocation in CNI_TEST_LOG. On
+// CHECK it verifies the link still exists in the netns, so tests can drive a
+// real CHECK failure by deleting the link behind the invoker's back. It lets
+// the tests exercise the full CNI provisioning path without shipping real
+// plugins.
 const fakeCNIPlugin = `#!/bin/sh
 set -e
 echo "$CNI_COMMAND $CNI_IFNAME" >> "$CNI_TEST_LOG"
@@ -58,6 +60,12 @@ ADD)
   ;;
 DEL)
   nsenter --net="$CNI_NETNS" ip link del "$CNI_IFNAME" 2>/dev/null || true
+  ;;
+CHECK)
+  if ! nsenter --net="$CNI_NETNS" ip link show "$CNI_IFNAME" >/dev/null 2>&1; then
+    echo "{\"cniVersion\":\"1.0.0\",\"code\":11,\"msg\":\"interface $CNI_IFNAME not found in $CNI_NETNS\"}"
+    exit 1
+  fi
   ;;
 esac
 `
@@ -151,12 +159,31 @@ var _ = Describe("Underlay CNI configuration", func() {
 			"the cni cache should be the source of truth for the provisioned interfaces")
 	})
 
-	It("is idempotent through the cni cache", func() {
+	It("is idempotent through the cni cache when the interface is healthy", func() {
 		params := cniParams("net1")
 		Expect(SetupUnderlay(context.Background(), params)).To(Succeed())
 		Expect(SetupUnderlay(context.Background(), params)).To(Succeed())
 
-		Expect(loggedCommands()).To(ConsistOf("ADD net1"), "the second setup should be served from the cache")
+		Expect(loggedCommands()).To(HaveExactElements("ADD net1", "CHECK net1"),
+			"the second setup should pass cni check and be served from the cache, without a new ADD")
+		validateCNIInterfaceInNS(testNs, "net1")
+	})
+
+	It("rebuilds the cni interface when cni check finds it missing from the netns", func() {
+		params := cniParams("net1")
+		Expect(SetupUnderlay(context.Background(), params)).To(Succeed())
+
+		// Simulate drift between the cni cache and the real namespace state:
+		// remove the link directly, bypassing the invoker, so the cache
+		// still believes the interface is provisioned.
+		Expect(netnamespace.In(testNs, func() error {
+			return netlink.LinkDel(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "net1"}})
+		})).To(Succeed())
+
+		Expect(SetupUnderlay(context.Background(), params)).To(Succeed())
+
+		Expect(loggedCommands()).To(HaveExactElements("ADD net1", "CHECK net1", "DEL net1", "ADD net1"),
+			"a failed check should tear down and re-provision the interface")
 		validateCNIInterfaceInNS(testNs, "net1")
 	})
 

--- a/website/content/docs/configuration/_index.md
+++ b/website/content/docs/configuration/_index.md
@@ -193,6 +193,11 @@ Key behaviors to be aware of:
   `mac`, `bandwidth`) to plugins that declare the corresponding
   `capabilities` in their config; undeclared keys are ignored. Like
   `rawConfig`, it is immutable once the Underlay is created.
+- **Drift is detected and repaired on the next reconcile**: the controller
+  runs a CNI CHECK against the cached attachment before trusting it. If the
+  interface was removed or misconfigured outside of OpenPERouter, the next
+  reconcile (triggered by a resource change, or a controller/router
+  restart) tears it down and re-provisions it.
 - Since the interface address is typically node-specific, CNI underlays
   are usually node-scoped via `nodeSelector`, one Underlay per node. See
   the [example on GitHub](https://github.com/openperouter/openperouter/tree/main/examples/evpn/cni-underlay).


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind feature

**What this PR does / why we need it**:

Following #543, this PR wires CNI CHECK into the underlay reconciliation path. On every
reconcile, the controller runs CHECK against the cached attachment before trusting it. 
When CHECK fails, the interface is torn down (DEL) and re-provisioned (ADD), so the 
kernel state - not just the cache - determines whether an interface needs rebuilding.

**Special notes for your reviewer**:

- The `internal/grout` datapath shares the same `SetupUnderlayCNIDevInterface`
  function, so the fix covers both the kernel and grout datapaths without
  separate changes.

**Release note**:

```release-note
CNI-provisioned underlay interfaces are now validated with a CNI CHECK
on every reconcile. If an interface was removed or misconfigured
outside of OpenPERouter, the next reconcile tears it down and
re-provisions it instead of trusting a stale cache entry.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CNI `CHECK`-based validation for cached CNI-provisioned underlay interfaces during reconcile.
  * On failed `CHECK` or detected drift, OpenPERouter now tears down via CNI `DEL` and re-provisions via CNI `ADD` so CNI sessions can re-establish (including after controller/router restarts).
  * Expanded end-to-end scenarios for DEL/ADD reprovisioning on interface changes and out-of-band interface deletion; enabled router pod restart coverage in Grout mode.
* **Documentation**
  * Updated docs to describe `CHECK`-driven drift detection and automatic teardown/reprovisioning.
* **Bug Fixes**
  * Under grout datapath, underlay specs backed by `CNIDevice`-based CNIs are now rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->