### PR TITLE
fix(underlay): fix neighbor address and neighbor interface dup detection

### DIFF
--- a/internal/conversion/validate_underlay.go
+++ b/internal/conversion/validate_underlay.go
@@ -67,6 +67,11 @@ func validateUnderlay(underlay v1alpha1.Underlay) error {
 		return fmt.Errorf("underlay %s has duplicate neighbor address: %w", underlay.Name, err)
 	}
 
+	if err := validateNoDuplicates(interfaceNamesOf(underlay.Spec.Neighbors)); err != nil {
+		return fmt.Errorf("underlay %s has duplicate neighbor interface names, "+
+			"only one peer is allowed per interface: %w", underlay.Name, err)
+	}
+
 	// do a no-op conversion to catch validation errors
 	if _, err := underlayInterfacesToHost(underlay.Spec.Interfaces); err != nil {
 		return fmt.Errorf("underlay %s has invalid interfaces: %w", underlay.Name, err)
@@ -123,12 +128,23 @@ func validateUnderlayTunnelEndpoint(underlay *v1alpha1.Underlay) error {
 }
 
 func neighborAddressesOf(neighbors []v1alpha1.Neighbor) []string {
-	res := make([]string, len(neighbors))
-	for i, n := range neighbors {
+	res := []string{}
+	for _, n := range neighbors {
 		if n.Address == nil {
 			continue
 		}
-		res[i] = *n.Address
+		res = append(res, *n.Address)
+	}
+	return res
+}
+
+func interfaceNamesOf(neighbors []v1alpha1.Neighbor) []string {
+	res := []string{}
+	for _, n := range neighbors {
+		if n.Interface == nil {
+			continue
+		}
+		res = append(res, *n.Interface)
 	}
 	return res
 }

--- a/internal/conversion/validate_underlay_test.go
+++ b/internal/conversion/validate_underlay_test.go
@@ -14,288 +14,390 @@ import (
 
 func TestValidateUnderlay(t *testing.T) {
 	tests := []struct {
-		name     string
-		underlay v1alpha1.Underlay
-		wantErr  bool
+		name       string
+		underlay   []v1alpha1.Underlay
+		wantErrStr string
 	}{
 		{
 			name: "valid underlay",
-			underlay: v1alpha1.Underlay{
-				Spec: v1alpha1.UnderlaySpec{
-					TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
-						CIDRs: []string{"192.168.1.0/24"},
-					},
-					Interfaces: []v1alpha1.UnderlayInterface{{Type: "NetworkDevice", NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"}}},
-					ASN:        65001,
-					Neighbors: []v1alpha1.Neighbor{
-						{
-							ASN:     new(int64(65002)),
-							Address: new("192.168.1.1"),
+			underlay: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+							CIDRs: []string{"192.168.1.0/24"},
+						},
+						Interfaces: []v1alpha1.UnderlayInterface{
+							{
+								Type:          v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+								NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"},
+							},
+						},
+						ASN: 65001,
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								ASN:     new(int64(65002)),
+								Address: new("192.168.1.1"),
+							},
 						},
 					},
 				},
 			},
-			wantErr: false,
 		},
 		{
 			name: "missing tunnel endpoint configuration",
-			underlay: v1alpha1.Underlay{
-				Spec: v1alpha1.UnderlaySpec{
-					Interfaces: []v1alpha1.UnderlayInterface{{Type: "NetworkDevice", NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"}}},
-					ASN:        65001,
-					Neighbors: []v1alpha1.Neighbor{
-						{
-							ASN:     new(int64(65002)),
-							Address: new("192.168.1.1"),
+			underlay: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						Interfaces: []v1alpha1.UnderlayInterface{
+							{
+								Type:          v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+								NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"},
+							},
+						},
+						ASN: 65001,
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								ASN:     new(int64(65002)),
+								Address: new("192.168.1.1"),
+							},
 						},
 					},
 				},
 			},
-			wantErr: false,
 		},
 		{
 			name: "invalid VTEP CIDR",
-			underlay: v1alpha1.Underlay{
-				Spec: v1alpha1.UnderlaySpec{
-					TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
-						CIDRs: []string{"invalidCIDR"},
-					},
-					Interfaces: []v1alpha1.UnderlayInterface{{Type: "NetworkDevice", NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"}}, {Type: "NetworkDevice", NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth1"}}},
-					ASN:        65001,
-					Neighbors: []v1alpha1.Neighbor{
-						{
-							ASN:     new(int64(65002)),
-							Address: new("192.168.1.1"),
+			underlay: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+							CIDRs: []string{"invalidCIDR"},
+						},
+						Interfaces: []v1alpha1.UnderlayInterface{
+							{
+								Type:          v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+								NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"},
+							},
+							{
+								Type:          v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+								NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth1"},
+							},
+						},
+						ASN: 65001,
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								ASN:     new(int64(65002)),
+								Address: new("192.168.1.1"),
+							},
 						},
 					},
 				},
 			},
-			wantErr: true,
+			wantErrStr: "Underlay/: invalid tunnel endpoint CIDRs for underlay : [invalidCIDR] - " +
+				"invalid cidr: invalid CIDR address: invalidCIDR",
 		},
 		{
 			name: "empty VTEP CIDR",
-			underlay: v1alpha1.Underlay{
-				Spec: v1alpha1.UnderlaySpec{
-					TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
-						CIDRs: []string{""},
-					},
-					Interfaces: []v1alpha1.UnderlayInterface{{Type: "NetworkDevice", NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"}}, {Type: "NetworkDevice", NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth1"}}},
-					ASN:        65001,
-					Neighbors: []v1alpha1.Neighbor{
-						{
-							ASN:     new(int64(65002)),
-							Address: new("192.168.1.1"),
+			underlay: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+							CIDRs: []string{""},
+						},
+						Interfaces: []v1alpha1.UnderlayInterface{
+							{
+								Type:          v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+								NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"},
+							},
+							{
+								Type:          v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+								NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth1"},
+							},
+						},
+						ASN: 65001,
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								ASN:     new(int64(65002)),
+								Address: new("192.168.1.1"),
+							},
 						},
 					},
 				},
 			},
