### PR TITLE
fix: apply the FRR configuration before the datapath

### DIFF
--- a/internal/controller/routerconfiguration/reconcile.go
+++ b/internal/controller/routerconfiguration/reconcile.go
@@ -110,16 +110,13 @@ func Reconcile(ctx context.Context, apiConfig conversion.APIConfigData, nodeInde
 		RawFRRConfigs: apiConfig.RawFRRConfigs,
 	}
 
-	err = datapathConfigurator.Configure(ctx, interfacesConfiguration{
-		targetNamespace: targetNamespace,
-		APIConfigData:   config,
-		nodeIndex:       nodeIndex,
-	})
-	if openpeerrors.IsNonResourceError(err) {
-		return err
-	}
-	resourceErrors = append(resourceErrors, err)
-
+	// The FRR configuration must be applied before the datapath creates the kernel
+	// objects it references. bgpd handles ZEBRA_VNI_ADD in bgp_evpn_local_vni_add(),
+	// which dereferences the instance returned by bgp_get_evpn() without checking it
+	// for NULL, so a VXLAN interface showing up while FRR has no EVPN instance
+	// configured crashes bgpd. See https://github.com/FRRouting/frr/issues/22851.
+	// Removals keep working in this order because ZEBRA_VNI_DEL does not touch the
+	// EVPN instance, and FRR stops referencing the objects before they are deleted.
 	if err = frrConfigurator(ctx, frrConfigData{
 		configFile:    frrConfigPath,
 		updater:       updater,
@@ -129,6 +126,16 @@ func Reconcile(ctx context.Context, apiConfig conversion.APIConfigData, nodeInde
 	}); err != nil {
 		return err
 	}
+
+	err = datapathConfigurator.Configure(ctx, interfacesConfiguration{
+		targetNamespace: targetNamespace,
+		APIConfigData:   config,
+		nodeIndex:       nodeIndex,
+	})
+	if openpeerrors.IsNonResourceError(err) {
+		return err
+	}
+	resourceErrors = append(resourceErrors, err)
 
 	return errors.Join(resourceErrors...)
 }

--- a/internal/controller/routerconfiguration/reconcile_test.go
+++ b/internal/controller/routerconfiguration/reconcile_test.go
@@ -557,6 +557,62 @@ func TestReconcileFrrReloadFailure(t *testing.T) {
 	}
 }
 
