### PR TITLE
fix(examples): make prepare.sh scripts cwd-independent

### DIFF
--- a/examples/common.sh
+++ b/examples/common.sh
@@ -2,6 +2,9 @@
 
 KIND_BIN="${KIND_BIN:-kind}"
 
+REPO_ROOT=$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)
+export KUBECONFIG="${REPO_ROOT}/bin/kubeconfig"
+
 apply_manifests_with_retries() {
   local manifests=("$@")
   for manifest in "${manifests[@]}"; do

--- a/examples/evpn/calico/prepare.sh
+++ b/examples/evpn/calico/prepare.sh
@@ -5,8 +5,7 @@ CURRENT_PATH=$(dirname "$0")
 
 source "${CURRENT_PATH}/../../common.sh"
 
-DEMO_MODE=true CALICO_MODE=true make deploy
-export KUBECONFIG=$(pwd)/bin/kubeconfig
+DEMO_MODE=true CALICO_MODE=true make -C "${REPO_ROOT}" deploy
 
 apply_manifests_with_retries openpe.yaml 
 apply_manifests_with_retries calico_config.yaml  workload.yaml

--- a/examples/evpn/calico/prepare.sh
+++ b/examples/evpn/calico/prepare.sh
@@ -2,11 +2,12 @@
 set -euo pipefail
 set -x
 CURRENT_PATH=$(dirname "$0")
+REPO_ROOT=$(git -C "${CURRENT_PATH}" rev-parse --show-toplevel)
 
 source "${CURRENT_PATH}/../../common.sh"
 
-DEMO_MODE=true CALICO_MODE=true make deploy
-export KUBECONFIG=$(pwd)/bin/kubeconfig
+DEMO_MODE=true CALICO_MODE=true make -C "${REPO_ROOT}" deploy
+export KUBECONFIG="${REPO_ROOT}/bin/kubeconfig"
 
 apply_manifests_with_retries openpe.yaml 
 apply_manifests_with_retries calico_config.yaml  workload.yaml

--- a/examples/evpn/cni-underlay/prepare.sh
+++ b/examples/evpn/cni-underlay/prepare.sh
@@ -2,11 +2,12 @@
 set -euo pipefail
 set -x
 CURRENT_PATH=$(dirname "$0")
+REPO_ROOT=$(git -C "${CURRENT_PATH}" rev-parse --show-toplevel)
 
 source "${CURRENT_PATH}/../../common.sh"
 
-DEMO_MODE=true make deploy
-export KUBECONFIG=$(pwd)/bin/kubeconfig
+DEMO_MODE=true make -C "${REPO_ROOT}" deploy
+export KUBECONFIG="${REPO_ROOT}/bin/kubeconfig"
 
 apply_manifests_with_retries openpe.yaml workload.yaml
 

--- a/examples/evpn/cni-underlay/prepare.sh
+++ b/examples/evpn/cni-underlay/prepare.sh
@@ -5,8 +5,7 @@ CURRENT_PATH=$(dirname "$0")
 
 source "${CURRENT_PATH}/../../common.sh"
 
-DEMO_MODE=true make deploy
-export KUBECONFIG=$(pwd)/bin/kubeconfig
+DEMO_MODE=true make -C "${REPO_ROOT}" deploy
 
 apply_manifests_with_retries openpe.yaml workload.yaml
 

--- a/examples/evpn/kubevirt/prepare.sh
+++ b/examples/evpn/kubevirt/prepare.sh
@@ -5,8 +5,7 @@ CURRENT_PATH=$(dirname "$0")
 
 source "${CURRENT_PATH}/../../common.sh"
 
-DEMO_MODE=true make deploy
-export KUBECONFIG=$(pwd)/bin/kubeconfig
+DEMO_MODE=true make -C "${REPO_ROOT}" deploy
 
 kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/v1.5.2/kubevirt-operator.yaml
 kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/v1.5.2/kubevirt-cr.yaml

--- a/examples/evpn/kubevirt/prepare.sh
+++ b/examples/evpn/kubevirt/prepare.sh
@@ -2,11 +2,12 @@
 set -euo pipefail
 set -x
 CURRENT_PATH=$(dirname "$0")
+REPO_ROOT=$(git -C "${CURRENT_PATH}" rev-parse --show-toplevel)
 
 source "${CURRENT_PATH}/../../common.sh"
 
-DEMO_MODE=true make deploy
-export KUBECONFIG=$(pwd)/bin/kubeconfig
+DEMO_MODE=true make -C "${REPO_ROOT}" deploy
+export KUBECONFIG="${REPO_ROOT}/bin/kubeconfig"
 
 kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/v1.5.2/kubevirt-operator.yaml
 kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/v1.5.2/kubevirt-cr.yaml

--- a/examples/evpn/layer2/prepare.sh
+++ b/examples/evpn/layer2/prepare.sh
@@ -2,11 +2,12 @@
 set -euo pipefail
 set -x
 CURRENT_PATH=$(dirname "$0")
+REPO_ROOT=$(git -C "${CURRENT_PATH}" rev-parse --show-toplevel)
 
 source "${CURRENT_PATH}/../../common.sh"
 
-DEMO_MODE=true make deploy
-export KUBECONFIG=$(pwd)/bin/kubeconfig
+DEMO_MODE=true make -C "${REPO_ROOT}" deploy
+export KUBECONFIG="${REPO_ROOT}/bin/kubeconfig"
 
 apply_manifests_with_retries openpe.yaml workload.yaml
 

--- a/examples/evpn/layer2/prepare.sh
+++ b/examples/evpn/layer2/prepare.sh
@@ -5,8 +5,7 @@ CURRENT_PATH=$(dirname "$0")
 
 source "${CURRENT_PATH}/../../common.sh"
 
-DEMO_MODE=true make deploy
-export KUBECONFIG=$(pwd)/bin/kubeconfig
+DEMO_MODE=true make -C "${REPO_ROOT}" deploy
 
 apply_manifests_with_retries openpe.yaml workload.yaml
 

--- a/examples/evpn/metallb/prepare.sh
+++ b/examples/evpn/metallb/prepare.sh
@@ -5,8 +5,7 @@ CURRENT_PATH=$(dirname "$0")
 
 source "${CURRENT_PATH}/../../common.sh"
 
-DEMO_MODE=true make deploy
-export KUBECONFIG=$(pwd)/bin/kubeconfig
+DEMO_MODE=true make -C "${REPO_ROOT}" deploy
 
 helm repo add metallb https://metallb.github.io/metallb
 

--- a/examples/evpn/metallb/prepare.sh
+++ b/examples/evpn/metallb/prepare.sh
@@ -2,11 +2,12 @@
 set -euo pipefail
 set -x
 CURRENT_PATH=$(dirname "$0")
+REPO_ROOT=$(git -C "${CURRENT_PATH}" rev-parse --show-toplevel)
 
 source "${CURRENT_PATH}/../../common.sh"
 
-DEMO_MODE=true make deploy
-export KUBECONFIG=$(pwd)/bin/kubeconfig
+DEMO_MODE=true make -C "${REPO_ROOT}" deploy
+export KUBECONFIG="${REPO_ROOT}/bin/kubeconfig"
 
 helm repo add metallb https://metallb.github.io/metallb
 

--- a/examples/evpn/multi-cluster/prepare.sh
+++ b/examples/evpn/multi-cluster/prepare.sh
@@ -5,7 +5,7 @@ CURRENT_PATH=$(dirname "$0")
 
 source "${CURRENT_PATH}/../../common.sh"
 
-DEMO_MODE=true make deploy-multi
+DEMO_MODE=true make -C "${REPO_ROOT}" deploy-multi
 
 provision_migration_network() {
     local kubeconfig="$1"
@@ -133,7 +133,7 @@ apply_demo_manifests() {
 
 declare -A kubeconfigs
 
-for kubeconfig in $(pwd)/bin/kubeconfig-*; do
+for kubeconfig in "${REPO_ROOT}"/bin/kubeconfig-*; do
     if [[ -f "$kubeconfig" ]]; then
         cluster_name=$(basename "$kubeconfig" | sed 's/kubeconfig-//')
         kubeconfigs["$cluster_name"]="$kubeconfig"

--- a/examples/evpn/multi-cluster/prepare.sh
+++ b/examples/evpn/multi-cluster/prepare.sh
@@ -2,10 +2,11 @@
 set -euo pipefail
 set -x
 CURRENT_PATH=$(dirname "$0")
+REPO_ROOT=$(git -C "${CURRENT_PATH}" rev-parse --show-toplevel)
 
 source "${CURRENT_PATH}/../../common.sh"
 
-DEMO_MODE=true make deploy-multi
+DEMO_MODE=true make -C "${REPO_ROOT}" deploy-multi
 
 provision_migration_network() {
     local kubeconfig="$1"
@@ -133,7 +134,7 @@ apply_demo_manifests() {
 
 declare -A kubeconfigs
 
-for kubeconfig in $(pwd)/bin/kubeconfig-*; do
+for kubeconfig in "${REPO_ROOT}"/bin/kubeconfig-*; do
     if [[ -f "$kubeconfig" ]]; then
         cluster_name=$(basename "$kubeconfig" | sed 's/kubeconfig-//')
         kubeconfigs["$cluster_name"]="$kubeconfig"

--- a/examples/evpn/route-reflector/prepare.sh
+++ b/examples/evpn/route-reflector/prepare.sh
@@ -5,8 +5,6 @@ CURRENT_PATH=$(dirname "$0")
 
 source "${CURRENT_PATH}/../../common.sh"
 
-DEMO_MODE=true make deploy
-KUBECONFIG="$(pwd)/bin/kubeconfig"
-export KUBECONFIG
+DEMO_MODE=true make -C "${REPO_ROOT}" deploy
 
 apply_manifests_with_retries openpe.yaml workload.yaml

--- a/examples/l3vpn/layer2/prepare.sh
+++ b/examples/l3vpn/layer2/prepare.sh
@@ -5,8 +5,7 @@ CURRENT_PATH=$(dirname "$0")
 
 source "${CURRENT_PATH}/../../common.sh"
 
-DEMO_MODE=true make deploy
-export KUBECONFIG=$(pwd)/bin/kubeconfig
+DEMO_MODE=true make -C "${REPO_ROOT}" deploy
 
 helm repo add metallb https://metallb.github.io/metallb
 

--- a/examples/l3vpn/layer2/prepare.sh
+++ b/examples/l3vpn/layer2/prepare.sh
@@ -2,11 +2,12 @@
 set -euo pipefail
 set -x
 CURRENT_PATH=$(dirname "$0")
+REPO_ROOT=$(git -C "${CURRENT_PATH}" rev-parse --show-toplevel)
 
 source "${CURRENT_PATH}/../../common.sh"
 
-DEMO_MODE=true make deploy
-export KUBECONFIG=$(pwd)/bin/kubeconfig
+DEMO_MODE=true make -C "${REPO_ROOT}" deploy
+export KUBECONFIG="${REPO_ROOT}/bin/kubeconfig"
 
 helm repo add metallb https://metallb.github.io/metallb
 

--- a/examples/l3vpn/metallb/prepare.sh
+++ b/examples/l3vpn/metallb/prepare.sh
@@ -5,8 +5,7 @@ CURRENT_PATH=$(dirname "$0")
 
 source "${CURRENT_PATH}/../../common.sh"
 
-DEMO_MODE=true make deploy
-export KUBECONFIG=$(pwd)/bin/kubeconfig
+DEMO_MODE=true make -C "${REPO_ROOT}" deploy
 
 helm repo add metallb https://metallb.github.io/metallb
 

--- a/examples/l3vpn/metallb/prepare.sh
+++ b/examples/l3vpn/metallb/prepare.sh
@@ -2,11 +2,12 @@
 set -euo pipefail
 set -x
 CURRENT_PATH=$(dirname "$0")
+REPO_ROOT=$(git -C "${CURRENT_PATH}" rev-parse --show-toplevel)
 
 source "${CURRENT_PATH}/../../common.sh"
 
-DEMO_MODE=true make deploy
-export KUBECONFIG=$(pwd)/bin/kubeconfig
+DEMO_MODE=true make -C "${REPO_ROOT}" deploy
+export KUBECONFIG="${REPO_ROOT}/bin/kubeconfig"
 
 helm repo add metallb https://metallb.github.io/metallb
 

--- a/examples/passthrough/metallb/prepare.sh
+++ b/examples/passthrough/metallb/prepare.sh
@@ -5,8 +5,7 @@ CURRENT_PATH=$(dirname "$0")
 
 source "${CURRENT_PATH}/../../common.sh"
 
-DEMO_MODE=true make deploy
-export KUBECONFIG=$(pwd)/bin/kubeconfig
+DEMO_MODE=true make -C "${REPO_ROOT}" deploy
 
 helm repo add metallb https://metallb.github.io/metallb
 

--- a/examples/passthrough/metallb/prepare.sh
+++ b/examples/passthrough/metallb/prepare.sh
@@ -2,11 +2,12 @@
 set -euo pipefail
 set -x
 CURRENT_PATH=$(dirname "$0")
+REPO_ROOT=$(git -C "${CURRENT_PATH}" rev-parse --show-toplevel)
 
 source "${CURRENT_PATH}/../../common.sh"
 
-DEMO_MODE=true make deploy
-export KUBECONFIG=$(pwd)/bin/kubeconfig
+DEMO_MODE=true make -C "${REPO_ROOT}" deploy
+export KUBECONFIG="${REPO_ROOT}/bin/kubeconfig"
 
 helm repo add metallb https://metallb.github.io/metallb
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:


> Uncomment only one, leave it on its own line:
>
> /kind bug

/kind cleanup

> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
Derive REPO_ROOT via `git rev-parse` so make, kubeconfig, and manifest paths resolve correctly
regardless of the caller's working directory.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EVPN, L3VPN, and passthrough deployment examples so they work reliably regardless of the directory used to launch them.
  * Standardized repository and configuration path handling across demo setup scripts.
  * Improved multi-cluster preparation by consistently locating deployment outputs.
  * Reduced failures caused by relative paths while preserving existing deployment, manifest, Helm, and retry workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->