-			wantErr: true,
+			wantErrStr: "Underlay/: invalid tunnel endpoint CIDRs for underlay : [] - " +
+				"invalid cidr: invalid CIDR address:",
 		},
 		{
 			name: "invalid NIC name",
-			underlay: v1alpha1.Underlay{
-				Spec: v1alpha1.UnderlaySpec{
-					TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
-						CIDRs: []string{"192.168.1.0/24"},
-					},
-					Interfaces: []v1alpha1.UnderlayInterface{{Type: "NetworkDevice", NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"}}, {Type: "NetworkDevice", NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "1$^&invalid"}}},
-					ASN:        65001,
-					Neighbors: []v1alpha1.Neighbor{
-						{
-							ASN:     new(int64(65002)),
-							Address: new("192.168.1.1"),
+			underlay: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+							CIDRs: []string{"192.168.1.0/24"},
+						},
+						Interfaces: []v1alpha1.UnderlayInterface{
+							{
+								Type:          v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+								NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"},
+							},
+							{
+								Type: v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+								NetworkDevice: &v1alpha1.NetworkDevice{
+									InterfaceName: "1$^&invalid",
+								},
+							},
+						},
+						ASN: 65001,
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								ASN:     new(int64(65002)),
+								Address: new("192.168.1.1"),
+							},
 						},
 					},
 				},
 			},
-			wantErr: true,
+			wantErrStr: "underlay  has invalid interfaces: invalid interface name 1$^&invalid: interface name " +
+				"1$^&invalid contains invalid characters",
 		},
 		{
 			name: "more than one nic",
-			underlay: v1alpha1.Underlay{
-				Spec: v1alpha1.UnderlaySpec{
-					TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
-						CIDRs: []string{"192.168.1.0/24"},
-					},
-					Interfaces: []v1alpha1.UnderlayInterface{{Type: "NetworkDevice", NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"}}, {Type: "NetworkDevice", NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth1"}}},
-					ASN:        65001,
-					Neighbors: []v1alpha1.Neighbor{
-						{
-							ASN:     new(int64(65002)),
-							Address: new("192.168.1.1"),
+			underlay: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+							CIDRs: []string{"192.168.1.0/24"},
+						},
+						Interfaces: []v1alpha1.UnderlayInterface{
+							{
+								Type:          v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+								NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"},
+							},
+							{
+								Type:          v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+								NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth1"},
+							},
+						},
+						ASN: 65001,
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								ASN:     new(int64(65002)),
+								Address: new("192.168.1.1"),
+							},
 						},
 					},
 				},
 			},
