### PR TITLE
adapt e2e suite to run on other platforms

### DIFF
--- a/e2etests/nodelink-default.json
+++ b/e2etests/nodelink-default.json
@@ -1,0 +1,34 @@
+{
+  "nodes": {
+    "pe-kind-control-plane": {
+      "ipForKindLeaf": "192.168.11.3",
+      "ipForKindLeaf2": "192.168.12.3",
+      "ipv6ForKindLeaf": "2001:db8:11::3",
+      "ipv6ForKindLeaf2": "2001:db8:12::3",
+      "ifaceForKindLeaf": "toleafkind1",
+      "ifaceForKindLeaf2": "toleafkind2",
+      "leafIfaceForKindLeaf": "tokindctrlpl",
+      "leafIfaceForKindLeaf2": "tokindctrlpl"
+    },
+    "pe-kind-worker": {
+      "ipForKindLeaf": "192.168.11.4",
+      "ipForKindLeaf2": "192.168.12.4",
+      "ipv6ForKindLeaf": "2001:db8:11::4",
+      "ipv6ForKindLeaf2": "2001:db8:12::4",
+      "ifaceForKindLeaf": "toleafkind1",
+      "ifaceForKindLeaf2": "toleafkind2",
+      "leafIfaceForKindLeaf": "tokindworker",
+      "leafIfaceForKindLeaf2": "tokindworker"
+    },
+    "pe-kind-worker2": {
+      "ipForKindLeaf": "192.168.11.5",
+      "ipForKindLeaf2": "192.168.12.5",
+      "ipv6ForKindLeaf": "2001:db8:11::5",
+      "ipv6ForKindLeaf2": "2001:db8:12::5",
+      "ifaceForKindLeaf": "toleafkind1",
+      "ifaceForKindLeaf2": "toleafkind2",
+      "leafIfaceForKindLeaf": "tokindworker2",
+      "leafIfaceForKindLeaf2": "tokindworker2"
+    }
+  }
+}

--- a/e2etests/nodelink-default.json
+++ b/e2etests/nodelink-default.json
@@ -1,0 +1,24 @@
+{
+  "nodes": {
+    "pe-kind-control-plane": {
+      "ipForKindLeaf": "192.168.11.3",
+      "ipForKindLeaf2": "192.168.12.3",
+      "ipv6ForKindLeaf": "2001:db8:11::3",
+      "ipv6ForKindLeaf2": "2001:db8:12::3",
+      "ifaceForKindLeaf": "toleafkind1",
+      "ifaceForKindLeaf2": "toleafkind2",
+      "leafIfaceForKindLeaf": "tokindctrlpl",
+      "leafIfaceForKindLeaf2": "tokindctrlpl"
+    },
+    "pe-kind-worker": {
+      "ipForKindLeaf": "192.168.11.4",
+      "ipForKindLeaf2": "192.168.12.4",
+      "ipv6ForKindLeaf": "2001:db8:11::4",
+      "ipv6ForKindLeaf2": "2001:db8:12::4",
+      "ifaceForKindLeaf": "toleafkind1",
+      "ifaceForKindLeaf2": "toleafkind2",
+      "leafIfaceForKindLeaf": "tokindworker",
+      "leafIfaceForKindLeaf2": "tokindworker"
+    }
+  }
+}

--- a/e2etests/pkg/config/update.go
+++ b/e2etests/pkg/config/update.go
@@ -26,11 +26,12 @@ type Resources struct {
 }
 
 type Updater struct {
-	cli       client.Client
-	namespace string
+	cli             client.Client
+	namespace       string
+	frrk8sNamespace string
 }
 
