### PR TITLE
fix: drop unused pod delete RBAC from controller

### DIFF
--- a/charts/openperouter/templates/rbac.yaml
+++ b/charts/openperouter/templates/rbac.yaml
@@ -26,7 +26,6 @@ rules:
   resources:
   - pods
   verbs:
-  - delete
   - get
   - list
   - watch

--- a/config/all-in-one/crio.yaml
+++ b/config/all-in-one/crio.yaml
@@ -1871,7 +1871,6 @@ rules:
   resources:
   - pods
   verbs:
-  - delete
   - get
   - list
   - watch

--- a/config/all-in-one/openpe.yaml
+++ b/config/all-in-one/openpe.yaml
@@ -1871,7 +1871,6 @@ rules:
   resources:
   - pods
   verbs:
-  - delete
   - get
   - list
   - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,7 +19,6 @@ rules:
   resources:
   - pods
   verbs:
-  - delete
   - get
   - list
   - watch

--- a/internal/controller/routerconfiguration/underlay_vni_controller.go
+++ b/internal/controller/routerconfiguration/underlay_vni_controller.go
@@ -67,7 +67,7 @@ type PERouterReconciler struct {
 type requestKey string
 
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;delete
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups=network.openperouter.io,resources=l3vnis,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=network.openperouter.io,resources=l3vnis/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=network.openperouter.io,resources=l3vnis/finalizers,verbs=update

--- a/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/openperouter-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2026-07-21T08:46:28Z"
+    createdAt: "2026-07-27T14:56:46Z"
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: openperouter-operator.v0.0.0
@@ -69,7 +69,6 @@ spec:
           resources:
           - pods
           verbs:
-          - delete
           - get
           - list
           - watch


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug

/kind cleanup

> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
The controller only watches pods for readiness changes — it never deletes them. Remove the stale "delete" verb from the pods RBAC rule in the kubebuilder marker, the generated role, and the Helm chart.

**Special notes for your reviewer**:
#615 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Remove pod delete RBAC permissions from the deployment manifest.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Tightened controller RBAC for core pods permissions to viewing/monitoring only (`get`, `list`, `watch`).
  * The controller can no longer delete pods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->