-			wantErr: false,
 		},
 		{
 			name: "same local and remote ASN (iBGP)",
-			underlay: v1alpha1.Underlay{
-				Spec: v1alpha1.UnderlaySpec{
-					TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
-						CIDRs: []string{"192.168.1.0/24"},
-					},
-					ASN: 65001,
-					Neighbors: []v1alpha1.Neighbor{
-						{
-							ASN: new(int64(65001)),
+			underlay: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+							CIDRs: []string{"192.168.1.0/24"},
+						},
+						ASN: 65001,
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								ASN: new(int64(65001)),
+							},
 						},
 					},
 				},
 			},
-			wantErr: false,
 		},
 		{
 			name: "underlay NIC is a vlan sub-interface",
-			underlay: v1alpha1.Underlay{
-				Spec: v1alpha1.UnderlaySpec{
-					TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
-						CIDRs: []string{"192.168.1.0/24"},
-					},
-					Interfaces: []v1alpha1.UnderlayInterface{{Type: "NetworkDevice", NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eno2.161"}}},
-					ASN:        65001,
-					Neighbors: []v1alpha1.Neighbor{
-						{
-							ASN:     new(int64(65002)),
-							Address: new("192.168.1.1"),
+			underlay: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+							CIDRs: []string{"192.168.1.0/24"},
+						},
+						Interfaces: []v1alpha1.UnderlayInterface{
+							{
+								Type:          v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+								NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eno2.161"},
+							},
+						},
+						ASN: 65001,
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								ASN:     new(int64(65002)),
+								Address: new("192.168.1.1"),
+							},
 						},
 					},
 				},
 			},
-			wantErr: false,
 		},
 		{
 			name: "underlay NIC starts with dot",
-			underlay: v1alpha1.Underlay{
-				Spec: v1alpha1.UnderlaySpec{
-					TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
-						CIDRs: []string{"192.168.1.0/24"},
-					},
-					Interfaces: []v1alpha1.UnderlayInterface{{Type: "NetworkDevice", NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: ".eth0"}}},
-					ASN:        65001,
-					Neighbors: []v1alpha1.Neighbor{
-						{
-							ASN:     new(int64(65002)),
-							Address: new("192.168.1.1"),
+			underlay: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+							CIDRs: []string{"192.168.1.0/24"},
+						},
+						Interfaces: []v1alpha1.UnderlayInterface{
+							{
+								Type:          v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+								NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: ".eth0"},
+							},
+						},
+						ASN: 65001,
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								ASN:     new(int64(65002)),
+								Address: new("192.168.1.1"),
+							},
 						},
 					},
 				},
 			},
-			wantErr: true,
+			wantErrStr: "underlay  has invalid interfaces: invalid interface name .eth0: " +
+				"interface name .eth0 contains invalid characters",
 		},
 		{
 			name: "a vlan sub interface whose name is too long",
-			underlay: v1alpha1.Underlay{
-				Spec: v1alpha1.UnderlaySpec{
-					TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
-						CIDRs: []string{"192.168.1.0/24"},
-					},
-					Interfaces: []v1alpha1.UnderlayInterface{{Type: "NetworkDevice", NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "verylongname.123"}}},
-					ASN:        65001,
-					Neighbors: []v1alpha1.Neighbor{
-						{
-							ASN:     new(int64(65002)),
-							Address: new("192.168.1.1"),
+			underlay: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+							CIDRs: []string{"192.168.1.0/24"},
+						},
+						Interfaces: []v1alpha1.UnderlayInterface{
+							{
+								Type:          v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+								NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "verylongname.123"},
+							},
+						},
+						ASN: 65001,
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								ASN:     new(int64(65002)),
+								Address: new("192.168.1.1"),
+							},
 						},
 					},
 				},
 			},