-func UpdaterForCRs(r *rest.Config, ns string) (*Updater, error) {
+func UpdaterForCRs(r *rest.Config, ns, frrk8sNs string) (*Updater, error) {
 	myScheme := runtime.NewScheme()
 
 	if err := v1alpha1.AddToScheme(myScheme); err != nil {
@@ -54,8 +55,9 @@ func UpdaterForCRs(r *rest.Config, ns string) (*Updater, error) {
 	}
 
 	return &Updater{
-		cli:       cl,
-		namespace: ns,
+		cli:             cl,
+		namespace:       ns,
+		frrk8sNamespace: frrk8sNs,
 	}, nil
 }
 
@@ -105,7 +107,13 @@ func (o Updater) Update(r Resources) error {
 
 	// Iterating over the map will return the items in a random order.
 	for i, obj := range objects {
-		obj.SetNamespace(o.namespace)
+		switch obj.(type) {
+		case *frrk8sv1beta1.FRRConfiguration:
+			obj.SetNamespace(o.frrk8sNamespace)
+		default:
+			obj.SetNamespace(o.namespace)
+		}
+
 		_, err := controllerutil.CreateOrUpdate(context.Background(), o.cli, obj, func() error {
 			// the mutate function is expected to change the object when updating.
 			// we always override with the old version, and we change only the spec part.
@@ -182,7 +190,7 @@ func (o Updater) CleanButUnderlay() error {
 		return err
 	}
 	if err := o.cli.DeleteAllOf(context.Background(), &frrk8sv1beta1.FRRConfiguration{},
-		client.InNamespace(o.namespace)); err != nil {
+		client.InNamespace(o.frrk8sNamespace)); err != nil {
 		return err
 	}
 	return nil

--- a/e2etests/pkg/config/update.go
+++ b/e2etests/pkg/config/update.go
@@ -26,11 +26,12 @@ type Resources struct {
 }
 
 type Updater struct {
-	cli       client.Client
-	namespace string
+	cli             client.Client
+	openpeNamespace string
+	frrk8sNamespace string
 }
 
-func UpdaterForCRs(r *rest.Config, ns string) (*Updater, error) {
+func UpdaterForCRs(r *rest.Config, openpeNs, frrk8sNs string) (*Updater, error) {
 	myScheme := runtime.NewScheme()
 
 	if err := v1alpha1.AddToScheme(myScheme); err != nil {
@@ -54,8 +55,9 @@ func UpdaterForCRs(r *rest.Config, ns string) (*Updater, error) {
 	}
 
 	return &Updater{
-		cli:       cl,
-		namespace: ns,
+		cli:             cl,
+		openpeNamespace: openpeNs,
+		frrk8sNamespace: frrk8sNs,
 	}, nil
 }
 
@@ -105,7 +107,13 @@ func (o Updater) Update(r Resources) error {
 
 	// Iterating over the map will return the items in a random order.
 	for i, obj := range objects {
-		obj.SetNamespace(o.namespace)
+		switch obj.(type) {
+		case *frrk8sv1beta1.FRRConfiguration:
+			obj.SetNamespace(o.frrk8sNamespace)
+		default:
+			obj.SetNamespace(o.openpeNamespace)
+		}
+
 		_, err := controllerutil.CreateOrUpdate(context.Background(), o.cli, obj, func() error {
 			// the mutate function is expected to change the object when updating.
 			// we always override with the old version, and we change only the spec part.
@@ -148,7 +156,7 @@ func (o Updater) Update(r Resources) error {
 // CleanAll deletes all relevant resources in the namespace.
 func (o Updater) CleanAll() error {
 	if err := o.cli.DeleteAllOf(context.Background(), &v1alpha1.Underlay{},
-		client.InNamespace(o.namespace)); err != nil {
+		client.InNamespace(o.openpeNamespace)); err != nil {
 		return err
 	}
 	if err := o.CleanButUnderlay(); err != nil {
@@ -162,27 +170,27 @@ func (o Updater) CleanAll() error {
 // will cause the router pods to be recreated.
 func (o Updater) CleanButUnderlay() error {
 	if err := o.cli.DeleteAllOf(context.Background(), &v1alpha1.L3VNI{},
-		client.InNamespace(o.namespace)); err != nil {
+		client.InNamespace(o.openpeNamespace)); err != nil {
 		return err
 	}
 	if err := o.cli.DeleteAllOf(context.Background(), &v1alpha1.L2VNI{},
-		client.InNamespace(o.namespace)); err != nil {
+		client.InNamespace(o.openpeNamespace)); err != nil {
 		return err
 	}
 	if err := o.cli.DeleteAllOf(context.Background(), &v1alpha1.L3VPN{},
-		client.InNamespace(o.namespace)); err != nil {
+		client.InNamespace(o.openpeNamespace)); err != nil {
 		return err
 	}
 	if err := o.cli.DeleteAllOf(context.Background(), &v1alpha1.L3Passthrough{},
-		client.InNamespace(o.namespace)); err != nil {
+		client.InNamespace(o.openpeNamespace)); err != nil {
 		return err
 	}
 	if err := o.cli.DeleteAllOf(context.Background(), &v1alpha1.RawFRRConfig{},
-		client.InNamespace(o.namespace)); err != nil {
+		client.InNamespace(o.openpeNamespace)); err != nil {
 		return err
 	}
 	if err := o.cli.DeleteAllOf(context.Background(), &frrk8sv1beta1.FRRConfiguration{},
-		client.InNamespace(o.namespace)); err != nil {
+		client.InNamespace(o.frrk8sNamespace)); err != nil {
 		return err
 	}
 	return nil
@@ -193,5 +201,5 @@ func (o Updater) Client() client.Client {
 }
 
 func (o Updater) Namespace() string {
-	return o.namespace
+	return o.openpeNamespace
 }

--- a/e2etests/pkg/executor/nodeexec.go
+++ b/e2etests/pkg/executor/nodeexec.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package executor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+const (
+	nodeExecHelperName  = "node-exec-helper"
+	nodeExecHelperLabel = "app=" + nodeExecHelperName
+)
+
+var (
+	forNodeClient    clientset.Interface
+	forNodeNamespace string
+)
+
+func SetupNodeExec(cs clientset.Interface, namespace, image string) error {
+	forNodeClient = cs
+	forNodeNamespace = namespace
+
+	if err := ensureServiceAccount(cs, namespace); err != nil {
+		return fmt.Errorf("creating node-exec-helper service account: %w", err)
+	}
+
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nodeExecHelperName,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": nodeExecHelperName},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": nodeExecHelperName},
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: nodeExecHelperName,
+					HostPID:            true,
+					HostNetwork:        true,
+					Tolerations:        []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
+					Containers: []corev1.Container{{
+						Name:    "nsenter",
+						Image:   image,
+						Command: []string{"sleep", "infinity"},
+						SecurityContext: &corev1.SecurityContext{
+							Privileged: new(true),
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	_, err := cs.AppsV1().DaemonSets(namespace).Create(context.Background(), ds, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("creating node-exec-helper DaemonSet: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	err = wait.PollUntilContextCancel(ctx, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+		d, err := cs.AppsV1().DaemonSets(namespace).Get(ctx, nodeExecHelperName, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		if d.Status.DesiredNumberScheduled == 0 {
+			return false, nil
+		}
+		return d.Status.NumberReady >= d.Status.DesiredNumberScheduled, nil
+	})
+	if err != nil {
+		return fmt.Errorf("waiting for node-exec-helper pods to be ready: %w", err)
+	}
+
+	return nil
+}
+
+func TeardownNodeExec() error {
+	if forNodeClient == nil {
+		return nil
+	}
+
+	err := forNodeClient.AppsV1().DaemonSets(forNodeNamespace).Delete(
+		context.Background(), nodeExecHelperName, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	err = forNodeClient.RbacV1().ClusterRoleBindings().Delete(
+		context.Background(), nodeExecHelperName+"-privileged", metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	err = forNodeClient.RbacV1().ClusterRoles().Delete(
+		context.Background(), nodeExecHelperName+"-privileged", metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	err = forNodeClient.CoreV1().ServiceAccounts(forNodeNamespace).Delete(
+		context.Background(), nodeExecHelperName, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	return nil
+}
+
+type nodeExecutor struct {
+	nodeName string
+}
+
+func ForNode(nodeName string) Executor {
+	return &nodeExecutor{nodeName: nodeName}
+}
+
+func (e *nodeExecutor) Exec(cmd string, args ...string) (string, error) {
+	if Kubectl == "" {
+		return "", errors.New("the kubectl parameter is not set")
+	}
+	podName, err := helperPodForNode(e.nodeName)
+	if err != nil {
+		return "", err
+	}
+	nsenterArgs := []string{
+		"exec", podName, "-n", forNodeNamespace, "-c", "nsenter", "--",
+		"chroot", "/proc/1/root",
+		"nsenter",
+		"--target", "1",
+		"--mount", "-u",
+		"--ipc",
+		"--net",
+		cmd}
+	fullargs := append(nsenterArgs, args...)
+	out, err := exec.Command(Kubectl, fullargs...).CombinedOutput()
+	if err != nil {
+		return string(out), fmt.Errorf("exec on node via pod %s/%s failed: %w. Output: %s",
+			forNodeNamespace, podName, err, string(out))
+	}
+	return string(out), nil
+}
+
+func helperPodForNode(nodeName string) (string, error) {
+	pods, err := forNodeClient.CoreV1().Pods(forNodeNamespace).List(
+		context.Background(),
+		metav1.ListOptions{LabelSelector: nodeExecHelperLabel},
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to list helper pods: %w", err)
+	}
+	for i := range pods.Items {
+		if pods.Items[i].Spec.NodeName == nodeName {
+			return pods.Items[i].Name, nil
+		}
+	}
+	return "", fmt.Errorf("no node-exec-helper pod found on node %s", nodeName)
+}
+
+func ensureServiceAccount(cs clientset.Interface, namespace string) error {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nodeExecHelperName,
+			Namespace: namespace,
+		},
+	}
+	_, err := cs.CoreV1().ServiceAccounts(namespace).Create(context.Background(), sa, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("creating service account: %w", err)
+	}
+
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeExecHelperName + "-privileged",
+		},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups:     []string{"security.openshift.io"},
+			Resources:     []string{"securitycontextconstraints"},
+			ResourceNames: []string{"privileged"},
+			Verbs:         []string{"use"},
+		}},
+	}
+	_, err = cs.RbacV1().ClusterRoles().Create(context.Background(), cr, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("creating cluster role: %w", err)
+	}
+
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeExecHelperName + "-privileged",
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     nodeExecHelperName + "-privileged",
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      nodeExecHelperName,
+			Namespace: namespace,
+		}},
+	}
+	_, err = cs.RbacV1().ClusterRoleBindings().Create(context.Background(), crb, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("creating cluster role binding: %w", err)
+	}
+
+	return nil
+}

--- a/e2etests/pkg/frr/container.go
+++ b/e2etests/pkg/frr/container.go
@@ -55,7 +55,7 @@ func writeFRRConfig(containerName, config string) error {
 		return fmt.Errorf("failed to close temporary file: %w", err)
 	}
 
-	cmd := exec.Command("docker", "cp", tmpFile.Name(), fmt.Sprintf("%s:%s", containerName, frrConfig))
+	cmd := exec.Command(executor.ContainerRuntime, "cp", tmpFile.Name(), fmt.Sprintf("%s:%s", containerName, frrConfig))
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to copy file to container: %s, %w", string(output), err)
 	}

--- a/e2etests/pkg/infra/config.go
+++ b/e2etests/pkg/infra/config.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package infra
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+const (
+	kindLeafIP    = "192.168.11.2"
+	kindLeaf2IP   = "192.168.12.2"
+	kindLeafIPv6  = "2001:db8:11::2"
+	kindLeaf2IPv6 = "2001:db8:12::2"
+)
+
+type nodeLinksConfig struct {
+	Nodes map[string]nodeConfig `json:"nodes"`
+}
+
+type nodeConfig struct {
+	IPForKindLeaf         string `json:"ipForKindLeaf"`
+	IPForKindLeaf2        string `json:"ipForKindLeaf2"`
+	IPv6ForKindLeaf       string `json:"ipv6ForKindLeaf"`
+	IPv6ForKindLeaf2      string `json:"ipv6ForKindLeaf2"`
+	IfaceForKindLeaf      string `json:"ifaceForKindLeaf"`
+	IfaceForKindLeaf2     string `json:"ifaceForKindLeaf2"`
+	LeafIfaceForKindLeaf  string `json:"leafIfaceForKindLeaf"`
+	LeafIfaceForKindLeaf2 string `json:"leafIfaceForKindLeaf2"`
+}
+
+func RegisterLinks(path string) error {
+	registerFabricLinks()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading node links config %s: %w", path, err)
+	}
+	var cfg nodeLinksConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return fmt.Errorf("parsing node links config %s: %w", path, err)
+	}
+
+	registerNodeLinks(cfg)
+	return nil
+}

--- a/e2etests/pkg/infra/routers.go
+++ b/e2etests/pkg/infra/routers.go
@@ -47,38 +47,30 @@ var linksForFamily map[ipfamily.Family]map[link]linkAddresses
 
 func init() {
 	linksForFamily = map[ipfamily.Family]map[link]linkAddresses{}
+}
 
-	// leafkind1 links - bridge connections use toswitch1
-	addLinkIPs("clab-kind-leafkind1", "pe-kind-control-plane", "192.168.11.2", "192.168.11.3")
-	addLinkIPv6s("clab-kind-leafkind1", "pe-kind-control-plane", "2001:db8:11::2", "2001:db8:11::3")
-	addLinkInterfaces("clab-kind-leafkind1", "pe-kind-control-plane", "tokindctrlpl", "toleafkind1")
-	addLinkIPs("clab-kind-leafkind1", "pe-kind-worker", "192.168.11.2", "192.168.11.4")
-	addLinkIPv6s("clab-kind-leafkind1", "pe-kind-worker", "2001:db8:11::2", "2001:db8:11::4")
-	addLinkInterfaces("clab-kind-leafkind1", "pe-kind-worker", "tokindworker", "toleafkind1")
-	addLinkIPs("clab-kind-leafkind1", "pe-kind-worker2", "192.168.11.2", "192.168.11.5")
-	addLinkIPv6s("clab-kind-leafkind1", "pe-kind-worker2", "2001:db8:11::2", "2001:db8:11::5")
-	addLinkInterfaces("clab-kind-leafkind1", "pe-kind-worker2", "tokindworker2", "toleafkind1")
-	addLinkIPs("clab-kind-leafkind1", "clab-kind-spine", "192.168.1.5", "192.168.1.4")
+func registerFabricLinks() {
+	spine := ClabPrefix + "spine"
 
-	// leafkind2 links - bridge connections use toswitch2
-	addLinkIPs("clab-kind-leafkind2", "pe-kind-control-plane", "192.168.12.2", "192.168.12.3")
-	addLinkIPv6s("clab-kind-leafkind2", "pe-kind-control-plane", "2001:db8:12::2", "2001:db8:12::3")
-	addLinkInterfaces("clab-kind-leafkind2", "pe-kind-control-plane", "tokindctrlpl", "toleafkind2")
-	addLinkIPs("clab-kind-leafkind2", "pe-kind-worker", "192.168.12.2", "192.168.12.4")
-	addLinkIPv6s("clab-kind-leafkind2", "pe-kind-worker", "2001:db8:12::2", "2001:db8:12::4")
-	addLinkInterfaces("clab-kind-leafkind2", "pe-kind-worker", "tokindworker", "toleafkind2")
-	addLinkIPs("clab-kind-leafkind2", "pe-kind-worker2", "192.168.12.2", "192.168.12.5")
-	addLinkIPv6s("clab-kind-leafkind2", "pe-kind-worker2", "2001:db8:12::2", "2001:db8:12::5")
-	addLinkInterfaces("clab-kind-leafkind2", "pe-kind-worker2", "tokindworker2", "toleafkind2")
-	addLinkIPs("clab-kind-leafkind2", "clab-kind-spine", "192.168.1.7", "192.168.1.6")
+	addLinkIPs(KindLeaf, spine, "192.168.1.5", "192.168.1.4")
+	addLinkIPs(KindLeaf2, spine, "192.168.1.7", "192.168.1.6")
+	addLinkIPs(LeafA, spine, "192.168.1.1", "192.168.1.0")
+	addLinkIPs(LeafB, spine, "192.168.1.3", "192.168.1.2")
+	addLinkIPs(LeafA, ClabPrefix+"hostA_red", "192.168.20.1", HostARedIPv4)
+	addLinkIPs(LeafA, ClabPrefix+"hostA_blue", "192.168.21.1", HostABlueIPv4)
+	addLinkIPs(LeafB, ClabPrefix+"hostB_red", "192.169.20.1", HostBRedIPv4)
+	addLinkIPs(LeafB, ClabPrefix+"hostB_blue", "192.169.21.1", HostBBlueIPv4)
+}
 
-	// Other leaf links
-	addLinkIPs("clab-kind-leafA", "clab-kind-spine", "192.168.1.1", "192.168.1.0")
-	addLinkIPs("clab-kind-leafB", "clab-kind-spine", "192.168.1.3", "192.168.1.2")
-	addLinkIPs("clab-kind-leafA", "clab-kind-hostA_red", "192.168.20.1", HostARedIPv4)
-	addLinkIPs("clab-kind-leafA", "clab-kind-hostA_blue", "192.168.21.1", HostABlueIPv4)
-	addLinkIPs("clab-kind-leafB", "clab-kind-hostB_red", "192.169.20.1", HostBRedIPv4)
-	addLinkIPs("clab-kind-leafB", "clab-kind-hostB_blue", "192.169.21.1", HostBBlueIPv4)
+func registerNodeLinks(cfg nodeLinksConfig) {
+	for nodeName, nc := range cfg.Nodes {
+		addLinkIPs(KindLeaf, nodeName, kindLeafIP, nc.IPForKindLeaf)
+		addLinkIPs(KindLeaf2, nodeName, kindLeaf2IP, nc.IPForKindLeaf2)
+		addLinkIPv6s(KindLeaf, nodeName, kindLeafIPv6, nc.IPv6ForKindLeaf)
+		addLinkIPv6s(KindLeaf2, nodeName, kindLeaf2IPv6, nc.IPv6ForKindLeaf2)
+		addLinkInterfaces(KindLeaf, nodeName, nc.LeafIfaceForKindLeaf, nc.IfaceForKindLeaf)
+		addLinkInterfaces(KindLeaf2, nodeName, nc.LeafIfaceForKindLeaf2, nc.IfaceForKindLeaf2)
+	}
 }
 
 type link struct {

--- a/e2etests/pkg/infra/routers.go
+++ b/e2etests/pkg/infra/routers.go
@@ -47,32 +47,30 @@ var linksForFamily map[ipfamily.Family]map[link]linkAddresses
 
 func init() {
 	linksForFamily = map[ipfamily.Family]map[link]linkAddresses{}
+}
 
-	// leafkind1 links - bridge connections use toswitch1
-	addLinkIPs("clab-kind-leafkind1", "pe-kind-control-plane", "192.168.11.2", "192.168.11.3")
-	addLinkIPv6s("clab-kind-leafkind1", "pe-kind-control-plane", "2001:db8:11::2", "2001:db8:11::3")
-	addLinkInterfaces("clab-kind-leafkind1", "pe-kind-control-plane", "tokindctrlpl", "toleafkind1")
-	addLinkIPs("clab-kind-leafkind1", "pe-kind-worker", "192.168.11.2", "192.168.11.4")
-	addLinkIPv6s("clab-kind-leafkind1", "pe-kind-worker", "2001:db8:11::2", "2001:db8:11::4")
-	addLinkInterfaces("clab-kind-leafkind1", "pe-kind-worker", "tokindworker", "toleafkind1")
-	addLinkIPs("clab-kind-leafkind1", "clab-kind-spine", "192.168.1.5", "192.168.1.4")
+func registerFabricLinks() {
+	spine := ClabPrefix + "spine"
 
-	// leafkind2 links - bridge connections use toswitch2
-	addLinkIPs("clab-kind-leafkind2", "pe-kind-control-plane", "192.168.12.2", "192.168.12.3")
-	addLinkIPv6s("clab-kind-leafkind2", "pe-kind-control-plane", "2001:db8:12::2", "2001:db8:12::3")
-	addLinkInterfaces("clab-kind-leafkind2", "pe-kind-control-plane", "tokindctrlpl", "toleafkind2")
-	addLinkIPs("clab-kind-leafkind2", "pe-kind-worker", "192.168.12.2", "192.168.12.4")
-	addLinkIPv6s("clab-kind-leafkind2", "pe-kind-worker", "2001:db8:12::2", "2001:db8:12::4")
-	addLinkInterfaces("clab-kind-leafkind2", "pe-kind-worker", "tokindworker", "toleafkind2")
-	addLinkIPs("clab-kind-leafkind2", "clab-kind-spine", "192.168.1.7", "192.168.1.6")
+	addLinkIPs(KindLeaf, spine, "192.168.1.5", "192.168.1.4")
+	addLinkIPs(KindLeaf2, spine, "192.168.1.7", "192.168.1.6")
+	addLinkIPs(LeafA, spine, "192.168.1.1", "192.168.1.0")
+	addLinkIPs(LeafB, spine, "192.168.1.3", "192.168.1.2")
+	addLinkIPs(LeafA, ClabPrefix+"hostA_red", "192.168.20.1", HostARedIPv4)
+	addLinkIPs(LeafA, ClabPrefix+"hostA_blue", "192.168.21.1", HostABlueIPv4)
+	addLinkIPs(LeafB, ClabPrefix+"hostB_red", "192.169.20.1", HostBRedIPv4)
+	addLinkIPs(LeafB, ClabPrefix+"hostB_blue", "192.169.21.1", HostBBlueIPv4)
+}
 
-	// Other leaf links
-	addLinkIPs("clab-kind-leafA", "clab-kind-spine", "192.168.1.1", "192.168.1.0")
-	addLinkIPs("clab-kind-leafB", "clab-kind-spine", "192.168.1.3", "192.168.1.2")
-	addLinkIPs("clab-kind-leafA", "clab-kind-hostA_red", "192.168.20.1", HostARedIPv4)
-	addLinkIPs("clab-kind-leafA", "clab-kind-hostA_blue", "192.168.21.1", HostABlueIPv4)
-	addLinkIPs("clab-kind-leafB", "clab-kind-hostB_red", "192.169.20.1", HostBRedIPv4)
-	addLinkIPs("clab-kind-leafB", "clab-kind-hostB_blue", "192.169.21.1", HostBBlueIPv4)
+func registerNodeLinks(cfg nodeLinksConfig) {
+	for nodeName, nc := range cfg.Nodes {
+		addLinkIPs(KindLeaf, nodeName, kindLeafIP, nc.IPForKindLeaf)
+		addLinkIPs(KindLeaf2, nodeName, kindLeaf2IP, nc.IPForKindLeaf2)
+		addLinkIPv6s(KindLeaf, nodeName, kindLeafIPv6, nc.IPv6ForKindLeaf)
+		addLinkIPv6s(KindLeaf2, nodeName, kindLeaf2IPv6, nc.IPv6ForKindLeaf2)
+		addLinkInterfaces(KindLeaf, nodeName, nc.LeafIfaceForKindLeaf, nc.IfaceForKindLeaf)
+		addLinkInterfaces(KindLeaf2, nodeName, nc.LeafIfaceForKindLeaf2, nc.IfaceForKindLeaf2)
+	}
 }
 
 type link struct {

--- a/e2etests/pkg/openperouter/dump_podman.go
+++ b/e2etests/pkg/openperouter/dump_podman.go
@@ -20,7 +20,7 @@ func DumpPodmanLogs(nodes []corev1.Node) (string, error) {
 	for _, node := range nodes {
 		res.WriteString(fmt.Sprintf("####### Node: %s\n", node.Name))
 
-		exec := executor.ForContainer(node.Name)
+		exec := executor.ForNode(node.Name)
 
 		res.WriteString(fmt.Sprintf("### Podman pods on %s:\n", node.Name))
 		podList, err := exec.Exec("podman", "pod", "ps", "--format", "{{.Name}}")

--- a/e2etests/pkg/openperouter/interface.go
+++ b/e2etests/pkg/openperouter/interface.go
@@ -15,7 +15,7 @@ import (
 // network namespace on nodeName. Pass NamedNetns for the perouter netns,
 // or an empty string for the default netns.
 func IsInterfaceInNS(nodeName, intf string, ns string) bool {
-	exec := executor.ForContainer(nodeName)
+	exec := executor.ForNode(nodeName)
 	if ns == "" {
 		_, err := exec.Exec("ip", "link", "show", intf)
 		return err == nil
@@ -35,7 +35,7 @@ var addrRegexp = regexp.MustCompile(`\s(inet6?\s+\S+)`)
 // InterfaceIPAddresses returns the non-link-local IP addresses assigned to the
 // interface in the default netns on nodeName, sorted and newline-joined.
 func InterfaceIPAddresses(nodeName, intf string) (string, error) {
-	exec := executor.ForContainer(nodeName)
+	exec := executor.ForNode(nodeName)
 	out, err := exec.Exec("ip", "-o", "a", "ls", "dev", intf, "scope", "global")
 	if err != nil {
 		return "", err
@@ -57,7 +57,7 @@ func InterfaceIPAddresses(nodeName, intf string) (string, error) {
 // prefix length) assigned to intf inside the named netns on nodeName, or an
 // error if none is found.
 func InterfaceIPv4InNetns(nodeName, intf, ns string) (string, error) {
-	exec := executor.ForContainer(nodeName)
+	exec := executor.ForNode(nodeName)
 	out, err := exec.Exec("ip", "netns", "exec", ns, "ip", "-4", "-o", "a", "ls", "dev", intf, "scope", "global")
 	if err != nil {
 		return "", err
@@ -81,7 +81,7 @@ func InterfaceIPv4InNetns(nodeName, intf, ns string) (string, error) {
 // InterfaceIsUp checks whether the interface in the default netns
 // on nodeName has state UP.
 func InterfaceIsUp(nodeName, intf string) bool {
-	exec := executor.ForContainer(nodeName)
+	exec := executor.ForNode(nodeName)
 	out, err := exec.Exec("ip", "link", "show", intf, "up")
 	if err != nil {
 		return false

--- a/e2etests/pkg/openperouter/netns.go
+++ b/e2etests/pkg/openperouter/netns.go
@@ -14,7 +14,7 @@ const NamedNetns = "perouter"
 
 // NamedNetnsExists checks whether /var/run/netns/perouter is present on nodeName.
 func NamedNetnsExists(nodeName string) (bool, error) {
-	exec := executor.ForContainer(nodeName)
+	exec := executor.ForNode(nodeName)
 	out, err := exec.Exec("ip", "netns", "list")
 	if err != nil {
 		return false, err
@@ -33,7 +33,7 @@ func NamedNetnsExists(nodeName string) (bool, error) {
 // NamedNetnsHasInterfaceType checks whether the named netns contains at least one
 // interface of the given link type (e.g. "vrf", "bridge", "vxlan").
 func NamedNetnsHasInterfaceType(nodeName, linkType string) (bool, error) {
-	exec := executor.ForContainer(nodeName)
+	exec := executor.ForNode(nodeName)
 	out, err := exec.Exec("ip", "netns", "exec", NamedNetns, "ip", "link", "show", "type", linkType)
 	if err != nil {
 		return false, err
@@ -45,7 +45,7 @@ func NamedNetnsHasInterfaceType(nodeName, linkType string) (bool, error) {
 // netns, then runs "ip netns delete perouter" on nodeName. Pre-deleting
 // devices accelerates the kernel's async cleanup_net() from ~28s to <2s.
 func DeleteNamedNetns(nodeName string) error {
-	e := executor.ForContainer(nodeName)
+	e := executor.ForNode(nodeName)
 
 	if err := deleteNetnsDevices(e); err != nil {
 		log.Printf("pre-deletion of devices failed for %q, proceeding with netns delete: %v", nodeName, err)
@@ -60,7 +60,7 @@ func DeleteNamedNetns(nodeName string) error {
 // the default loopback interfaces on the VTEP loopback (lo), and by checking
 // that `lo` is up.
 func UnderlayConfigured(nodeName string) (bool, error) {
-	exec := executor.ForContainer(nodeName)
+	exec := executor.ForNode(nodeName)
 
 	out, err := exec.Exec("ip", "netns", "list")
 	if err != nil {
@@ -92,7 +92,7 @@ func UnderlayConfigured(nodeName string) (bool, error) {
 // UnderlayVethExists checks whether the toswitch interfaces exist on nodeName,
 // either in the default netns or inside the perouter netns.
 func UnderlayVethsExists(nodeName string) bool {
-	exec := executor.ForContainer(nodeName)
+	exec := executor.ForNode(nodeName)
 	for _, iface := range []string{"toswitch1", "toswitch2"} {
 		if _, err := exec.Exec("ip", "link", "show", iface); err == nil {
 			return true

--- a/e2etests/pkg/openperouter/openperouter.go
+++ b/e2etests/pkg/openperouter/openperouter.go
@@ -14,10 +14,9 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 )
 
-const (
-	Namespace           = "openperouter-system"
-	routerLabelSelector = "app=router"
-)
+const routerLabelSelector = "app=router"
+
+var Namespace = "openperouter-system"
 
 type Routers interface {
 	Dump(writer io.Writer)

--- a/e2etests/pkg/openperouter/openperouter.go
+++ b/e2etests/pkg/openperouter/openperouter.go
@@ -28,6 +28,7 @@ type Routers interface {
 type RouterExecutor interface {
 	executor.Executor
 	Name() string
+	NodeName() string
 }
 
 func Get(cs clientset.Interface, hostMode bool) (Routers, error) {

--- a/e2etests/pkg/openperouter/pod_routers.go
+++ b/e2etests/pkg/openperouter/pod_routers.go
@@ -44,6 +44,10 @@ func (r routerPod) Name() string {
 	return r.Pod.Name
 }
 
+func (r routerPod) NodeName() string {
+	return r.Pod.Spec.NodeName
+}
+
 func (r routerPods) GetExecutors() iter.Seq[RouterExecutor] {
 	return func(yield func(RouterExecutor) bool) {
 		for _, pod := range r.pods {

--- a/e2etests/pkg/openperouter/podman_routers.go
+++ b/e2etests/pkg/openperouter/podman_routers.go
@@ -102,8 +102,8 @@ func checkFRRDaemons(router routerPodman) error {
 }
 
 func getPodmanRouterPID(nodeName string) (string, error) {
-	exec := executor.ForContainer(nodeName)
 	// Read the PID from the file written by the router pod
+	exec := executor.ForNode(nodeName)
 	out, err := exec.Exec("cat", "/etc/perouter/frr/frr.pid")
 	if err != nil {
 		return "", fmt.Errorf("failed to read PID file: %w, output: %s", err, out)

--- a/e2etests/pkg/openperouter/podman_routers.go
+++ b/e2etests/pkg/openperouter/podman_routers.go
@@ -28,6 +28,10 @@ func (r routerPodman) Name() string {
 	return r.nodeName
 }
 
+func (r routerPodman) NodeName() string {
+	return r.nodeName
+}
+
 func (r routerPodmans) GetExecutors() iter.Seq[RouterExecutor] {
 	return func(yield func(RouterExecutor) bool) {
 		for _, router := range r.routers {

--- a/e2etests/scale_suite/suite_test.go
+++ b/e2etests/scale_suite/suite_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openperouter/openperouter/e2etests/pkg/config"
 	"github.com/openperouter/openperouter/e2etests/pkg/executor"
+	"github.com/openperouter/openperouter/e2etests/pkg/frrk8s"
 	"github.com/openperouter/openperouter/e2etests/pkg/k8sclient"
 	"github.com/openperouter/openperouter/e2etests/pkg/openperouter"
 	"github.com/openperouter/openperouter/e2etests/scale_tests"
@@ -49,7 +50,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	log.SetLogger(zap.New(zap.WriteTo(ginkgo.GinkgoWriter), zap.UseDevMode(true)))
 	clientconfig, err := k8sclient.RestConfig()
 	Expect(err).NotTo(HaveOccurred(), "failed to load kubeconfig (KUBECONFIG=%s)", os.Getenv("KUBECONFIG"))
-	updater, err = config.UpdaterForCRs(clientconfig, openperouter.Namespace)
+	updater, err = config.UpdaterForCRs(clientconfig, openperouter.Namespace, frrk8s.Namespace)
 	Expect(err).NotTo(HaveOccurred())
 	scale_tests.Updater = updater
 })

--- a/e2etests/suite/suite_test.go
+++ b/e2etests/suite/suite_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openperouter/openperouter/e2etests/pkg/config"
 	"github.com/openperouter/openperouter/e2etests/pkg/executor"
 	"github.com/openperouter/openperouter/e2etests/pkg/frrk8s"
+	"github.com/openperouter/openperouter/e2etests/pkg/infra"
 	"github.com/openperouter/openperouter/e2etests/pkg/k8s"
 	"github.com/openperouter/openperouter/e2etests/pkg/k8sclient"
 	"github.com/openperouter/openperouter/e2etests/pkg/openperouter"
@@ -23,7 +24,8 @@ import (
 )
 
 var (
-	updater *config.Updater
+	updater            *config.Updater
+	nodeLinkConfigPath string
 )
 
 // handleFlags sets up all flags and parses the command line.
@@ -35,6 +37,7 @@ func handleFlags() {
 	flag.BoolVar(&tests.GroutMode, "groutmode", false, "tells if openperouter is running with grout dataplane")
 	flag.BoolVar(&tests.SkipUnderlayPassthrough, "skip-underlay-passthrough", false, "skip creating underlay in passthrough tests")
 	flag.StringVar(&frrk8s.Namespace, "frrk8s-namespace", frrk8s.Namespace, "namespace where FRR-K8s pods run")
+	flag.StringVar(&nodeLinkConfigPath, "nodelink-config", "../nodelink-default.json", "path to node links config JSON")
 	flag.Parse()
 }
 
@@ -73,6 +76,11 @@ var _ = ginkgo.BeforeSuite(func() {
 	tests.K8sReporter = reporter
 
 	cs := k8sclient.New()
+
+	ginkgo.By("Registering fabric and node links from " + nodeLinkConfigPath)
+	err = infra.RegisterLinks(nodeLinkConfigPath)
+	Expect(err).NotTo(HaveOccurred(), "failed to register links")
+
 	ginkgo.By("validating CNI binaries and cache directory in controller")
 	Eventually(func(g Gomega) {
 		tests.ValidateCNIBinaries(g, cs)

--- a/e2etests/suite/suite_test.go
+++ b/e2etests/suite/suite_test.go
@@ -38,6 +38,7 @@ func handleFlags() {
 	flag.BoolVar(&tests.GroutMode, "groutmode", false, "tells if openperouter is running with grout dataplane")
 	flag.BoolVar(&tests.SkipUnderlayPassthrough, "skip-underlay-passthrough", false, "skip creating underlay in passthrough tests")
 	flag.StringVar(&frrk8s.Namespace, "frrk8s-namespace", frrk8s.Namespace, "namespace where FRR-K8s pods run")
+	flag.StringVar(&openperouter.Namespace, "openperouter-namespace", openperouter.Namespace, "namespace where OpenPERouter pods run")
 	flag.StringVar(&nodeLinkConfigPath, "nodelink-config", "../nodelink-default.json", "path to node links config JSON")
 	flag.StringVar(&nodeExecImage, "node-exec-image", "busybox:1.36", "container image for node-exec-helper pods")
 	flag.Parse()

--- a/e2etests/suite/suite_test.go
+++ b/e2etests/suite/suite_test.go
@@ -34,6 +34,7 @@ func handleFlags() {
 	flag.BoolVar(&tests.HostMode, "systemdmode", false, "tells if openperouter is running on the host")
 	flag.BoolVar(&tests.GroutMode, "groutmode", false, "tells if openperouter is running with grout dataplane")
 	flag.BoolVar(&tests.SkipUnderlayPassthrough, "skip-underlay-passthrough", false, "skip creating underlay in passthrough tests")
+	flag.StringVar(&frrk8s.Namespace, "frrk8s-namespace", frrk8s.Namespace, "namespace where FRR-K8s pods run")
 	flag.Parse()
 }
 
@@ -60,7 +61,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	log.SetLogger(zap.New(zap.WriteTo(ginkgo.GinkgoWriter), zap.UseDevMode(true)))
 	clientconfig, err := k8sclient.RestConfig()
 	Expect(err).NotTo(HaveOccurred(), "failed to load kubeconfig (KUBECONFIG=%s)", os.Getenv("KUBECONFIG"))
-	updater, err = config.UpdaterForCRs(clientconfig, openperouter.Namespace)
+	updater, err = config.UpdaterForCRs(clientconfig, openperouter.Namespace, frrk8s.Namespace)
 	Expect(err).NotTo(HaveOccurred())
 	tests.Updater = updater
 	kubeconfig := os.Getenv("KUBECONFIG")

--- a/e2etests/suite/suite_test.go
+++ b/e2etests/suite/suite_test.go
@@ -26,6 +26,7 @@ import (
 var (
 	updater            *config.Updater
 	nodeLinkConfigPath string
+	nodeExecImage      string
 )
 
 // handleFlags sets up all flags and parses the command line.
@@ -38,6 +39,7 @@ func handleFlags() {
 	flag.BoolVar(&tests.SkipUnderlayPassthrough, "skip-underlay-passthrough", false, "skip creating underlay in passthrough tests")
 	flag.StringVar(&frrk8s.Namespace, "frrk8s-namespace", frrk8s.Namespace, "namespace where FRR-K8s pods run")
 	flag.StringVar(&nodeLinkConfigPath, "nodelink-config", "../nodelink-default.json", "path to node links config JSON")
+	flag.StringVar(&nodeExecImage, "node-exec-image", "busybox:1.36", "container image for node-exec-helper pods")
 	flag.Parse()
 }
 
@@ -76,6 +78,8 @@ var _ = ginkgo.BeforeSuite(func() {
 	tests.K8sReporter = reporter
 
 	cs := k8sclient.New()
+	err = executor.SetupNodeExec(cs, frrk8s.Namespace, nodeExecImage)
+	Expect(err).NotTo(HaveOccurred(), "failed to setup node-exec-helper")
 
 	ginkgo.By("Registering fabric and node links from " + nodeLinkConfigPath)
 	err = infra.RegisterLinks(nodeLinkConfigPath)
@@ -88,6 +92,8 @@ var _ = ginkgo.BeforeSuite(func() {
 })
 
 var _ = ginkgo.AfterSuite(func() {
+	Expect(executor.TeardownNodeExec()).NotTo(HaveOccurred())
+
 	if updater == nil {
 		return
 	}

--- a/e2etests/suite/suite_test.go
+++ b/e2etests/suite/suite_test.go
@@ -26,6 +26,7 @@ import (
 var (
 	updater            *config.Updater
 	nodeLinkConfigPath string
+	nodeExecImage      string
 )
 
 // handleFlags sets up all flags and parses the command line.
@@ -38,6 +39,7 @@ func handleFlags() {
 	flag.BoolVar(&tests.SkipUnderlayPassthrough, "skip-underlay-passthrough", false, "skip creating underlay in passthrough tests")
 	flag.StringVar(&frrk8s.Namespace, "frrk8s-namespace", frrk8s.Namespace, "namespace where FRR-K8s pods run")
 	flag.StringVar(&nodeLinkConfigPath, "nodelink-config", "../nodelink-default.json", "path to node links config JSON")
+	flag.StringVar(&nodeExecImage, "node-exec-image", "busybox:1.36", "container image for node-exec-helper pods")
 	flag.Parse()
 }
 
@@ -76,6 +78,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	tests.K8sReporter = reporter
 
 	cs := k8sclient.New()
+	Expect(executor.SetupNodeExec(cs, frrk8s.Namespace, nodeExecImage)).To(Succeed(), "failed to setup node-exec-helper")
 
 	ginkgo.By("Registering fabric and node links from " + nodeLinkConfigPath)
 	Expect(infra.RegisterLinks(nodeLinkConfigPath)).To(Succeed())
@@ -87,6 +90,8 @@ var _ = ginkgo.BeforeSuite(func() {
 })
 
 var _ = ginkgo.AfterSuite(func() {
+	Expect(executor.TeardownNodeExec()).NotTo(HaveOccurred())
+
 	if updater == nil {
 		return
 	}

--- a/e2etests/suite/suite_test.go
+++ b/e2etests/suite/suite_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openperouter/openperouter/e2etests/pkg/config"
 	"github.com/openperouter/openperouter/e2etests/pkg/executor"
 	"github.com/openperouter/openperouter/e2etests/pkg/frrk8s"
+	"github.com/openperouter/openperouter/e2etests/pkg/infra"
 	"github.com/openperouter/openperouter/e2etests/pkg/k8s"
 	"github.com/openperouter/openperouter/e2etests/pkg/k8sclient"
 	"github.com/openperouter/openperouter/e2etests/pkg/openperouter"
@@ -23,7 +24,8 @@ import (
 )
 
 var (
-	updater *config.Updater
+	updater            *config.Updater
+	nodeLinkConfigPath string
 )
 
 // handleFlags sets up all flags and parses the command line.
@@ -35,6 +37,7 @@ func handleFlags() {
 	flag.BoolVar(&tests.GroutMode, "groutmode", false, "tells if openperouter is running with grout dataplane")
 	flag.BoolVar(&tests.SkipUnderlayPassthrough, "skip-underlay-passthrough", false, "skip creating underlay in passthrough tests")
 	flag.StringVar(&frrk8s.Namespace, "frrk8s-namespace", frrk8s.Namespace, "namespace where FRR-K8s pods run")
+	flag.StringVar(&nodeLinkConfigPath, "nodelink-config", "../nodelink-default.json", "path to node links config JSON")
 	flag.Parse()
 }
 
@@ -73,6 +76,10 @@ var _ = ginkgo.BeforeSuite(func() {
 	tests.K8sReporter = reporter
 
 	cs := k8sclient.New()
+
+	ginkgo.By("Registering fabric and node links from " + nodeLinkConfigPath)
+	Expect(infra.RegisterLinks(nodeLinkConfigPath)).To(Succeed())
+
 	ginkgo.By("validating CNI binaries and cache directory in controller")
 	Eventually(func(g Gomega) {
 		tests.ValidateCNIBinaries(g, cs)

--- a/e2etests/systemd_static_suite/suite_test.go
+++ b/e2etests/systemd_static_suite/suite_test.go
@@ -11,17 +11,21 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openperouter/openperouter/e2etests/pkg/config"
 	"github.com/openperouter/openperouter/e2etests/pkg/executor"
+	"github.com/openperouter/openperouter/e2etests/pkg/frrk8s"
+	"github.com/openperouter/openperouter/e2etests/pkg/k8sclient"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 var (
-	updater *config.Updater
+	updater       *config.Updater
+	nodeExecImage string
 )
 
 // handleFlags sets up all flags and parses the command line.
 func handleFlags() {
 	flag.StringVar(&executor.Kubectl, "kubectl", "kubectl", "the path for the kubectl binary")
+	flag.StringVar(&nodeExecImage, "node-exec-image", "busybox:1.36", "container image for node-exec-helper pods")
 	flag.Parse()
 }
 
@@ -50,4 +54,12 @@ var _ = ginkgo.BeforeSuite(func() {
 	if kubeconfig == "" {
 		ginkgo.Fail("KUBECONFIG not set")
 	}
+
+	cs := k8sclient.New()
+	err := executor.SetupNodeExec(cs, frrk8s.Namespace, nodeExecImage)
+	Expect(err).NotTo(HaveOccurred(), "failed to setup node-exec-helper")
+})
+
+var _ = ginkgo.AfterSuite(func() {
+	Expect(executor.TeardownNodeExec()).NotTo(HaveOccurred())
 })

--- a/e2etests/systemd_static_suite/suite_test.go
+++ b/e2etests/systemd_static_suite/suite_test.go
@@ -11,17 +11,21 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openperouter/openperouter/e2etests/pkg/config"
 	"github.com/openperouter/openperouter/e2etests/pkg/executor"
+	"github.com/openperouter/openperouter/e2etests/pkg/frrk8s"
+	"github.com/openperouter/openperouter/e2etests/pkg/k8sclient"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 var (
-	updater *config.Updater
+	updater       *config.Updater
+	nodeExecImage string
 )
 
 // handleFlags sets up all flags and parses the command line.
 func handleFlags() {
 	flag.StringVar(&executor.Kubectl, "kubectl", "kubectl", "the path for the kubectl binary")
+	flag.StringVar(&nodeExecImage, "node-exec-image", "busybox:1.36", "container image for node-exec-helper pods")
 	flag.Parse()
 }
 
@@ -50,4 +54,10 @@ var _ = ginkgo.BeforeSuite(func() {
 	if kubeconfig == "" {
 		ginkgo.Fail("KUBECONFIG not set")
 	}
+
+	Expect(executor.SetupNodeExec(k8sclient.New(), frrk8s.Namespace, nodeExecImage)).To(Succeed(), "failed to setup node-exec-helper")
+})
+
+var _ = ginkgo.AfterSuite(func() {
+	Expect(executor.TeardownNodeExec()).NotTo(HaveOccurred())
 })

--- a/e2etests/tests/cni_lifecycle.go
+++ b/e2etests/tests/cni_lifecycle.go
@@ -209,7 +209,7 @@ var _ = Describe("CNI underlay lifecycle", Ordered, func() {
 
 		By("deleting the CNI interface directly, behind the controller's back")
 		for _, node := range nodes {
-			exec := executor.ForContainer(node.Name)
+			exec := executor.ForNode(node.Name)
 			_, err := exec.Exec("ip", "netns", "exec", openperouter.NamedNetns, "ip", "link", "del", lcUnderlayStaticInterface)
 			Expect(err).NotTo(HaveOccurred())
 		}
@@ -415,7 +415,7 @@ var _ = Describe("DHCP underlay lifecycle", Ordered, func() {
 func cniInterfaceIndexes(nodes []corev1.Node, ifName string) (map[string]string, error) {
 	res := map[string]string{}
 	for _, node := range nodes {
-		exec := executor.ForContainer(node.Name)
+		exec := executor.ForNode(node.Name)
 		out, err := exec.Exec("ip", "netns", "exec", openperouter.NamedNetns, "ip", "-o", "link", "show", "dev", ifName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get %s ifindex on %s: %w", ifName, node.Name, err)
@@ -433,6 +433,6 @@ func cniInterfaceIndexes(nodes []corev1.Node, ifName string) (map[string]string,
 // to become active again with a fresh main PID.
 func restartSystemdUnit(node corev1.Node, unit string) {
 	By(fmt.Sprintf("restarting %s via systemd on node %s", unit, node.Name))
-	nodeExec := executor.ForContainer(node.Name)
+	nodeExec := executor.ForNode(node.Name)
 	Expect(systemd.RestartSystemdUnit(nodeExec, unit)).To(Succeed())
 }

--- a/e2etests/tests/cni_lifecycle.go
+++ b/e2etests/tests/cni_lifecycle.go
@@ -207,8 +207,8 @@ var _ = Describe("CNI underlay lifecycle", Ordered, func() {
 
 		By("deleting the CNI interface directly, behind the controller's back")
 		for _, node := range nodes {
-			exec := executor.ForContainer(node.Name)
-			_, err := exec.Exec("ip", "netns", "exec", openperouter.NamedNetns, "ip", "link", "del", infra.CNIUnderlayInterface)
+			exec := executor.ForNode(node.Name)
+			_, err = exec.Exec("ip", "netns", "exec", openperouter.NamedNetns, "ip", "link", "del", infra.CNIUnderlayInterface)
 			Expect(err).NotTo(HaveOccurred())
 		}
 		validateCNIInterfacesGone(infra.CNIUnderlayInterface)
@@ -413,7 +413,7 @@ var _ = Describe("DHCP underlay lifecycle", Ordered, func() {
 func cniInterfaceIndexes(nodes []corev1.Node, ifName string) (map[string]string, error) {
 	res := map[string]string{}
 	for _, node := range nodes {
-		exec := executor.ForContainer(node.Name)
+		exec := executor.ForNode(node.Name)
 		out, err := exec.Exec("ip", "netns", "exec", openperouter.NamedNetns, "ip", "-o", "link", "show", "dev", ifName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get %s ifindex on %s: %w", ifName, node.Name, err)
@@ -431,6 +431,6 @@ func cniInterfaceIndexes(nodes []corev1.Node, ifName string) (map[string]string,
 // to become active again with a fresh main PID.
 func restartSystemdUnit(node corev1.Node, unit string) {
 	By(fmt.Sprintf("restarting %s via systemd on node %s", unit, node.Name))
-	nodeExec := executor.ForContainer(node.Name)
+	nodeExec := executor.ForNode(node.Name)
 	Expect(systemd.RestartSystemdUnit(nodeExec, unit)).To(Succeed())
 }

--- a/e2etests/tests/evpn_l2.go
+++ b/e2etests/tests/evpn_l2.go
@@ -29,7 +29,6 @@ var _ = Describe("Routes between bgp and the fabric with Underlay in ipv4", Orde
 	var (
 		cs      clientset.Interface
 		routers openperouter.Routers
-		nodes   []corev1.Node
 	)
 
 	vniRed := v1alpha1.L3VNI{
@@ -82,12 +81,12 @@ var _ = Describe("Routes between bgp and the fabric with Underlay in ipv4", Orde
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		// Create pre-existing OVS bridges on Kind nodes for testing
-		nodes, err = k8s.GetNodes(cs)
+		// Create pre-existing OVS bridges on cluster nodes for testing
+		ovsNodes, err := k8s.GetNodes(cs)
 		Expect(err).NotTo(HaveOccurred())
-		for _, node := range nodes {
-			exec := executor.ForContainer(node.Name)
-			_, err = exec.Exec("ovs-vsctl", "add-br", preExistingOVSBridge)
+		for _, node := range ovsNodes {
+			exec := executor.ForNode(node.Name)
+			_, err = exec.Exec("ovs-vsctl", "--may-exist", "add-br", preExistingOVSBridge)
 			Expect(err).NotTo(HaveOccurred())
 		}
 	})
@@ -104,8 +103,11 @@ var _ = Describe("Routes between bgp and the fabric with Underlay in ipv4", Orde
 			return openperouter.AreReady(routers)
 		}, 2*time.Minute, time.Second).ShouldNot(HaveOccurred())
 
-		for _, node := range nodes {
-			exec := executor.ForContainer(node.Name)
+		// Clean up pre-existing OVS bridges
+		ovsNodes, err := k8s.GetNodes(cs)
+		Expect(err).NotTo(HaveOccurred())
+		for _, node := range ovsNodes {
+			exec := executor.ForNode(node.Name)
 			_, err = exec.Exec("ovs-vsctl", "--if-exists", "del-br", preExistingOVSBridge)
 			Expect(err).NotTo(HaveOccurred())
 		}

--- a/e2etests/tests/evpn_l2.go
+++ b/e2etests/tests/evpn_l2.go
@@ -79,12 +79,12 @@ var _ = Describe("Routes between bgp and the fabric with Underlay in ipv4", Orde
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		// Create pre-existing OVS bridges on Kind nodes for testing
-		nodes := []string{infra.KindControlPlane, infra.KindWorker}
-		for _, nodeName := range nodes {
-			exec := executor.ForContainer(nodeName)
-			// Create OVS bridge (ignore error if bridge already exists)
-			_, err = exec.Exec("ovs-vsctl", "add-br", preExistingOVSBridge)
+		// Create pre-existing OVS bridges on cluster nodes for testing
+		ovsNodes, err := k8s.GetNodes(cs)
+		Expect(err).NotTo(HaveOccurred())
+		for _, node := range ovsNodes {
+			exec := executor.ForNode(node.Name)
+			_, err = exec.Exec("ovs-vsctl", "--may-exist", "add-br", preExistingOVSBridge)
 			Expect(err).NotTo(HaveOccurred())
 		}
 	})
@@ -102,9 +102,10 @@ var _ = Describe("Routes between bgp and the fabric with Underlay in ipv4", Orde
 		}, 2*time.Minute, time.Second).ShouldNot(HaveOccurred())
 
 		// Clean up pre-existing OVS bridges
-		nodes := []string{infra.KindControlPlane, infra.KindWorker}
-		for _, nodeName := range nodes {
-			exec := executor.ForContainer(nodeName)
+		ovsNodes, err := k8s.GetNodes(cs)
+		Expect(err).NotTo(HaveOccurred())
+		for _, node := range ovsNodes {
+			exec := executor.ForNode(node.Name)
 			_, err = exec.Exec("ovs-vsctl", "--if-exists", "del-br", preExistingOVSBridge)
 			Expect(err).NotTo(HaveOccurred())
 		}

--- a/e2etests/tests/l3vpn_l2.go
+++ b/e2etests/tests/l3vpn_l2.go
@@ -122,7 +122,7 @@ var _ = Describe("SRV6 routes between bgp and the fabric", Ordered, func() {
 
 		for _, node := range nodes {
 			By(fmt.Sprintf("adding bridge %s on node %s", preExistingOVSBridge, node.Name))
-			exec := executor.ForContainer(node.Name)
+			exec := executor.ForNode(node.Name)
 			_, err = exec.Exec("ovs-vsctl", "add-br", preExistingOVSBridge)
 			Expect(err).NotTo(HaveOccurred())
 		}
@@ -139,7 +139,7 @@ var _ = Describe("SRV6 routes between bgp and the fabric", Ordered, func() {
 	AfterAll(func() {
 		for _, node := range nodes {
 			By(fmt.Sprintf("deleting bridge %s from node %s", preExistingOVSBridge, node.Name))
-			exec := executor.ForContainer(node.Name)
+			exec := executor.ForNode(node.Name)
 			_, err := exec.Exec("ovs-vsctl", "--if-exists", "del-br", preExistingOVSBridge)
 			Expect(err).NotTo(HaveOccurred())
 		}

--- a/e2etests/tests/node_status.go
+++ b/e2etests/tests/node_status.go
@@ -24,7 +24,7 @@ import (
 )
 
 var _ = Describe("Node Router Status", func() {
-	const routerNamespace = openperouter.Namespace
+	routerNamespace := openperouter.Namespace
 
 	var nodes []corev1.Node
 	var cs kubernetes.Interface

--- a/e2etests/tests/raw_config.go
+++ b/e2etests/tests/raw_config.go
@@ -169,7 +169,7 @@ var _ = Describe("RawFRRConfig", Ordered, func() {
 					return err
 				}
 				hasConfig := strings.Contains(runningConfig, expected)
-				isTarget := strings.Contains(router.Name(), targetNode.Name)
+				isTarget := router.NodeName() == targetNode.Name
 
 				if isTarget && !hasConfig {
 					return fmt.Errorf("target router %s running config does not contain %q", router.Name(), expected)

--- a/e2etests/tests/resiliency.go
+++ b/e2etests/tests/resiliency.go
@@ -714,7 +714,7 @@ func dumpUnderlayVeths(cs clientset.Interface, label string) {
 	}
 
 	for _, node := range nodes {
-		nodeExec := executor.ForContainer(node.Name)
+		nodeExec := executor.ForNode(node.Name)
 
 		for _, iface := range []string{"toswitch1", "toswitch2"} {
 			for _, loc := range []struct {

--- a/e2etests/tests/systemd_resiliency.go
+++ b/e2etests/tests/systemd_resiliency.go
@@ -91,7 +91,7 @@ var _ = Describe("Systemd Router Restart Resiliency", Label("systemdmode"), Orde
 
 	restartRouterOnNode := func(node corev1.Node) {
 		By("restarting FRR container via systemd on node " + node.Name)
-		nodeExec := executor.ForContainer(node.Name)
+		nodeExec := executor.ForNode(node.Name)
 		Expect(systemd.RestartSystemdUnit(nodeExec, "routerpod-pod.service")).To(Succeed())
 	}
 
@@ -180,7 +180,7 @@ var _ = Describe("Systemd: Named netns and kernel objects survive FRR container 
 	It("should preserve named netns and kernel objects when FRR container is killed", func() {
 		Expect(nodes).NotTo(BeEmpty())
 		nodeName := nodes[0].Name
-		nodeExec := executor.ForContainer(nodeName)
+		nodeExec := executor.ForNode(nodeName)
 
 		By("verifying named netns exists before crash")
 		Expect(openperouter.NamedNetnsExists(nodeName)).To(BeTrue())
@@ -279,7 +279,7 @@ var _ = Describe("Systemd: Controller auto-recovers when operator deletes named 
 	It("should auto-recover after ip netns delete and routerpod restart", func() {
 		Expect(nodes).NotTo(BeEmpty())
 		nodeName := nodes[0].Name
-		nodeExec := executor.ForContainer(nodeName)
+		nodeExec := executor.ForNode(nodeName)
 
 		By("verifying named netns exists")
 		Expect(openperouter.NamedNetnsExists(nodeName)).To(BeTrue())
@@ -423,7 +423,7 @@ var _ = Describe("Systemd: Data plane continuity during FRR restart", Label("sys
 		stopAndCount := measureTrafficLoss(clientExec, urlStr)
 
 		By("restarting routerpod on server's node")
-		serverNodeExec := executor.ForContainer(nodes[0].Name)
+		serverNodeExec := executor.ForNode(nodes[0].Name)
 		_, err = serverNodeExec.Exec("systemctl", "restart", "routerpod-pod.service")
 		Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
The existing suite relies on the cluster being kind (where nodes are containers), making it impossible to run the suite on other k8s clusters. Here we adapt the suite to support generic k8s clusters, under the assumption that the clab is deployed the way (w.r.t to the cluster).

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a node-exec helper for node-scoped E2E command execution with automated setup/teardown.
  * Added JSON-driven node/fabric link registration (including a new default links file) and suite flags for link config and FRR-K8s namespace.

* **Bug Fixes**
  * Improved E2E configuration namespace handling during updates and cleanup.
  * FRR config injection now uses the configured container runtime.
  * Enhanced error handling across interface, netns, and underlay checks.

* **Tests**
  * Updated E2E scenarios to run commands on real Kubernetes nodes and improved polling/error surfacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->