+// recordingDatapathConfigurator appends to a shared list every time the datapath
+// is configured, so that tests can assert the order of the reconcile steps.
+type recordingDatapathConfigurator struct {
+	steps *[]string
+}
+
+func (r *recordingDatapathConfigurator) Configure(_ context.Context, _ interfacesConfiguration) error {
+	*r.steps = append(*r.steps, "datapath")
+	return nil
+}
+
+func (r *recordingDatapathConfigurator) Validate(_ conversion.APIConfigData) error {
+	return nil
+}
+
+// TestReconcileAppliesFRRConfigBeforeDatapath pins the ordering between the FRR
+// configuration and the datapath. The kernel objects must only be created once FRR
+// already references them: bgpd handles ZEBRA_VNI_ADD in bgp_evpn_local_vni_add(),
+// which dereferences bgp_get_evpn() without a NULL check, so a VXLAN interface
+// created while FRR has no EVPN instance crashes bgpd.
+// See https://github.com/FRRouting/frr/issues/22851.
+func TestReconcileAppliesFRRConfigBeforeDatapath(t *testing.T) {
+	var steps []string
+	recordingConfigureFRR := func(_ context.Context, _ frrConfigData) error {
+		steps = append(steps, "frr")
+		return nil
+	}
+
+	reconcileErr := Reconcile(context.Background(), conversion.APIConfigData{}, 0, "",
+		"", "", noopUpdater, &recordingDatapathConfigurator{steps: &steps}, recordingConfigureFRR)
+	if reconcileErr != nil {
+		t.Fatalf("unexpected reconcile error: %v", reconcileErr)
+	}
+
+	want := []string{"frr", "datapath"}
+	if diff := cmp.Diff(steps, want); diff != "" {
+		t.Errorf("reconcile steps out of order (-got, +want):\n%s", diff)
+	}
+}
+
+// TestReconcileSkipsDatapathOnFrrReloadFailure ensures no kernel object is created
+// when FRR could not be configured, so that the datapath never gets ahead of FRR.
+func TestReconcileSkipsDatapathOnFrrReloadFailure(t *testing.T) {
+	var steps []string
+
+	reconcileErr := Reconcile(context.Background(), conversion.APIConfigData{}, 0, "",
+		"", "", failingUpdater, &recordingDatapathConfigurator{steps: &steps}, configureFRR)
+	if reconcileErr == nil {
+		t.Fatal("expected error from FRR reload failure")
+	}
+
+	if len(steps) != 0 {
+		t.Errorf("expected the datapath not to be configured, got steps: %v", steps)
+	}
+}
+
 func l3VNI(name, vrf string, vni int32) v1alpha1.L3VNI {
 	return v1alpha1.L3VNI{
 		ObjectMeta: metav1.ObjectMeta{Name: name},

--- a/internal/frr/config.go
+++ b/internal/frr/config.go
@@ -170,8 +170,14 @@ func templateConfig(data any) (string, error) {
 				}
 				return dict, nil
 			},
-			"mustDisableConnectedCheck": func(nlps []networklayerprotocol.NLP, myASN int64, peerASN PeerASN,
-				eBGPMultiHop bool) bool {
+			"mustDisableConnectedCheck": func(addr string, nlps []networklayerprotocol.NLP, myASN int64,
+				peerASN PeerASN, eBGPMultiHop bool) bool {
+				// Neighbors configured over an interface are directly connected by
+				// definition, and FRR rejects disable-connected-check for them, which
+				// makes the whole reload fail.
+				if addr == "" {
+					return false
+				}
 				// Return true only if neighbor establishes an IPv6 eBGP session.
 				return networklayerprotocol.HasUnicastFamily(nlps, networklayerprotocol.IPv6) &&
 					!eBGPMultiHop && peerASN.IsExternalTo(myASN)

--- a/internal/frr/frr_test.go
+++ b/internal/frr/frr_test.go
@@ -463,6 +463,43 @@ func TestBGPUnnumbered(t *testing.T) {
 	testCheckConfigFile(t)
 }
 
+// TestBGPUnnumberedEBGPIPv6 covers an unnumbered neighbor peering with an
+// external ASN over IPv6 unicast. FRR rejects disable-connected-check for
+// neighbors configured over an interface, so the generated configuration must
+// not contain it, otherwise the whole reload fails.
+func TestBGPUnnumberedEBGPIPv6(t *testing.T) {
+	configFile := testSetup(t)
+	updater := testUpdater(configFile)
+
+	config := Config{
+		Underlay: UnderlayConfig{
+			MyASN: 64512,
+			TunnelEndpoint: &TunnelEndpoint{
+				IPv4CIDR: "100.64.0.1/32",
+			},
+			RouterID: "10.0.0.1",
+			Neighbors: []NeighborConfig{
+				{
+					ASN:       mustNewPeerASNFromNumber(64513),
+					Interface: "eth1",
+					ID:        "eth1",
+					NetworkLayerProtocols: []networklayerprotocol.NLP{
+						{AFI: networklayerprotocol.IPv4, SAFI: networklayerprotocol.Unicast},
+						{AFI: networklayerprotocol.IPv6, SAFI: networklayerprotocol.Unicast},
+						{AFI: networklayerprotocol.L2VPN, SAFI: networklayerprotocol.EVPN},
+					},
+					ExtendedNexthop: true,
+				},
+			},
+		},
+	}
+	if err := ApplyConfig(context.Background(), &config, updater); err != nil {
+		t.Fatalf("Failed to apply config: %s", err)
+	}
+
+	testCheckConfigFile(t)
+}
+
 func TestIPv6OnlyWithRT(t *testing.T) {
 	configFile := testSetup(t)
 	updater := testUpdater(configFile)

--- a/internal/frr/templates/neighborsession.tmpl
+++ b/internal/frr/templates/neighborsession.tmpl
@@ -24,7 +24,7 @@
 {{- else if .neighbor.BFDEnabled}}
   neighbor {{.neighbor.ID}} bfd
 {{- end }}
-{{- if  mustDisableConnectedCheck .neighbor.NetworkLayerProtocols .routerASN .neighbor.ASN .neighbor.EBGPMultiHop }}
+{{- if  mustDisableConnectedCheck .neighbor.Addr .neighbor.NetworkLayerProtocols .routerASN .neighbor.ASN .neighbor.EBGPMultiHop }}
   neighbor {{.neighbor.ID}} disable-connected-check
 {{- end }}
 {{- if .neighbor.ExtendedNexthop }}

--- a/internal/frr/testdata/TestBGPUnnumberedEBGPIPv6.golden
+++ b/internal/frr/testdata/TestBGPUnnumberedEBGPIPv6.golden
@@ -1,0 +1,38 @@
+log stdout 
+log timestamp precision 3
+hostname hostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+
+route-map allowall permit 1
+router bgp 64512
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+  bgp router-id 10.0.0.1
+  neighbor eth1 interface remote-as 64513
+  
+  
+  
+  neighbor eth1 capability extended-nexthop
+
+  address-family ipv4 unicast
+    neighbor eth1 activate
+    neighbor eth1 allowas-in
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor eth1 activate
+    neighbor eth1 allowas-in
+  exit-address-family
+  address-family ipv4 unicast
+    network 100.64.0.1/32
+  exit-address-family
+
+  address-family l2vpn evpn
+    neighbor eth1 activate
+    neighbor eth1 allowas-in
+    advertise-all-vni
+    advertise-svi-ip
+  exit-address-family
+exit
+!


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

The datapath created the kernel objects before the FRR configuration referencing them was reloaded. A VXLAN interface showing up while FRR has no EVPN instance makes zebra send `ZEBRA_VNI_ADD`, and bgpd handles it in `bgp_evpn_local_vni_add()`, which dereferences the instance returned by `bgp_get_evpn()` without checking it for NULL, so bgpd crashes.

`Reconcile()` ran `datapathConfigurator.Configure()` and only then `frrConfigurator()`, so the kernel objects existed for as long as the FRR reload takes (~1.5s in CI) before the configuration declaring the EVPN instance was applied. Reloading the FRR configuration first closes that window.

The crash analysis and the CI occurrences are in #604, and the missing NULL check was reported upstream in https://github.com/FRRouting/frr/issues/22851 and fixed by [fc7ccc3](https://github.com/FRRouting/frr/commit/fc7ccc32aca5d8f9dd2db7bb52b0efdadfa2b421). That fix is in FRR `master` only, it is not in any release yet, and we are pinned to `frr:10.6.0`, so this reordering is what keeps us from hitting the crash until a backport is released.

Fixed #604

**Special notes for your reviewer**:

The second commit fixes a pre-existing bug that this reordering exposed. We were generating `disable-connected-check` for neighbors configured over an interface, which FRR rejects, so every reload of an unnumbered underlay failed:

```
toleafkind1 is directly connected peer, cannot accept disable-connected-check
line 2: Failure to communicate[13] to bgpd
```

That went unnoticed because the datapath was configured before the reload, so the interfaces were already in place and the sessions came up regardless, with the reconcile error only being requeued. The same message is present in the nightly artifacts of Jul 24, 25 and 27, before this branch. With the reordering the reload failure became fatal, since the datapath is no longer configured when FRR rejects the configuration.


Removals stay correct in this order: `ZEBRA_VNI_DEL` is handled by `bgp_evpn_local_vni_del()`, which does not touch the EVPN instance, and FRR stops referencing the objects before they are deleted.

The reordering is safe because `internal/conversion` builds the FRR configuration from the API config and the node index only, with no netlink reads, and the objects it names (`vrf`, `vni`, `router bgp ... vrf`, `interface`) are accepted by FRR before they exist and bind once they show up.

Two behaviour changes come with it:

- when the FRR reload fails, the datapath is no longer configured, which is what keeps the datapath from getting ahead of FRR. `TestReconcileSkipsDatapathOnFrrReloadFailure` covers it.
- when the datapath fails, FRR has already been reloaded. The configuration is declarative, so the next reconcile converges.

`TestReconcileAppliesFRRConfigBeforeDatapath` pins the ordering, since it is an invariant that a refactor could silently drop. Both tests fail without the fix.

The zebra crashes seen in the same runs are a different race and are not addressed here, they are tracked in #632.

**Release note**:

```release-note
Fixed a crash of the FRR bgpd daemon that could happen while VNIs were being created, by applying the FRR configuration before the corresponding kernel objects.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved routing configuration sequencing to apply FRR settings before datapath configuration, preventing potential VXLAN/BGP setup failures.
  * Datapath configuration is now skipped when FRR reload/configuration fails.
  * Corrected connected-check handling for unnumbered IPv6 eBGP neighbor sessions.

* **Tests**
  * Added new test coverage for configuration ordering and for skipping datapath steps on FRR failures.
  * Added a golden test for unnumbered IPv6 eBGP configuration generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->