-			wantErr: true,
+			wantErrStr: "underlay  has invalid interfaces: invalid interface name verylongname.123: " +
+				"interface name verylongname.123 can't be longer than 15 characters",
 		},
 		{
 			name: "underlay NIC with invalid characters after dot",
-			underlay: v1alpha1.Underlay{
-				Spec: v1alpha1.UnderlaySpec{
-					TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
-						CIDRs: []string{"192.168.1.0/24"},
-					},
-					Interfaces: []v1alpha1.UnderlayInterface{{Type: "NetworkDevice", NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0.100!"}}},
-					ASN:        65001,
-					Neighbors: []v1alpha1.Neighbor{
-						{
-							ASN:     new(int64(65002)),
-							Address: new("192.168.1.1"),
+			underlay: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+							CIDRs: []string{"192.168.1.0/24"},
+						},
+						Interfaces: []v1alpha1.UnderlayInterface{
+							{
+								Type:          v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+								NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0.100!"},
+							},
+						},
+						ASN: 65001,
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								ASN:     new(int64(65002)),
+								Address: new("192.168.1.1"),
+							},
 						},
 					},
 				},
 			},
-			wantErr: true,
+			wantErrStr: "underlay  has invalid interfaces: invalid interface name eth0.100!: " +
+				"interface name eth0.100! contains invalid characters",
 		},
 		{
 			name: "empty vtepCIDR specified",
-			underlay: v1alpha1.Underlay{
-				Spec: v1alpha1.UnderlaySpec{
-					TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{},
-					Interfaces:     []v1alpha1.UnderlayInterface{{Type: "NetworkDevice", NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"}}},
-					ASN:            65001,
-					Neighbors: []v1alpha1.Neighbor{
-						{
-							ASN:     new(int64(65002)),
-							Address: new("192.168.1.1"),
+			underlay: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{},
+						Interfaces: []v1alpha1.UnderlayInterface{
+							{
+								Type:          v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+								NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"},
+							},
+						},
+						ASN: 65001,
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								ASN:     new(int64(65002)),
+								Address: new("192.168.1.1"),
+							},
 						},
 					},
 				},
 			},
-			wantErr: true,
+			wantErrStr: "underlay : tunnel endpoint CIDRs must be specified",
 		},
 		{
 			name: "valid IPv6-only tunnel endpoint",
-			underlay: v1alpha1.Underlay{
-				Spec: v1alpha1.UnderlaySpec{
-					TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
-						CIDRs: []string{"2001:db8::1/128"},
-					},
-					Interfaces: []v1alpha1.UnderlayInterface{
-						{
-							Type:          "NetworkDevice",
-							NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"},
+			underlay: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+							CIDRs: []string{"2001:db8::1/128"},
 						},
-					},
-					ASN: 65001,
-					Neighbors: []v1alpha1.Neighbor{
-						{
-							ASN:     new(int64(65002)),
-							Address: new("2001:db8::2"),
+						Interfaces: []v1alpha1.UnderlayInterface{
+							{
+								Type:          v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+								NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"},
+							},
+						},
+						ASN: 65001,
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								ASN:     new(int64(65002)),
+								Address: new("2001:db8::2"),
+							},
 						},
 					},
 				},
 			},
-			wantErr: false,
 		},
 		{
 			name: "valid dual-stack tunnel endpoint",
-			underlay: v1alpha1.Underlay{
-				Spec: v1alpha1.UnderlaySpec{
-					TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
-						CIDRs: []string{"192.168.1.0/24", "2001:db8::1/128"},
-					},
-					Interfaces: []v1alpha1.UnderlayInterface{
-						{
-							Type:          "NetworkDevice",
-							NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"},
+			underlay: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+							CIDRs: []string{"192.168.1.0/24", "2001:db8::1/128"},
 						},
-					},
-					ASN: 65001,
-					Neighbors: []v1alpha1.Neighbor{
-						{
-							ASN:     new(int64(65002)),
-							Address: new("192.168.1.1"),
+						Interfaces: []v1alpha1.UnderlayInterface{
+							{
+								Type:          v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+								NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"},
+							},
+						},
+						ASN: 65001,
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								ASN:     new(int64(65002)),
+								Address: new("192.168.1.1"),
+							},
 						},
 					},
 				},
 			},
-			wantErr: false,
 		},
 		{
 			name: "valid SRv6 Locator Format",
-			underlay: v1alpha1.Underlay{
-				Spec: v1alpha1.UnderlaySpec{
-					ASN:       65001,
-					Neighbors: []v1alpha1.Neighbor{{}},
-					SRV6: &v1alpha1.SRV6Config{
-						Locator: v1alpha1.SRV6Locator{
-							Format: "usid-f3216",
+			underlay: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						ASN:       65001,
+						Neighbors: []v1alpha1.Neighbor{{}},
+						SRV6: &v1alpha1.SRV6Config{
+							Locator: v1alpha1.SRV6Locator{
+								Format: "usid-f3216",
+							},
 						},
 					},
 				},
@@ -303,193 +405,358 @@ func TestValidateUnderlay(t *testing.T) {
 		},
 		{
 			name: "invalid SRv6 Locator Format",
-			underlay: v1alpha1.Underlay{
-				Spec: v1alpha1.UnderlaySpec{
-					ASN:       65001,
-					Neighbors: []v1alpha1.Neighbor{{}},
-					SRV6: &v1alpha1.SRV6Config{
-						Locator: v1alpha1.SRV6Locator{
-							Format: "usid-finvalid",
+			underlay: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						ASN:       65001,
+						Neighbors: []v1alpha1.Neighbor{{}},
+						SRV6: &v1alpha1.SRV6Config{
+							Locator: v1alpha1.SRV6Locator{
+								Format: "usid-finvalid",
+							},
 						},
 					},
 				},
 			},
-			wantErr: true,
+			wantErrStr: "invalid locator format \"usid-finvalid\"",
 		},
 		{
 			name: "valid cni interface",
-			underlay: v1alpha1.Underlay{
-				Spec: v1alpha1.UnderlaySpec{
-					TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
-						CIDRs: []string{"192.168.1.0/24"},
-					},
-					Interfaces: []v1alpha1.UnderlayInterface{
-						{
-							Type: v1alpha1.UnderlayInterfaceTypeCNIDevice,
-							CNIDevice: &v1alpha1.CNIDevice{
-								Type:          v1alpha1.CNIConfigTypeRawConfig,
-								RawConfig:     &apiextensionsv1.JSON{Raw: []byte(`{"cniVersion":"1.0.0","name":"macvlan-underlay","type":"macvlan","master":"eth1"}`)},
-								InterfaceName: new("net1"),
+			underlay: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+							CIDRs: []string{"192.168.1.0/24"},
+						},
+						Interfaces: []v1alpha1.UnderlayInterface{
+							{
+								Type: v1alpha1.UnderlayInterfaceTypeCNIDevice,
+								CNIDevice: &v1alpha1.CNIDevice{
+									Type: v1alpha1.CNIConfigTypeRawConfig,
+									RawConfig: &apiextensionsv1.JSON{
+										Raw: []byte(
+											`{"cniVersion":"1.0.0","name":"macvlan-underlay","type":"macvlan","master":"eth1"}`,
+										),
+									},
+									InterfaceName: new("net1"),
+								},
 							},
 						},
-					},
-					ASN: 65001,
-					Neighbors: []v1alpha1.Neighbor{
-						{
-							ASN:     new(int64(65002)),
-							Address: new("192.168.1.1"),
+						ASN: 65001,
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								ASN:     new(int64(65002)),
+								Address: new("192.168.1.1"),
+							},
 						},
 					},
 				},
 			},
-			wantErr: false,
 		},
 		{
 			name: "cni interface with invalid raw config",
-			underlay: v1alpha1.Underlay{
-				Spec: v1alpha1.UnderlaySpec{
-					TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
-						CIDRs: []string{"192.168.1.0/24"},
-					},
-					Interfaces: []v1alpha1.UnderlayInterface{
-						{
-							Type: v1alpha1.UnderlayInterfaceTypeCNIDevice,
-							CNIDevice: &v1alpha1.CNIDevice{
-								Type:          v1alpha1.CNIConfigTypeRawConfig,
-								RawConfig:     &apiextensionsv1.JSON{Raw: []byte(`{"cniVersion":"1.0.0","name":"broken","plugins":"notalist"}`)},
-								InterfaceName: new("net1"),
+			underlay: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+							CIDRs: []string{"192.168.1.0/24"},
+						},
+						Interfaces: []v1alpha1.UnderlayInterface{
+							{
+								Type: v1alpha1.UnderlayInterfaceTypeCNIDevice,
+								CNIDevice: &v1alpha1.CNIDevice{
+									Type: v1alpha1.CNIConfigTypeRawConfig,
+									RawConfig: &apiextensionsv1.JSON{
+										Raw: []byte(
+											`{"cniVersion":"1.0.0","name":"broken","plugins":"notalist"}`,
+										),
+									},
+									InterfaceName: new("net1"),
+								},
 							},
 						},
-					},
-					ASN: 65001,
-					Neighbors: []v1alpha1.Neighbor{
-						{
-							ASN:     new(int64(65002)),
-							Address: new("192.168.1.1"),
+						ASN: 65001,
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								ASN:     new(int64(65002)),
+								Address: new("192.168.1.1"),
+							},
 						},
 					},
 				},
 			},
-			wantErr: true,
+			wantErrStr: "underlay  has invalid interfaces: invalid cni config for interface net1: " +
+				"error parsing configuration list: invalid 'plugins' type string",
+		},
+		{
+			name: "duplicate interface name",
+			underlay: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+							CIDRs: []string{"192.168.1.0/24"},
+						},
+						Interfaces: []v1alpha1.UnderlayInterface{
+							{
+								Type:          v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+								NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"},
+							},
+							{
+								Type:          v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+								NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"},
+							},
+						},
+						ASN: 65001,
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								ASN:     new(int64(65002)),
+								Address: new("192.168.1.1"),
+							},
+						},
+					},
+				},
+			},
+			wantErrStr: "underlay  has invalid interfaces: duplicate underlay interface name eth0",
 		},
 		{
 			name: "mixed network device and cni interfaces",
-			underlay: v1alpha1.Underlay{
-				Spec: v1alpha1.UnderlaySpec{
-					TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
-						CIDRs: []string{"192.168.1.0/24"},
-					},
-					Interfaces: []v1alpha1.UnderlayInterface{
-						{
-							Type:          v1alpha1.UnderlayInterfaceTypeNetworkDevice,
-							NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"},
+			underlay: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+							CIDRs: []string{"192.168.1.0/24"},
 						},
-						{
-							Type: v1alpha1.UnderlayInterfaceTypeCNIDevice,
-							CNIDevice: &v1alpha1.CNIDevice{
-								Type:          v1alpha1.CNIConfigTypeRawConfig,
-								RawConfig:     &apiextensionsv1.JSON{Raw: []byte(`{"cniVersion":"1.0.0","name":"macvlan-underlay","type":"macvlan","master":"eth1"}`)},
-								InterfaceName: new("eth0"),
+						Interfaces: []v1alpha1.UnderlayInterface{
+							{
+								Type:          v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+								NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"},
+							},
+							{
+								Type: v1alpha1.UnderlayInterfaceTypeCNIDevice,
+								CNIDevice: &v1alpha1.CNIDevice{
+									Type: v1alpha1.CNIConfigTypeRawConfig,
+									RawConfig: &apiextensionsv1.JSON{
+										Raw: []byte(
+											`{"cniVersion":"1.0.0","name":"macvlan-underlay","type":"macvlan","master":"eth1"}`,
+										),
+									},
+									InterfaceName: new("eth1"),
+								},
 							},
 						},
-					},
-					ASN: 65001,
-					Neighbors: []v1alpha1.Neighbor{
-						{
-							ASN:     new(int64(65002)),
-							Address: new("192.168.1.1"),
+						ASN: 65001,
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								ASN:     new(int64(65002)),
+								Address: new("192.168.1.1"),
+							},
 						},
 					},
 				},
 			},
-			wantErr: true,
+			wantErrStr: "underlay  has invalid interfaces: all interfaces must be of the same type",
 		},
 		{
 			name: "duplicate cni interface names",
-			underlay: v1alpha1.Underlay{
-				Spec: v1alpha1.UnderlaySpec{
-					TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
-						CIDRs: []string{"192.168.1.0/24"},
-					},
-					Interfaces: []v1alpha1.UnderlayInterface{
-						{
-							Type: v1alpha1.UnderlayInterfaceTypeCNIDevice,
-							CNIDevice: &v1alpha1.CNIDevice{
-								Type:          v1alpha1.CNIConfigTypeRawConfig,
-								RawConfig:     &apiextensionsv1.JSON{Raw: []byte(`{"cniVersion":"1.0.0","name":"macvlan-underlay","type":"macvlan","master":"eth1"}`)},
-								InterfaceName: new("net1"),
+			underlay: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+							CIDRs: []string{"192.168.1.0/24"},
+						},
+						Interfaces: []v1alpha1.UnderlayInterface{
+							{
+								Type: v1alpha1.UnderlayInterfaceTypeCNIDevice,
+								CNIDevice: &v1alpha1.CNIDevice{
+									Type: v1alpha1.CNIConfigTypeRawConfig,
+									RawConfig: &apiextensionsv1.JSON{
+										Raw: []byte(
+											`{"cniVersion":"1.0.0","name":"macvlan-underlay","type":"macvlan","master":"eth1"}`,
+										),
+									},
+									InterfaceName: new("net1"),
+								},
+							},
+							{
+								Type: v1alpha1.UnderlayInterfaceTypeCNIDevice,
+								CNIDevice: &v1alpha1.CNIDevice{
+									Type: v1alpha1.CNIConfigTypeRawConfig,
+									RawConfig: &apiextensionsv1.JSON{
+										Raw: []byte(
+											`{"cniVersion":"1.0.0","name":"ipvlan-underlay","type":"ipvlan","master":"eth2"}`,
+										),
+									},
+									InterfaceName: new("net1"),
+								},
 							},
 						},
-						{
-							Type: v1alpha1.UnderlayInterfaceTypeCNIDevice,
-							CNIDevice: &v1alpha1.CNIDevice{
-								Type:          v1alpha1.CNIConfigTypeRawConfig,
-								RawConfig:     &apiextensionsv1.JSON{Raw: []byte(`{"cniVersion":"1.0.0","name":"ipvlan-underlay","type":"ipvlan","master":"eth2"}`)},
-								InterfaceName: new("net1"),
+						ASN: 65001,
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								ASN:     new(int64(65002)),
+								Address: new("192.168.1.1"),
 							},
-						},
-					},
-					ASN: 65001,
-					Neighbors: []v1alpha1.Neighbor{
-						{
-							ASN:     new(int64(65002)),
-							Address: new("192.168.1.1"),
 						},
 					},
 				},
 			},
-			wantErr: true,
+			wantErrStr: "underlay  has invalid interfaces: duplicate underlay interface name net1",
+		},
+		{
+			name: "duplicate neighbor address",
+			underlay: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+							CIDRs: []string{"192.168.1.0/24"},
+						},
+						Interfaces: []v1alpha1.UnderlayInterface{
+							{
+								Type:          v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+								NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"},
+							},
+						},
+						ASN: 65001,
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								ASN:     new(int64(65002)),
+								Address: new("192.168.1.1"),
+							},
+							{
+								ASN:     new(int64(65002)),
+								Address: new("192.168.1.1"),
+							},
+						},
+					},
+				},
+			},
+			wantErrStr: "underlay  has duplicate neighbor address: duplicate entry 192.168.1.1",
+		},
+		{
+			name: "neighbors via different interfaces",
+			underlay: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+							CIDRs: []string{"192.168.1.0/24"},
+						},
+						Interfaces: []v1alpha1.UnderlayInterface{
+							{
+								Type:          v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+								NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"},
+							},
+						},
+						ASN: 65001,
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								ASN:       new(int64(65002)),
+								Interface: new("eth0"),
+							},
+							{
+								ASN:       new(int64(65002)),
+								Interface: new("eth1"),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "neighbors with the same interface name",
+			underlay: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+							CIDRs: []string{"192.168.1.0/24"},
+						},
+						Interfaces: []v1alpha1.UnderlayInterface{
+							{
+								Type:          v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+								NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"},
+							},
+						},
+						ASN: 65001,
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								ASN:       new(int64(65002)),
+								Interface: new("eth0"),
+							},
+							{
+								ASN:       new(int64(65002)),
+								Interface: new("eth0"),
+							},
+						},
+					},
+				},
+			},
+			wantErrStr: "underlay  has duplicate neighbor interface names, only one peer is allowed per interface: " +
+				"duplicate entry eth0",
+		},
+		{
+			name: "multiple underlays",
+			underlay: []v1alpha1.Underlay{
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+							CIDRs: []string{"192.168.1.0/24"},
+						},
+						Interfaces: []v1alpha1.UnderlayInterface{
+							{
+								Type:          v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+								NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"},
+							},
+						},
+						ASN: 65001,
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								ASN:     new(int64(65002)),
+								Address: new("192.168.1.1"),
+							},
+						},
+					},
+				},
+				{
+					Spec: v1alpha1.UnderlaySpec{
+						TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
+							CIDRs: []string{"192.168.2.0/24"},
+						},
+						Interfaces: []v1alpha1.UnderlayInterface{
+							{
+								Type:          v1alpha1.UnderlayInterfaceTypeNetworkDevice,
+								NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth1"},
+							},
+						},
+						ASN: 65002,
+						Neighbors: []v1alpha1.Neighbor{
+							{
+								ASN:     new(int64(65003)),
+								Address: new("192.168.2.1"),
+							},
+						},
+					},
+				},
+			},
+			wantErrStr: "can't have more than one underlay per node",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateUnderlays([]v1alpha1.Underlay{tt.underlay})
-			if (err != nil) != tt.wantErr {
-				t.Errorf("validateUnderlay() error = %v, wantErr %v", err, tt.wantErr)
+			err := ValidateUnderlays(tt.underlay)
+			if tt.wantErrStr == "" {
+				if err != nil {
+					t.Fatalf("expected no error but got error %q instead", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error %q but got nil instead", tt.wantErrStr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErrStr) {
+				t.Errorf("expected error to contain %q but instead got error: %q", tt.wantErrStr, err)
 			}
 		})
 	}
-
-	// Additional test: more than one underlay should error
-	t.Run("multiple underlays", func(t *testing.T) {
-		underlays := []v1alpha1.Underlay{
-			{
-				Spec: v1alpha1.UnderlaySpec{
-					TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
-						CIDRs: []string{"192.168.1.0/24"},
-					},
-					Interfaces: []v1alpha1.UnderlayInterface{{Type: "NetworkDevice", NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"}}},
-					ASN:        65001,
-					Neighbors: []v1alpha1.Neighbor{
-						{
-							ASN:     new(int64(65002)),
-							Address: new("192.168.1.1"),
-						},
-					},
-				},
-			},
-			{
-				Spec: v1alpha1.UnderlaySpec{
-					TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
-						CIDRs: []string{"192.168.2.0/24"},
-					},
-					Interfaces: []v1alpha1.UnderlayInterface{{Type: "NetworkDevice", NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth1"}}},
-					ASN:        65002,
-					Neighbors: []v1alpha1.Neighbor{
-						{
-							ASN:     new(int64(65003)),
-							Address: new("192.168.2.1"),
-						},
-					},
-				},
-			},
-		}
-		err := ValidateUnderlays(underlays)
-		if err == nil {
-			t.Errorf("expected error for multiple underlays, got nil")
-		}
-	})
 }
 
 func TestValidateUnderlaysForNodes(t *testing.T) {


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:
Fix detection of duplicate neighbor addresses and interface names.
Refactor test TestValidateUnderlay.

**Special notes for your reviewer**:
N/A

**Release note**:

```release-note
None
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Underlay validation now flags duplicate neighbor interface names and clearly indicates that only one peer per interface is allowed.
  - Improved neighbor parsing to ignore missing entries, preventing incorrect validation results.
- **Tests**
  - Expanded coverage for validating multiple underlays.
  - Updated assertions to verify specific error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->