### PR TITLE
refactor(api): normalize JSON tag casing to lowerCamelCase

### DIFF
--- a/API-DOCS.md
+++ b/API-DOCS.md
@@ -243,7 +243,7 @@ _Appears in:_
 | `asn` _integer_ | asn is the local AS number to use to establish a BGP session with<br />the default namespace. |  | Maximum: 4.294967295e+09 <br />Minimum: 1 <br />Required: \{\} <br /> |
 | `hostASN` _integer_ | hostASN is the expected AS number for a BGP speaking component running in<br />the default network namespace. Either HostASN or HostType must be set. |  | Maximum: 4.294967295e+09 <br />Minimum: 1 <br />Optional: \{\} <br /> |
 | `hostType` _string_ | hostType is the AS type of the BGP speaking component running in the<br />default network namespace. Either HostASN or HostType must be set. |  | Enum: [external internal] <br />Optional: \{\} <br /> |
-| `localCIDR` _[LocalCIDRConfig](#localCIDRconfig)_ | localCIDR is the CIDR configuration for the veth pair<br />to connect with the default namespace. The interface under<br />the PERouter side is going to use the first IP of the cidr on all the nodes.<br />At least one of IPv4 or IPv6 must be provided. |  | Required: \{\} <br /> |
+| `localCIDR` _[LocalCIDRConfig](#localcidrconfig)_ | localCIDR is the CIDR configuration for the veth pair<br />to connect with the default namespace. The interface under<br />the PERouter side is going to use the first IP of the cidr on all the nodes.<br />At least one of IPv4 or IPv6 must be provided. |  | Required: \{\} <br /> |
 
 
 #### IPFamily
@@ -389,7 +389,7 @@ _Appears in:_
 | `vni` _integer_ | vni is the VXLan VNI to be used |  | Maximum: 1.6777215e+07 <br />Minimum: 1 <br />Required: \{\} <br /> |
 | `vxlanPort` _integer_ | vxlanPort is the port to be used for VXLan encapsulation. | 4789 | Optional: \{\} <br /> |
 | `underlayAddressFamily` _string_ | underlayAddressFamily selects which VTEP address family to use for this VNI's<br />VXLAN interface. When omitted, defaults to the available family in the underlay<br />(IPv4 preferred in dual-stack). |  | Enum: [ipv4 ipv6] <br />Optional: \{\} <br /> |
-| `hostMaster` _[HostMaster](#hostMaster)_ | hostMaster is the interface on the host the veth should be attached to.<br />If not set, the host veth will not be attached to any interface and it must be<br />attached manually (or by some other means). This is useful if another controller<br />is leveraging the host interface for the VNI. |  | Optional: \{\} <br /> |
+| `hostMaster` _[HostMaster](#hostmaster)_ | hostMaster is the interface on the host the veth should be attached to.<br />If not set, the host veth will not be attached to any interface and it must be<br />attached manually (or by some other means). This is useful if another controller<br />is leveraging the host interface for the VNI. |  | Optional: \{\} <br /> |
 | `gatewayIPs` _string array_ | gatewayIPs is a list of IP addresses in CIDR notation for the<br />distributed anycast gateway on this L2 segment's bridge<br />(Integrated Routing and Bridging interface). It is a property of<br />the L2 segment itself, so it lives on the L2VNI rather than<br />inside the routing-domain reference.<br />Maximum of 2 addresses are allowed. If 2 addresses are provided, one must be IPv4 and one must be IPv6. |  | MaxItems: 2 <br />Optional: \{\} <br /> |
 
 
@@ -440,7 +440,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `nodeSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#labelselector-v1-meta)_ | nodeSelector specifies which nodes this L3Passthrough applies to.<br />If empty or not specified, applies to all nodes.<br />Multiple L3Passthrough with overlapping node selectors will be rejected. |  | Optional: \{\} <br /> |
-| `hostSession` _[HostSession](#hostSession)_ | hostSession is the configuration for the host session. |  | Required: \{\} <br /> |
+| `hostSession` _[HostSession](#hostsession)_ | hostSession is the configuration for the host session. |  | Required: \{\} <br /> |
 
 
 #### L3PassthroughStatus
@@ -510,7 +510,7 @@ _Appears in:_
 | `vni` _integer_ | vni is the VXLan VNI to be used |  | Maximum: 1.6777215e+07 <br />Minimum: 1 <br />Required: \{\} <br /> |
 | `vxlanPort` _integer_ | vxlanPort is the port to be used for VXLan encapsulation. | 4789 | Optional: \{\} <br /> |
 | `underlayAddressFamily` _string_ | underlayAddressFamily selects which VTEP address family to use for this VNI's<br />VXLAN interface. When omitted, defaults to the available family in the underlay<br />(IPv4 preferred in dual-stack). |  | Enum: [ipv4 ipv6] <br />Optional: \{\} <br /> |
-| `hostSession` _[HostSession](#hostSession)_ | hostSession is the configuration for the host session. |  | Optional: \{\} <br /> |
+| `hostSession` _[HostSession](#hostsession)_ | hostSession is the configuration for the host session. |  | Optional: \{\} <br /> |
 | `exportRTs` _[RouteTarget](#routetarget) array_ | exportRTs are the Route Targets to be used for exporting routes.<br />RouteTarget defines a BGP Extended Community for route filtering. |  | MaxItems: 100 <br />MaxLength: 21 <br />Optional: \{\} <br /> |
 | `importRTs` _[RouteTarget](#routetarget) array_ | importRTs are the Route Targets to be used for importing routes.<br />RouteTarget defines a BGP Extended Community for route filtering. |  | MaxItems: 100 <br />MaxLength: 21 <br />Optional: \{\} <br /> |
 
@@ -581,7 +581,7 @@ _Appears in:_
 | `exportRTs` _[RouteTarget](#routetarget) array_ | exportRTs are the Route Targets to be used for exporting routes.<br />If no exportRTs are provided, defaults to single export Route Target<br /><asn>:<rdAssignedNumber>. |  | MaxItems: 100 <br />MaxLength: 21 <br />Optional: \{\} <br /> |
 | `importRTs` _[RouteTarget](#routetarget) array_ | importRTs are the Route Targets to be used for importing routes.<br />importRTs must always be provided explicitly. |  | MaxItems: 100 <br />MaxLength: 21 <br />Required: \{\} <br /> |
 | `rdAssignedNumber` _integer_ | rdAssignedNumber sets the Route Distinguisher's Assigned Number subfield.<br />The Administrator subfield is automatically set to the value of the router<br />ID. OpenPERouter uses Type 1 Route Distinguishers as defined in RFC4364,<br />meaning <Administrator subfield>:<Assigned Number subfield>. |  | Maximum: 65535 <br />Minimum: 1 <br />Required: \{\} <br /> |
-| `hostSession` _[HostSession](#hostSession)_ | hostSession is the configuration for the host session. |  | Optional: \{\} <br /> |
+| `hostSession` _[HostSession](#hostsession)_ | hostSession is the configuration for the host session. |  | Optional: \{\} <br /> |
 
 
 #### L3VPNStatus
@@ -606,7 +606,7 @@ LinuxBridgeConfig contains configuration for Linux bridge type.
 
 
 _Appears in:_
-- [HostMaster](#hostMaster)
+- [HostMaster](#hostmaster)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -623,7 +623,7 @@ _Appears in:_
 
 
 _Appears in:_
-- [HostSession](#hostSession)
+- [HostSession](#hostsession)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -739,7 +739,7 @@ OVSBridgeConfig contains configuration for OVS bridge type.
 
 
 _Appears in:_
-- [HostMaster](#hostMaster)
+- [HostMaster](#hostmaster)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |

--- a/API-DOCS.md
+++ b/API-DOCS.md
@@ -241,9 +241,9 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `asn` _integer_ | asn is the local AS number to use to establish a BGP session with<br />the default namespace. |  | Maximum: 4.294967295e+09 <br />Minimum: 1 <br />Required: \{\} <br /> |
-| `hostasn` _integer_ | hostasn is the expected AS number for a BGP speaking component running in<br />the default network namespace. Either HostASN or HostType must be set. |  | Maximum: 4.294967295e+09 <br />Minimum: 1 <br />Optional: \{\} <br /> |
-| `hosttype` _string_ | hosttype is the AS type of the BGP speaking component running in the<br />default network namespace. Either HostASN or HostType must be set. |  | Enum: [external internal] <br />Optional: \{\} <br /> |
-| `localcidr` _[LocalCIDRConfig](#localcidrconfig)_ | localcidr is the CIDR configuration for the veth pair<br />to connect with the default namespace. The interface under<br />the PERouter side is going to use the first IP of the cidr on all the nodes.<br />At least one of IPv4 or IPv6 must be provided. |  | Required: \{\} <br /> |
+| `hostASN` _integer_ | hostASN is the expected AS number for a BGP speaking component running in<br />the default network namespace. Either HostASN or HostType must be set. |  | Maximum: 4.294967295e+09 <br />Minimum: 1 <br />Optional: \{\} <br /> |
+| `hostType` _string_ | hostType is the AS type of the BGP speaking component running in the<br />default network namespace. Either HostASN or HostType must be set. |  | Enum: [external internal] <br />Optional: \{\} <br /> |
+| `localCIDR` _[LocalCIDRConfig](#localCIDRconfig)_ | localCIDR is the CIDR configuration for the veth pair<br />to connect with the default namespace. The interface under<br />the PERouter side is going to use the first IP of the cidr on all the nodes.<br />At least one of IPv4 or IPv6 must be provided. |  | Required: \{\} <br /> |
 
 
 #### IPFamily
@@ -387,9 +387,9 @@ _Appears in:_
 | `nodeSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#labelselector-v1-meta)_ | nodeSelector specifies which nodes this L2VNI applies to.<br />If empty or not specified, applies to all nodes.<br />Multiple L2VNIs can match the same node. |  | Optional: \{\} <br /> |
 | `routingDomain` _[RoutingDomain](#routingdomain)_ | routingDomain optionally attaches this L2VNI to a routing domain<br />provided by a backing resource (L3VNI or L3VPN). When omitted, the<br />L2VNI is a disconnected overlay (east-west L2 only, no VRF, no<br />gateway). |  | Optional: \{\} <br /> |
 | `vni` _integer_ | vni is the VXLan VNI to be used |  | Maximum: 1.6777215e+07 <br />Minimum: 1 <br />Required: \{\} <br /> |
-| `vxlanport` _integer_ | vxlanport is the port to be used for VXLan encapsulation. | 4789 | Optional: \{\} <br /> |
+| `vxlanPort` _integer_ | vxlanPort is the port to be used for VXLan encapsulation. | 4789 | Optional: \{\} <br /> |
 | `underlayAddressFamily` _string_ | underlayAddressFamily selects which VTEP address family to use for this VNI's<br />VXLAN interface. When omitted, defaults to the available family in the underlay<br />(IPv4 preferred in dual-stack). |  | Enum: [ipv4 ipv6] <br />Optional: \{\} <br /> |
-| `hostmaster` _[HostMaster](#hostmaster)_ | hostmaster is the interface on the host the veth should be attached to.<br />If not set, the host veth will not be attached to any interface and it must be<br />attached manually (or by some other means). This is useful if another controller<br />is leveraging the host interface for the VNI. |  | Optional: \{\} <br /> |
+| `hostMaster` _[HostMaster](#hostMaster)_ | hostMaster is the interface on the host the veth should be attached to.<br />If not set, the host veth will not be attached to any interface and it must be<br />attached manually (or by some other means). This is useful if another controller<br />is leveraging the host interface for the VNI. |  | Optional: \{\} <br /> |
 | `gatewayIPs` _string array_ | gatewayIPs is a list of IP addresses in CIDR notation for the<br />distributed anycast gateway on this L2 segment's bridge<br />(Integrated Routing and Bridging interface). It is a property of<br />the L2 segment itself, so it lives on the L2VNI rather than<br />inside the routing-domain reference.<br />Maximum of 2 addresses are allowed. If 2 addresses are provided, one must be IPv4 and one must be IPv6. |  | MaxItems: 2 <br />Optional: \{\} <br /> |
 
 
@@ -440,7 +440,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `nodeSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#labelselector-v1-meta)_ | nodeSelector specifies which nodes this L3Passthrough applies to.<br />If empty or not specified, applies to all nodes.<br />Multiple L3Passthrough with overlapping node selectors will be rejected. |  | Optional: \{\} <br /> |
-| `hostsession` _[HostSession](#hostsession)_ | hostsession is the configuration for the host session. |  | Required: \{\} <br /> |
+| `hostSession` _[HostSession](#hostSession)_ | hostSession is the configuration for the host session. |  | Required: \{\} <br /> |
 
 
 #### L3PassthroughStatus
@@ -508,9 +508,9 @@ _Appears in:_
 | `nodeSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#labelselector-v1-meta)_ | nodeSelector specifies which nodes this L3VNI applies to.<br />If empty or not specified, applies to all nodes.<br />Multiple L3VNIs can match the same node. |  | Optional: \{\} <br /> |
 | `vrf` _string_ | vrf is the name of the linux VRF to be used inside the PERouter namespace. |  | MaxLength: 15 <br />MinLength: 1 <br />Pattern: `^[a-zA-Z][a-zA-Z0-9_-]*$` <br />Required: \{\} <br /> |
 | `vni` _integer_ | vni is the VXLan VNI to be used |  | Maximum: 1.6777215e+07 <br />Minimum: 1 <br />Required: \{\} <br /> |
-| `vxlanport` _integer_ | vxlanport is the port to be used for VXLan encapsulation. | 4789 | Optional: \{\} <br /> |
+| `vxlanPort` _integer_ | vxlanPort is the port to be used for VXLan encapsulation. | 4789 | Optional: \{\} <br /> |
 | `underlayAddressFamily` _string_ | underlayAddressFamily selects which VTEP address family to use for this VNI's<br />VXLAN interface. When omitted, defaults to the available family in the underlay<br />(IPv4 preferred in dual-stack). |  | Enum: [ipv4 ipv6] <br />Optional: \{\} <br /> |
-| `hostsession` _[HostSession](#hostsession)_ | hostsession is the configuration for the host session. |  | Optional: \{\} <br /> |
+| `hostSession` _[HostSession](#hostSession)_ | hostSession is the configuration for the host session. |  | Optional: \{\} <br /> |
 | `exportRTs` _[RouteTarget](#routetarget) array_ | exportRTs are the Route Targets to be used for exporting routes.<br />RouteTarget defines a BGP Extended Community for route filtering. |  | MaxItems: 100 <br />MaxLength: 21 <br />Optional: \{\} <br /> |
 | `importRTs` _[RouteTarget](#routetarget) array_ | importRTs are the Route Targets to be used for importing routes.<br />RouteTarget defines a BGP Extended Community for route filtering. |  | MaxItems: 100 <br />MaxLength: 21 <br />Optional: \{\} <br /> |
 
@@ -581,7 +581,7 @@ _Appears in:_
 | `exportRTs` _[RouteTarget](#routetarget) array_ | exportRTs are the Route Targets to be used for exporting routes.<br />If no exportRTs are provided, defaults to single export Route Target<br /><asn>:<rdAssignedNumber>. |  | MaxItems: 100 <br />MaxLength: 21 <br />Optional: \{\} <br /> |
 | `importRTs` _[RouteTarget](#routetarget) array_ | importRTs are the Route Targets to be used for importing routes.<br />importRTs must always be provided explicitly. |  | MaxItems: 100 <br />MaxLength: 21 <br />Required: \{\} <br /> |
 | `rdAssignedNumber` _integer_ | rdAssignedNumber sets the Route Distinguisher's Assigned Number subfield.<br />The Administrator subfield is automatically set to the value of the router<br />ID. OpenPERouter uses Type 1 Route Distinguishers as defined in RFC4364,<br />meaning <Administrator subfield>:<Assigned Number subfield>. |  | Maximum: 65535 <br />Minimum: 1 <br />Required: \{\} <br /> |
-| `hostsession` _[HostSession](#hostsession)_ | hostsession is the configuration for the host session. |  | Optional: \{\} <br /> |
+| `hostSession` _[HostSession](#hostSession)_ | hostSession is the configuration for the host session. |  | Optional: \{\} <br /> |
 
 
 #### L3VPNStatus
@@ -606,7 +606,7 @@ LinuxBridgeConfig contains configuration for Linux bridge type.
 
 
 _Appears in:_
-- [HostMaster](#hostmaster)
+- [HostMaster](#hostMaster)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -623,7 +623,7 @@ _Appears in:_
 
 
 _Appears in:_
-- [HostSession](#hostsession)
+- [HostSession](#hostSession)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -739,7 +739,7 @@ OVSBridgeConfig contains configuration for OVS bridge type.
 
 
 _Appears in:_
-- [HostMaster](#hostmaster)
+- [HostMaster](#hostMaster)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -1013,7 +1013,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `nodeSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#labelselector-v1-meta)_ | nodeSelector specifies which nodes this Underlay applies to.<br />If empty or not specified, applies to all nodes (backward compatible).<br />Multiple Underlays with overlapping node selectors will be rejected. |  | Optional: \{\} <br /> |
 | `asn` _integer_ | asn is the local AS number to use for the session with the TOR switch. |  | Maximum: 4.294967295e+09 <br />Minimum: 1 <br />Required: \{\} <br /> |
-| `routeridcidr` _string_ | routeridcidr is the ipv4 cidr to be used to assign a different routerID on each node. | 10.0.0.0/24 | Optional: \{\} <br /> |
+| `routerIDCIDR` _string_ | routerIDCIDR is the ipv4 cidr to be used to assign a different routerID on each node. | 10.0.0.0/24 | Optional: \{\} <br /> |
 | `neighbors` _[Neighbor](#neighbor) array_ | neighbors is the list of external BGP neighbors to peer with.<br />Multiple neighbors are supported for connecting to multiple TOR switches<br />or establishing redundant BGP sessions. Each neighbor address must be unique.<br />At least one neighbor is required. |  | MaxItems: 128 <br />MinItems: 1 <br />Required: \{\} <br /> |
 | `interfaces` _[UnderlayInterface](#underlayinterface) array_ | interfaces is the list of interfaces the router uses for underlay<br />connectivity. Each entry is a discriminated union describing how the<br />interface is obtained. At least one interface is required. All the<br />entries must be of the same type: mixing NetworkDevice and CNIDevice<br />interfaces is not supported. |  | MinItems: 1 <br />Required: \{\} <br /> |
 | `tunnelEndpoint` _[TunnelEndpointConfig](#tunnelendpointconfig)_ | tunnelEndpoint contains tunnel endpoint configuration for the underlay. |  | Optional: \{\} <br /> |

--- a/api/v1alpha1/hostsession.go
+++ b/api/v1alpha1/hostsession.go
@@ -4,8 +4,8 @@ package v1alpha1
 
 // Host Session represents the leg between the router and the host.
 // A BGP session is established over this leg.
-// +kubebuilder:validation:XValidation:rule="has(self.hostasn) || has(self.hosttype)",message="either HostASN or HostType must be set"
-// +kubebuilder:validation:XValidation:rule="!has(self.hostasn) || !has(self.hosttype)",message="HostASN and HostType cannot be set together"
+// +kubebuilder:validation:XValidation:rule="has(self.hostASN) || has(self.hostType)",message="either HostASN or HostType must be set"
+// +kubebuilder:validation:XValidation:rule="!has(self.hostASN) || !has(self.hostType)",message="HostASN and HostType cannot be set together"
 type HostSession struct {
 	// asn is the local AS number to use to establish a BGP session with
 	// the default namespace.
@@ -14,26 +14,26 @@ type HostSession struct {
 	// +required
 	ASN int64 `json:"asn,omitempty"`
 
-	// hostasn is the expected AS number for a BGP speaking component running in
+	// hostASN is the expected AS number for a BGP speaking component running in
 	// the default network namespace. Either HostASN or HostType must be set.
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=4294967295
 	// +optional
-	HostASN *int64 `json:"hostasn,omitempty"`
+	HostASN *int64 `json:"hostASN,omitempty"`
 
-	// hosttype is the AS type of the BGP speaking component running in the
+	// hostType is the AS type of the BGP speaking component running in the
 	// default network namespace. Either HostASN or HostType must be set.
 	// +kubebuilder:validation:Enum=external;internal
 	// +optional
-	HostType *string `json:"hosttype,omitempty"`
+	HostType *string `json:"hostType,omitempty"`
 
-	// localcidr is the CIDR configuration for the veth pair
+	// localCIDR is the CIDR configuration for the veth pair
 	// to connect with the default namespace. The interface under
 	// the PERouter side is going to use the first IP of the cidr on all the nodes.
 	// At least one of IPv4 or IPv6 must be provided.
 	// +required
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="LocalCIDR can't be changed"
-	LocalCIDR LocalCIDRConfig `json:"localcidr,omitzero"` //nolint:kubeapilinter // CEL rule on LocalCIDRConfig enforces at least one of ipv4/ipv6
+	LocalCIDR LocalCIDRConfig `json:"localCIDR,omitzero"` //nolint:kubeapilinter // CEL rule on LocalCIDRConfig enforces at least one of ipv4/ipv6
 }
 
 // +kubebuilder:validation:XValidation:rule="has(self.ipv4) || has(self.ipv6)",message="at least one of ipv4 or ipv6 must be specified"

--- a/api/v1alpha1/l2vni_types.go
+++ b/api/v1alpha1/l2vni_types.go
@@ -53,10 +53,10 @@ type L2VNISpec struct {
 	// +required
 	VNI int32 `json:"vni,omitempty"`
 
-	// vxlanport is the port to be used for VXLan encapsulation.
+	// vxlanPort is the port to be used for VXLan encapsulation.
 	// +default=4789
 	// +optional
-	VXLanPort *int32 `json:"vxlanport,omitempty"`
+	VXLanPort *int32 `json:"vxlanPort,omitempty"`
 
 	// underlayAddressFamily selects which VTEP address family to use for this VNI's
 	// VXLAN interface. When omitted, defaults to the available family in the underlay
@@ -65,12 +65,12 @@ type L2VNISpec struct {
 	// +optional
 	UnderlayAddressFamily *string `json:"underlayAddressFamily,omitempty"`
 
-	// hostmaster is the interface on the host the veth should be attached to.
+	// hostMaster is the interface on the host the veth should be attached to.
 	// If not set, the host veth will not be attached to any interface and it must be
 	// attached manually (or by some other means). This is useful if another controller
 	// is leveraging the host interface for the VNI.
 	// +optional
-	HostMaster *HostMaster `json:"hostmaster,omitempty"`
+	HostMaster *HostMaster `json:"hostMaster,omitempty"`
 
 	// gatewayIPs is a list of IP addresses in CIDR notation for the
 	// distributed anycast gateway on this L2 segment's bridge

--- a/api/v1alpha1/l3passthrough_types.go
+++ b/api/v1alpha1/l3passthrough_types.go
@@ -27,9 +27,9 @@ type L3PassthroughSpec struct {
 	// +optional
 	NodeSelector *metav1.LabelSelector `json:"nodeSelector,omitempty"`
 
-	// hostsession is the configuration for the host session.
+	// hostSession is the configuration for the host session.
 	// +required
-	HostSession HostSession `json:"hostsession,omitzero,omitempty"`
+	HostSession HostSession `json:"hostSession,omitzero,omitempty"`
 }
 
 // L3PassthroughStatus defines the observed state of L3Passthrough.

--- a/api/v1alpha1/l3vni_types.go
+++ b/api/v1alpha1/l3vni_types.go
@@ -21,7 +21,7 @@ import (
 )
 
 // L3VNISpec defines the desired state of VNI.
-// +kubebuilder:validation:XValidation:rule="!has(self.hostsession) || !has(self.hostsession.hostasn) || self.hostsession.hostasn != self.hostsession.asn",message="hostASN must be different from asn"
+// +kubebuilder:validation:XValidation:rule="!has(self.hostSession) || !has(self.hostSession.hostASN) || self.hostSession.hostASN != self.hostSession.asn",message="hostASN must be different from asn"
 type L3VNISpec struct {
 	// nodeSelector specifies which nodes this L3VNI applies to.
 	// If empty or not specified, applies to all nodes.
@@ -42,10 +42,10 @@ type L3VNISpec struct {
 	// +required
 	VNI int32 `json:"vni,omitempty"`
 
-	// vxlanport is the port to be used for VXLan encapsulation.
+	// vxlanPort is the port to be used for VXLan encapsulation.
 	// +default=4789
 	// +optional
-	VXLanPort *int32 `json:"vxlanport,omitempty"`
+	VXLanPort *int32 `json:"vxlanPort,omitempty"`
 
 	// underlayAddressFamily selects which VTEP address family to use for this VNI's
 	// VXLAN interface. When omitted, defaults to the available family in the underlay
@@ -54,9 +54,9 @@ type L3VNISpec struct {
 	// +optional
 	UnderlayAddressFamily *string `json:"underlayAddressFamily,omitempty"`
 
-	// hostsession is the configuration for the host session.
+	// hostSession is the configuration for the host session.
 	// +optional
-	HostSession *HostSession `json:"hostsession,omitempty"`
+	HostSession *HostSession `json:"hostSession,omitempty"`
 
 	// exportRTs are the Route Targets to be used for exporting routes.
 	// RouteTarget defines a BGP Extended Community for route filtering.

--- a/api/v1alpha1/l3vpn_types.go
+++ b/api/v1alpha1/l3vpn_types.go
@@ -21,7 +21,7 @@ import (
 )
 
 // L3VPNSpec defines the desired state of L3VPN.
-// +kubebuilder:validation:XValidation:rule="!has(self.hostsession) || self.hostsession.hostasn != self.hostsession.asn",message="hostASN must be different from asn"
+// +kubebuilder:validation:XValidation:rule="!has(self.hostSession) || self.hostSession.hostASN != self.hostSession.asn",message="hostASN must be different from asn"
 type L3VPNSpec struct {
 	// nodeSelector specifies which nodes this L3VPN applies to.
 	// If empty or not specified, applies to all nodes.
@@ -61,9 +61,9 @@ type L3VPNSpec struct {
 	// +required
 	RDAssignedNumber int32 `json:"rdAssignedNumber,omitempty"`
 
-	// hostsession is the configuration for the host session.
+	// hostSession is the configuration for the host session.
 	// +optional
-	HostSession *HostSession `json:"hostsession,omitempty"`
+	HostSession *HostSession `json:"hostSession,omitempty"`
 }
 
 // L3VPNStatus defines the observed state of L3VPN.

--- a/api/v1alpha1/underlay_types.go
+++ b/api/v1alpha1/underlay_types.go
@@ -37,10 +37,10 @@ type UnderlaySpec struct {
 	// +required
 	ASN int64 `json:"asn,omitempty"`
 
-	// routeridcidr is the ipv4 cidr to be used to assign a different routerID on each node.
+	// routerIDCIDR is the ipv4 cidr to be used to assign a different routerID on each node.
 	// +default="10.0.0.0/24"
 	// +optional
-	RouterIDCIDR *string `json:"routeridcidr,omitempty"`
+	RouterIDCIDR *string `json:"routerIDCIDR,omitempty"`
 
 	// Note: MaxItems:=128 is arbitrarily chosen to keep total CEL cost low
 	// Note: kubeapilinter complained about 'the struct has no required fields', but CEL enforces either/or choices

--- a/charts/openperouter/charts/crds/templates/network.openperouter.io_l2vnis.yaml
+++ b/charts/openperouter/charts/crds/templates/network.openperouter.io_l2vnis.yaml
@@ -57,9 +57,9 @@ spec:
                 x-kubernetes-validations:
                 - message: GatewayIPs cannot be changed
                   rule: self == oldSelf
-              hostmaster:
+              hostMaster:
                 description: |-
-                  hostmaster is the interface on the host the veth should be attached to.
+                  hostMaster is the interface on the host the veth should be attached to.
                   If not set, the host veth will not be attached to any interface and it must be
                   attached manually (or by some other means). This is useful if another controller
                   is leveraging the host interface for the VNI.
@@ -247,9 +247,9 @@ spec:
                 maximum: 16777215
                 minimum: 1
                 type: integer
-              vxlanport:
+              vxlanPort:
                 default: 4789
-                description: vxlanport is the port to be used for VXLan encapsulation.
+                description: vxlanPort is the port to be used for VXLan encapsulation.
                 format: int32
                 type: integer
             required:

--- a/charts/openperouter/charts/crds/templates/network.openperouter.io_l3passthroughs.yaml
+++ b/charts/openperouter/charts/crds/templates/network.openperouter.io_l3passthroughs.yaml
@@ -41,8 +41,8 @@ spec:
           spec:
             description: spec defines the desired state of L3Passthrough.
             properties:
-              hostsession:
-                description: hostsession is the configuration for the host session.
+              hostSession:
+                description: hostSession is the configuration for the host session.
                 properties:
                   asn:
                     description: |-
@@ -52,25 +52,25 @@ spec:
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hostasn:
+                  hostASN:
                     description: |-
-                      hostasn is the expected AS number for a BGP speaking component running in
+                      hostASN is the expected AS number for a BGP speaking component running in
                       the default network namespace. Either HostASN or HostType must be set.
                     format: int64
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hosttype:
+                  hostType:
                     description: |-
-                      hosttype is the AS type of the BGP speaking component running in the
+                      hostType is the AS type of the BGP speaking component running in the
                       default network namespace. Either HostASN or HostType must be set.
                     enum:
                     - external
                     - internal
                     type: string
-                  localcidr:
+                  localCIDR:
                     description: |-
-                      localcidr is the CIDR configuration for the veth pair
+                      localCIDR is the CIDR configuration for the veth pair
                       to connect with the default namespace. The interface under
                       the PERouter side is going to use the first IP of the cidr on all the nodes.
                       At least one of IPv4 or IPv6 must be provided.
@@ -95,13 +95,13 @@ spec:
                       rule: has(self.ipv4) || has(self.ipv6)
                 required:
                 - asn
-                - localcidr
+                - localCIDR
                 type: object
                 x-kubernetes-validations:
                 - message: either HostASN or HostType must be set
-                  rule: has(self.hostasn) || has(self.hosttype)
+                  rule: has(self.hostASN) || has(self.hostType)
                 - message: HostASN and HostType cannot be set together
-                  rule: '!has(self.hostasn) || !has(self.hosttype)'
+                  rule: '!has(self.hostASN) || !has(self.hostType)'
               nodeSelector:
                 description: |-
                   nodeSelector specifies which nodes this L3Passthrough applies to.
@@ -152,7 +152,7 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
             required:
-            - hostsession
+            - hostSession
             type: object
           status:
             description: status defines the observed state of L3Passthrough.

--- a/charts/openperouter/charts/crds/templates/network.openperouter.io_l3vnis.yaml
+++ b/charts/openperouter/charts/crds/templates/network.openperouter.io_l3vnis.yaml
@@ -53,8 +53,8 @@ spec:
                 maxItems: 100
                 type: array
                 x-kubernetes-list-type: atomic
-              hostsession:
-                description: hostsession is the configuration for the host session.
+              hostSession:
+                description: hostSession is the configuration for the host session.
                 properties:
                   asn:
                     description: |-
@@ -64,25 +64,25 @@ spec:
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hostasn:
+                  hostASN:
                     description: |-
-                      hostasn is the expected AS number for a BGP speaking component running in
+                      hostASN is the expected AS number for a BGP speaking component running in
                       the default network namespace. Either HostASN or HostType must be set.
                     format: int64
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hosttype:
+                  hostType:
                     description: |-
-                      hosttype is the AS type of the BGP speaking component running in the
+                      hostType is the AS type of the BGP speaking component running in the
                       default network namespace. Either HostASN or HostType must be set.
                     enum:
                     - external
                     - internal
                     type: string
-                  localcidr:
+                  localCIDR:
                     description: |-
-                      localcidr is the CIDR configuration for the veth pair
+                      localCIDR is the CIDR configuration for the veth pair
                       to connect with the default namespace. The interface under
                       the PERouter side is going to use the first IP of the cidr on all the nodes.
                       At least one of IPv4 or IPv6 must be provided.
@@ -107,13 +107,13 @@ spec:
                       rule: has(self.ipv4) || has(self.ipv6)
                 required:
                 - asn
-                - localcidr
+                - localCIDR
                 type: object
                 x-kubernetes-validations:
                 - message: either HostASN or HostType must be set
-                  rule: has(self.hostasn) || has(self.hosttype)
+                  rule: has(self.hostASN) || has(self.hostType)
                 - message: HostASN and HostType cannot be set together
-                  rule: '!has(self.hostasn) || !has(self.hosttype)'
+                  rule: '!has(self.hostASN) || !has(self.hostType)'
               importRTs:
                 description: |-
                   importRTs are the Route Targets to be used for importing routes.
@@ -197,9 +197,9 @@ spec:
                 minLength: 1
                 pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
                 type: string
-              vxlanport:
+              vxlanPort:
                 default: 4789
-                description: vxlanport is the port to be used for VXLan encapsulation.
+                description: vxlanPort is the port to be used for VXLan encapsulation.
                 format: int32
                 type: integer
             required:
@@ -208,8 +208,8 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: hostASN must be different from asn
-              rule: '!has(self.hostsession) || !has(self.hostsession.hostasn) || self.hostsession.hostasn
-                != self.hostsession.asn'
+              rule: '!has(self.hostSession) || !has(self.hostSession.hostASN) || self.hostSession.hostASN
+                != self.hostSession.asn'
           status:
             description: status defines the observed state of L3VNI.
             type: object

--- a/charts/openperouter/charts/crds/templates/network.openperouter.io_l3vpns.yaml
+++ b/charts/openperouter/charts/crds/templates/network.openperouter.io_l3vpns.yaml
@@ -52,8 +52,8 @@ spec:
                 maxItems: 100
                 type: array
                 x-kubernetes-list-type: atomic
-              hostsession:
-                description: hostsession is the configuration for the host session.
+              hostSession:
+                description: hostSession is the configuration for the host session.
                 properties:
                   asn:
                     description: |-
@@ -63,25 +63,25 @@ spec:
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hostasn:
+                  hostASN:
                     description: |-
-                      hostasn is the expected AS number for a BGP speaking component running in
+                      hostASN is the expected AS number for a BGP speaking component running in
                       the default network namespace. Either HostASN or HostType must be set.
                     format: int64
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hosttype:
+                  hostType:
                     description: |-
-                      hosttype is the AS type of the BGP speaking component running in the
+                      hostType is the AS type of the BGP speaking component running in the
                       default network namespace. Either HostASN or HostType must be set.
                     enum:
                     - external
                     - internal
                     type: string
-                  localcidr:
+                  localCIDR:
                     description: |-
-                      localcidr is the CIDR configuration for the veth pair
+                      localCIDR is the CIDR configuration for the veth pair
                       to connect with the default namespace. The interface under
                       the PERouter side is going to use the first IP of the cidr on all the nodes.
                       At least one of IPv4 or IPv6 must be provided.
@@ -106,13 +106,13 @@ spec:
                       rule: has(self.ipv4) || has(self.ipv6)
                 required:
                 - asn
-                - localcidr
+                - localCIDR
                 type: object
                 x-kubernetes-validations:
                 - message: either HostASN or HostType must be set
-                  rule: has(self.hostasn) || has(self.hosttype)
+                  rule: has(self.hostASN) || has(self.hostType)
                 - message: HostASN and HostType cannot be set together
-                  rule: '!has(self.hostasn) || !has(self.hosttype)'
+                  rule: '!has(self.hostASN) || !has(self.hostType)'
               importRTs:
                 description: |-
                   importRTs are the Route Targets to be used for importing routes.
@@ -198,7 +198,7 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: hostASN must be different from asn
-              rule: '!has(self.hostsession) || self.hostsession.hostasn != self.hostsession.asn'
+              rule: '!has(self.hostSession) || self.hostSession.hostASN != self.hostSession.asn'
           status:
             description: status defines the observed state of L3VPN.
             type: object

--- a/charts/openperouter/charts/crds/templates/network.openperouter.io_underlays.yaml
+++ b/charts/openperouter/charts/crds/templates/network.openperouter.io_underlays.yaml
@@ -578,9 +578,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
-              routeridcidr:
+              routerIDCIDR:
                 default: 10.0.0.0/24
-                description: routeridcidr is the ipv4 cidr to be used to assign a
+                description: routerIDCIDR is the ipv4 cidr to be used to assign a
                   different routerID on each node.
                 type: string
               srv6:

--- a/config/all-in-one/crio.yaml
+++ b/config/all-in-one/crio.yaml
@@ -66,9 +66,9 @@ spec:
                 x-kubernetes-validations:
                 - message: GatewayIPs cannot be changed
                   rule: self == oldSelf
-              hostmaster:
+              hostMaster:
                 description: |-
-                  hostmaster is the interface on the host the veth should be attached to.
+                  hostMaster is the interface on the host the veth should be attached to.
                   If not set, the host veth will not be attached to any interface and it must be
                   attached manually (or by some other means). This is useful if another controller
                   is leveraging the host interface for the VNI.
@@ -256,9 +256,9 @@ spec:
                 maximum: 16777215
                 minimum: 1
                 type: integer
-              vxlanport:
+              vxlanPort:
                 default: 4789
-                description: vxlanport is the port to be used for VXLan encapsulation.
+                description: vxlanPort is the port to be used for VXLan encapsulation.
                 format: int32
                 type: integer
             required:
@@ -320,8 +320,8 @@ spec:
           spec:
             description: spec defines the desired state of L3Passthrough.
             properties:
-              hostsession:
-                description: hostsession is the configuration for the host session.
+              hostSession:
+                description: hostSession is the configuration for the host session.
                 properties:
                   asn:
                     description: |-
@@ -331,25 +331,25 @@ spec:
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hostasn:
+                  hostASN:
                     description: |-
-                      hostasn is the expected AS number for a BGP speaking component running in
+                      hostASN is the expected AS number for a BGP speaking component running in
                       the default network namespace. Either HostASN or HostType must be set.
                     format: int64
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hosttype:
+                  hostType:
                     description: |-
-                      hosttype is the AS type of the BGP speaking component running in the
+                      hostType is the AS type of the BGP speaking component running in the
                       default network namespace. Either HostASN or HostType must be set.
                     enum:
                     - external
                     - internal
                     type: string
-                  localcidr:
+                  localCIDR:
                     description: |-
-                      localcidr is the CIDR configuration for the veth pair
+                      localCIDR is the CIDR configuration for the veth pair
                       to connect with the default namespace. The interface under
                       the PERouter side is going to use the first IP of the cidr on all the nodes.
                       At least one of IPv4 or IPv6 must be provided.
@@ -374,13 +374,13 @@ spec:
                       rule: has(self.ipv4) || has(self.ipv6)
                 required:
                 - asn
-                - localcidr
+                - localCIDR
                 type: object
                 x-kubernetes-validations:
                 - message: either HostASN or HostType must be set
-                  rule: has(self.hostasn) || has(self.hosttype)
+                  rule: has(self.hostASN) || has(self.hostType)
                 - message: HostASN and HostType cannot be set together
-                  rule: '!has(self.hostasn) || !has(self.hosttype)'
+                  rule: '!has(self.hostASN) || !has(self.hostType)'
               nodeSelector:
                 description: |-
                   nodeSelector specifies which nodes this L3Passthrough applies to.
@@ -431,7 +431,7 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
             required:
-            - hostsession
+            - hostSession
             type: object
           status:
             description: status defines the observed state of L3Passthrough.
@@ -498,8 +498,8 @@ spec:
                 maxItems: 100
                 type: array
                 x-kubernetes-list-type: atomic
-              hostsession:
-                description: hostsession is the configuration for the host session.
+              hostSession:
+                description: hostSession is the configuration for the host session.
                 properties:
                   asn:
                     description: |-
@@ -509,25 +509,25 @@ spec:
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hostasn:
+                  hostASN:
                     description: |-
-                      hostasn is the expected AS number for a BGP speaking component running in
+                      hostASN is the expected AS number for a BGP speaking component running in
                       the default network namespace. Either HostASN or HostType must be set.
                     format: int64
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hosttype:
+                  hostType:
                     description: |-
-                      hosttype is the AS type of the BGP speaking component running in the
+                      hostType is the AS type of the BGP speaking component running in the
                       default network namespace. Either HostASN or HostType must be set.
                     enum:
                     - external
                     - internal
                     type: string
-                  localcidr:
+                  localCIDR:
                     description: |-
-                      localcidr is the CIDR configuration for the veth pair
+                      localCIDR is the CIDR configuration for the veth pair
                       to connect with the default namespace. The interface under
                       the PERouter side is going to use the first IP of the cidr on all the nodes.
                       At least one of IPv4 or IPv6 must be provided.
@@ -552,13 +552,13 @@ spec:
                       rule: has(self.ipv4) || has(self.ipv6)
                 required:
                 - asn
-                - localcidr
+                - localCIDR
                 type: object
                 x-kubernetes-validations:
                 - message: either HostASN or HostType must be set
-                  rule: has(self.hostasn) || has(self.hosttype)
+                  rule: has(self.hostASN) || has(self.hostType)
                 - message: HostASN and HostType cannot be set together
-                  rule: '!has(self.hostasn) || !has(self.hosttype)'
+                  rule: '!has(self.hostASN) || !has(self.hostType)'
               importRTs:
                 description: |-
                   importRTs are the Route Targets to be used for importing routes.
@@ -642,9 +642,9 @@ spec:
                 minLength: 1
                 pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
                 type: string
-              vxlanport:
+              vxlanPort:
                 default: 4789
-                description: vxlanport is the port to be used for VXLan encapsulation.
+                description: vxlanPort is the port to be used for VXLan encapsulation.
                 format: int32
                 type: integer
             required:
@@ -653,8 +653,8 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: hostASN must be different from asn
-              rule: '!has(self.hostsession) || !has(self.hostsession.hostasn) || self.hostsession.hostasn
-                != self.hostsession.asn'
+              rule: '!has(self.hostSession) || !has(self.hostSession.hostASN) || self.hostSession.hostASN
+                != self.hostSession.asn'
           status:
             description: status defines the observed state of L3VNI.
             type: object
@@ -719,8 +719,8 @@ spec:
                 maxItems: 100
                 type: array
                 x-kubernetes-list-type: atomic
-              hostsession:
-                description: hostsession is the configuration for the host session.
+              hostSession:
+                description: hostSession is the configuration for the host session.
                 properties:
                   asn:
                     description: |-
@@ -730,25 +730,25 @@ spec:
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hostasn:
+                  hostASN:
                     description: |-
-                      hostasn is the expected AS number for a BGP speaking component running in
+                      hostASN is the expected AS number for a BGP speaking component running in
                       the default network namespace. Either HostASN or HostType must be set.
                     format: int64
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hosttype:
+                  hostType:
                     description: |-
-                      hosttype is the AS type of the BGP speaking component running in the
+                      hostType is the AS type of the BGP speaking component running in the
                       default network namespace. Either HostASN or HostType must be set.
                     enum:
                     - external
                     - internal
                     type: string
-                  localcidr:
+                  localCIDR:
                     description: |-
-                      localcidr is the CIDR configuration for the veth pair
+                      localCIDR is the CIDR configuration for the veth pair
                       to connect with the default namespace. The interface under
                       the PERouter side is going to use the first IP of the cidr on all the nodes.
                       At least one of IPv4 or IPv6 must be provided.
@@ -773,13 +773,13 @@ spec:
                       rule: has(self.ipv4) || has(self.ipv6)
                 required:
                 - asn
-                - localcidr
+                - localCIDR
                 type: object
                 x-kubernetes-validations:
                 - message: either HostASN or HostType must be set
-                  rule: has(self.hostasn) || has(self.hosttype)
+                  rule: has(self.hostASN) || has(self.hostType)
                 - message: HostASN and HostType cannot be set together
-                  rule: '!has(self.hostasn) || !has(self.hosttype)'
+                  rule: '!has(self.hostASN) || !has(self.hostType)'
               importRTs:
                 description: |-
                   importRTs are the Route Targets to be used for importing routes.
@@ -865,7 +865,7 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: hostASN must be different from asn
-              rule: '!has(self.hostsession) || self.hostsession.hostasn != self.hostsession.asn'
+              rule: '!has(self.hostSession) || self.hostSession.hostASN != self.hostSession.asn'
           status:
             description: status defines the observed state of L3VPN.
             type: object
@@ -1735,9 +1735,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
-              routeridcidr:
+              routerIDCIDR:
                 default: 10.0.0.0/24
-                description: routeridcidr is the ipv4 cidr to be used to assign a
+                description: routerIDCIDR is the ipv4 cidr to be used to assign a
                   different routerID on each node.
                 type: string
               srv6:

--- a/config/all-in-one/openpe.yaml
+++ b/config/all-in-one/openpe.yaml
@@ -66,9 +66,9 @@ spec:
                 x-kubernetes-validations:
                 - message: GatewayIPs cannot be changed
                   rule: self == oldSelf
-              hostmaster:
+              hostMaster:
                 description: |-
-                  hostmaster is the interface on the host the veth should be attached to.
+                  hostMaster is the interface on the host the veth should be attached to.
                   If not set, the host veth will not be attached to any interface and it must be
                   attached manually (or by some other means). This is useful if another controller
                   is leveraging the host interface for the VNI.
@@ -256,9 +256,9 @@ spec:
                 maximum: 16777215
                 minimum: 1
                 type: integer
-              vxlanport:
+              vxlanPort:
                 default: 4789
-                description: vxlanport is the port to be used for VXLan encapsulation.
+                description: vxlanPort is the port to be used for VXLan encapsulation.
                 format: int32
                 type: integer
             required:
@@ -320,8 +320,8 @@ spec:
           spec:
             description: spec defines the desired state of L3Passthrough.
             properties:
-              hostsession:
-                description: hostsession is the configuration for the host session.
+              hostSession:
+                description: hostSession is the configuration for the host session.
                 properties:
                   asn:
                     description: |-
@@ -331,25 +331,25 @@ spec:
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hostasn:
+                  hostASN:
                     description: |-
-                      hostasn is the expected AS number for a BGP speaking component running in
+                      hostASN is the expected AS number for a BGP speaking component running in
                       the default network namespace. Either HostASN or HostType must be set.
                     format: int64
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hosttype:
+                  hostType:
                     description: |-
-                      hosttype is the AS type of the BGP speaking component running in the
+                      hostType is the AS type of the BGP speaking component running in the
                       default network namespace. Either HostASN or HostType must be set.
                     enum:
                     - external
                     - internal
                     type: string
-                  localcidr:
+                  localCIDR:
                     description: |-
-                      localcidr is the CIDR configuration for the veth pair
+                      localCIDR is the CIDR configuration for the veth pair
                       to connect with the default namespace. The interface under
                       the PERouter side is going to use the first IP of the cidr on all the nodes.
                       At least one of IPv4 or IPv6 must be provided.
@@ -374,13 +374,13 @@ spec:
                       rule: has(self.ipv4) || has(self.ipv6)
                 required:
                 - asn
-                - localcidr
+                - localCIDR
                 type: object
                 x-kubernetes-validations:
                 - message: either HostASN or HostType must be set
-                  rule: has(self.hostasn) || has(self.hosttype)
+                  rule: has(self.hostASN) || has(self.hostType)
                 - message: HostASN and HostType cannot be set together
-                  rule: '!has(self.hostasn) || !has(self.hosttype)'
+                  rule: '!has(self.hostASN) || !has(self.hostType)'
               nodeSelector:
                 description: |-
                   nodeSelector specifies which nodes this L3Passthrough applies to.
@@ -431,7 +431,7 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
             required:
-            - hostsession
+            - hostSession
             type: object
           status:
             description: status defines the observed state of L3Passthrough.
@@ -498,8 +498,8 @@ spec:
                 maxItems: 100
                 type: array
                 x-kubernetes-list-type: atomic
-              hostsession:
-                description: hostsession is the configuration for the host session.
+              hostSession:
+                description: hostSession is the configuration for the host session.
                 properties:
                   asn:
                     description: |-
@@ -509,25 +509,25 @@ spec:
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hostasn:
+                  hostASN:
                     description: |-
-                      hostasn is the expected AS number for a BGP speaking component running in
+                      hostASN is the expected AS number for a BGP speaking component running in
                       the default network namespace. Either HostASN or HostType must be set.
                     format: int64
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hosttype:
+                  hostType:
                     description: |-
-                      hosttype is the AS type of the BGP speaking component running in the
+                      hostType is the AS type of the BGP speaking component running in the
                       default network namespace. Either HostASN or HostType must be set.
                     enum:
                     - external
                     - internal
                     type: string
-                  localcidr:
+                  localCIDR:
                     description: |-
-                      localcidr is the CIDR configuration for the veth pair
+                      localCIDR is the CIDR configuration for the veth pair
                       to connect with the default namespace. The interface under
                       the PERouter side is going to use the first IP of the cidr on all the nodes.
                       At least one of IPv4 or IPv6 must be provided.
@@ -552,13 +552,13 @@ spec:
                       rule: has(self.ipv4) || has(self.ipv6)
                 required:
                 - asn
-                - localcidr
+                - localCIDR
                 type: object
                 x-kubernetes-validations:
                 - message: either HostASN or HostType must be set
-                  rule: has(self.hostasn) || has(self.hosttype)
+                  rule: has(self.hostASN) || has(self.hostType)
                 - message: HostASN and HostType cannot be set together
-                  rule: '!has(self.hostasn) || !has(self.hosttype)'
+                  rule: '!has(self.hostASN) || !has(self.hostType)'
               importRTs:
                 description: |-
                   importRTs are the Route Targets to be used for importing routes.
@@ -642,9 +642,9 @@ spec:
                 minLength: 1
                 pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
                 type: string
-              vxlanport:
+              vxlanPort:
                 default: 4789
-                description: vxlanport is the port to be used for VXLan encapsulation.
+                description: vxlanPort is the port to be used for VXLan encapsulation.
                 format: int32
                 type: integer
             required:
@@ -653,8 +653,8 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: hostASN must be different from asn
-              rule: '!has(self.hostsession) || !has(self.hostsession.hostasn) || self.hostsession.hostasn
-                != self.hostsession.asn'
+              rule: '!has(self.hostSession) || !has(self.hostSession.hostASN) || self.hostSession.hostASN
+                != self.hostSession.asn'
           status:
             description: status defines the observed state of L3VNI.
             type: object
@@ -719,8 +719,8 @@ spec:
                 maxItems: 100
                 type: array
                 x-kubernetes-list-type: atomic
-              hostsession:
-                description: hostsession is the configuration for the host session.
+              hostSession:
+                description: hostSession is the configuration for the host session.
                 properties:
                   asn:
                     description: |-
@@ -730,25 +730,25 @@ spec:
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hostasn:
+                  hostASN:
                     description: |-
-                      hostasn is the expected AS number for a BGP speaking component running in
+                      hostASN is the expected AS number for a BGP speaking component running in
                       the default network namespace. Either HostASN or HostType must be set.
                     format: int64
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hosttype:
+                  hostType:
                     description: |-
-                      hosttype is the AS type of the BGP speaking component running in the
+                      hostType is the AS type of the BGP speaking component running in the
                       default network namespace. Either HostASN or HostType must be set.
                     enum:
                     - external
                     - internal
                     type: string
-                  localcidr:
+                  localCIDR:
                     description: |-
-                      localcidr is the CIDR configuration for the veth pair
+                      localCIDR is the CIDR configuration for the veth pair
                       to connect with the default namespace. The interface under
                       the PERouter side is going to use the first IP of the cidr on all the nodes.
                       At least one of IPv4 or IPv6 must be provided.
@@ -773,13 +773,13 @@ spec:
                       rule: has(self.ipv4) || has(self.ipv6)
                 required:
                 - asn
-                - localcidr
+                - localCIDR
                 type: object
                 x-kubernetes-validations:
                 - message: either HostASN or HostType must be set
-                  rule: has(self.hostasn) || has(self.hosttype)
+                  rule: has(self.hostASN) || has(self.hostType)
                 - message: HostASN and HostType cannot be set together
-                  rule: '!has(self.hostasn) || !has(self.hosttype)'
+                  rule: '!has(self.hostASN) || !has(self.hostType)'
               importRTs:
                 description: |-
                   importRTs are the Route Targets to be used for importing routes.
@@ -865,7 +865,7 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: hostASN must be different from asn
-              rule: '!has(self.hostsession) || self.hostsession.hostasn != self.hostsession.asn'
+              rule: '!has(self.hostSession) || self.hostSession.hostASN != self.hostSession.asn'
           status:
             description: status defines the observed state of L3VPN.
             type: object
@@ -1735,9 +1735,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
-              routeridcidr:
+              routerIDCIDR:
                 default: 10.0.0.0/24
-                description: routeridcidr is the ipv4 cidr to be used to assign a
+                description: routerIDCIDR is the ipv4 cidr to be used to assign a
                   different routerID on each node.
                 type: string
               srv6:

--- a/config/crd/bases/network.openperouter.io_l2vnis.yaml
+++ b/config/crd/bases/network.openperouter.io_l2vnis.yaml
@@ -57,9 +57,9 @@ spec:
                 x-kubernetes-validations:
                 - message: GatewayIPs cannot be changed
                   rule: self == oldSelf
-              hostmaster:
+              hostMaster:
                 description: |-
-                  hostmaster is the interface on the host the veth should be attached to.
+                  hostMaster is the interface on the host the veth should be attached to.
                   If not set, the host veth will not be attached to any interface and it must be
                   attached manually (or by some other means). This is useful if another controller
                   is leveraging the host interface for the VNI.
@@ -247,9 +247,9 @@ spec:
                 maximum: 16777215
                 minimum: 1
                 type: integer
-              vxlanport:
+              vxlanPort:
                 default: 4789
-                description: vxlanport is the port to be used for VXLan encapsulation.
+                description: vxlanPort is the port to be used for VXLan encapsulation.
                 format: int32
                 type: integer
             required:

--- a/config/crd/bases/network.openperouter.io_l3passthroughs.yaml
+++ b/config/crd/bases/network.openperouter.io_l3passthroughs.yaml
@@ -41,8 +41,8 @@ spec:
           spec:
             description: spec defines the desired state of L3Passthrough.
             properties:
-              hostsession:
-                description: hostsession is the configuration for the host session.
+              hostSession:
+                description: hostSession is the configuration for the host session.
                 properties:
                   asn:
                     description: |-
@@ -52,25 +52,25 @@ spec:
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hostasn:
+                  hostASN:
                     description: |-
-                      hostasn is the expected AS number for a BGP speaking component running in
+                      hostASN is the expected AS number for a BGP speaking component running in
                       the default network namespace. Either HostASN or HostType must be set.
                     format: int64
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hosttype:
+                  hostType:
                     description: |-
-                      hosttype is the AS type of the BGP speaking component running in the
+                      hostType is the AS type of the BGP speaking component running in the
                       default network namespace. Either HostASN or HostType must be set.
                     enum:
                     - external
                     - internal
                     type: string
-                  localcidr:
+                  localCIDR:
                     description: |-
-                      localcidr is the CIDR configuration for the veth pair
+                      localCIDR is the CIDR configuration for the veth pair
                       to connect with the default namespace. The interface under
                       the PERouter side is going to use the first IP of the cidr on all the nodes.
                       At least one of IPv4 or IPv6 must be provided.
@@ -95,13 +95,13 @@ spec:
                       rule: has(self.ipv4) || has(self.ipv6)
                 required:
                 - asn
-                - localcidr
+                - localCIDR
                 type: object
                 x-kubernetes-validations:
                 - message: either HostASN or HostType must be set
-                  rule: has(self.hostasn) || has(self.hosttype)
+                  rule: has(self.hostASN) || has(self.hostType)
                 - message: HostASN and HostType cannot be set together
-                  rule: '!has(self.hostasn) || !has(self.hosttype)'
+                  rule: '!has(self.hostASN) || !has(self.hostType)'
               nodeSelector:
                 description: |-
                   nodeSelector specifies which nodes this L3Passthrough applies to.
@@ -152,7 +152,7 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
             required:
-            - hostsession
+            - hostSession
             type: object
           status:
             description: status defines the observed state of L3Passthrough.

--- a/config/crd/bases/network.openperouter.io_l3vnis.yaml
+++ b/config/crd/bases/network.openperouter.io_l3vnis.yaml
@@ -53,8 +53,8 @@ spec:
                 maxItems: 100
                 type: array
                 x-kubernetes-list-type: atomic
-              hostsession:
-                description: hostsession is the configuration for the host session.
+              hostSession:
+                description: hostSession is the configuration for the host session.
                 properties:
                   asn:
                     description: |-
@@ -64,25 +64,25 @@ spec:
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hostasn:
+                  hostASN:
                     description: |-
-                      hostasn is the expected AS number for a BGP speaking component running in
+                      hostASN is the expected AS number for a BGP speaking component running in
                       the default network namespace. Either HostASN or HostType must be set.
                     format: int64
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hosttype:
+                  hostType:
                     description: |-
-                      hosttype is the AS type of the BGP speaking component running in the
+                      hostType is the AS type of the BGP speaking component running in the
                       default network namespace. Either HostASN or HostType must be set.
                     enum:
                     - external
                     - internal
                     type: string
-                  localcidr:
+                  localCIDR:
                     description: |-
-                      localcidr is the CIDR configuration for the veth pair
+                      localCIDR is the CIDR configuration for the veth pair
                       to connect with the default namespace. The interface under
                       the PERouter side is going to use the first IP of the cidr on all the nodes.
                       At least one of IPv4 or IPv6 must be provided.
@@ -107,13 +107,13 @@ spec:
                       rule: has(self.ipv4) || has(self.ipv6)
                 required:
                 - asn
-                - localcidr
+                - localCIDR
                 type: object
                 x-kubernetes-validations:
                 - message: either HostASN or HostType must be set
-                  rule: has(self.hostasn) || has(self.hosttype)
+                  rule: has(self.hostASN) || has(self.hostType)
                 - message: HostASN and HostType cannot be set together
-                  rule: '!has(self.hostasn) || !has(self.hosttype)'
+                  rule: '!has(self.hostASN) || !has(self.hostType)'
               importRTs:
                 description: |-
                   importRTs are the Route Targets to be used for importing routes.
@@ -197,9 +197,9 @@ spec:
                 minLength: 1
                 pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
                 type: string
-              vxlanport:
+              vxlanPort:
                 default: 4789
-                description: vxlanport is the port to be used for VXLan encapsulation.
+                description: vxlanPort is the port to be used for VXLan encapsulation.
                 format: int32
                 type: integer
             required:
@@ -208,8 +208,8 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: hostASN must be different from asn
-              rule: '!has(self.hostsession) || !has(self.hostsession.hostasn) || self.hostsession.hostasn
-                != self.hostsession.asn'
+              rule: '!has(self.hostSession) || !has(self.hostSession.hostASN) || self.hostSession.hostASN
+                != self.hostSession.asn'
           status:
             description: status defines the observed state of L3VNI.
             type: object

--- a/config/crd/bases/network.openperouter.io_l3vpns.yaml
+++ b/config/crd/bases/network.openperouter.io_l3vpns.yaml
@@ -52,8 +52,8 @@ spec:
                 maxItems: 100
                 type: array
                 x-kubernetes-list-type: atomic
-              hostsession:
-                description: hostsession is the configuration for the host session.
+              hostSession:
+                description: hostSession is the configuration for the host session.
                 properties:
                   asn:
                     description: |-
@@ -63,25 +63,25 @@ spec:
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hostasn:
+                  hostASN:
                     description: |-
-                      hostasn is the expected AS number for a BGP speaking component running in
+                      hostASN is the expected AS number for a BGP speaking component running in
                       the default network namespace. Either HostASN or HostType must be set.
                     format: int64
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hosttype:
+                  hostType:
                     description: |-
-                      hosttype is the AS type of the BGP speaking component running in the
+                      hostType is the AS type of the BGP speaking component running in the
                       default network namespace. Either HostASN or HostType must be set.
                     enum:
                     - external
                     - internal
                     type: string
-                  localcidr:
+                  localCIDR:
                     description: |-
-                      localcidr is the CIDR configuration for the veth pair
+                      localCIDR is the CIDR configuration for the veth pair
                       to connect with the default namespace. The interface under
                       the PERouter side is going to use the first IP of the cidr on all the nodes.
                       At least one of IPv4 or IPv6 must be provided.
@@ -106,13 +106,13 @@ spec:
                       rule: has(self.ipv4) || has(self.ipv6)
                 required:
                 - asn
-                - localcidr
+                - localCIDR
                 type: object
                 x-kubernetes-validations:
                 - message: either HostASN or HostType must be set
-                  rule: has(self.hostasn) || has(self.hosttype)
+                  rule: has(self.hostASN) || has(self.hostType)
                 - message: HostASN and HostType cannot be set together
-                  rule: '!has(self.hostasn) || !has(self.hosttype)'
+                  rule: '!has(self.hostASN) || !has(self.hostType)'
               importRTs:
                 description: |-
                   importRTs are the Route Targets to be used for importing routes.
@@ -198,7 +198,7 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: hostASN must be different from asn
-              rule: '!has(self.hostsession) || self.hostsession.hostasn != self.hostsession.asn'
+              rule: '!has(self.hostSession) || self.hostSession.hostASN != self.hostSession.asn'
           status:
             description: status defines the observed state of L3VPN.
             type: object

--- a/config/crd/bases/network.openperouter.io_underlays.yaml
+++ b/config/crd/bases/network.openperouter.io_underlays.yaml
@@ -578,9 +578,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
-              routeridcidr:
+              routerIDCIDR:
                 default: 10.0.0.0/24
-                description: routeridcidr is the ipv4 cidr to be used to assign a
+                description: routerIDCIDR is the ipv4 cidr to be used to assign a
                   different routerID on each node.
                 type: string
               srv6:

--- a/config/samples/l2vni-nodeselector-at-workers.yaml
+++ b/config/samples/l2vni-nodeselector-at-workers.yaml
@@ -9,12 +9,12 @@ spec:
     matchLabels:
       node-role.kubernetes.io/worker: ""
   vni: 10100
-  vxlanport: 4789
+  vxlanPort: 4789
   routingDomain:
     type: L3VNI
     l3vni:
       name: app-l3vni
-  hostmaster:
+  hostMaster:
     type: linux-bridge
     linuxBridge:
       lifecycle: Managed

--- a/config/samples/l2vni-nodeselector-different-racks.yaml
+++ b/config/samples/l2vni-nodeselector-different-racks.yaml
@@ -14,7 +14,7 @@ spec:
     type: L3VNI
     l3vni:
       name: storage
-  hostmaster:
+  hostMaster:
     type: linux-bridge
     linuxBridge:
       lifecycle: External
@@ -37,7 +37,7 @@ spec:
     type: L3VNI
     l3vni:
       name: storage
-  hostmaster:
+  hostMaster:
     type: linux-bridge
     linuxBridge:
       lifecycle: External

--- a/config/samples/l2vni-ovs.yaml
+++ b/config/samples/l2vni-ovs.yaml
@@ -9,7 +9,7 @@ spec:
     type: L3VNI
     l3vni:
       name: red
-  hostmaster:
+  hostMaster:
     type: ovs-bridge
     ovsBridge:
       lifecycle: Managed

--- a/config/samples/l2vni.yaml
+++ b/config/samples/l2vni.yaml
@@ -9,7 +9,7 @@ spec:
     type: L3VNI
     l3vni:
       name: red
-  hostmaster:
+  hostMaster:
     type: linux-bridge
     linuxBridge:
       lifecycle: Managed

--- a/config/samples/l3passthrough-nodeselector-edge.yaml
+++ b/config/samples/l3passthrough-nodeselector-edge.yaml
@@ -8,9 +8,9 @@ spec:
   nodeSelector:
     matchLabels:
       node-role.kubernetes.io/edge: ""
-  hostsession:
+  hostSession:
     asn: 64512
-    hostasn: 64700
-    localcidr:
+    hostASN: 64700
+    localCIDR:
       ipv4: 192.169.20.0/24
 

--- a/config/samples/l3passthrough-nodeselector-security-zone.yaml
+++ b/config/samples/l3passthrough-nodeselector-security-zone.yaml
@@ -9,10 +9,10 @@ spec:
   nodeSelector:
     matchLabels:
       security-zone: dmz
-  hostsession:
+  hostSession:
     asn: 64512
-    hostasn: 64710
-    localcidr:
+    hostASN: 64710
+    localCIDR:
       ipv4: 192.169.21.0/24
 ---
 # L3Passthrough for internal nodes
@@ -25,9 +25,9 @@ spec:
   nodeSelector:
     matchLabels:
       security-zone: internal
-  hostsession:
+  hostSession:
     asn: 64512
-    hostasn: 64720
-    localcidr:
+    hostASN: 64720
+    localCIDR:
       ipv4: 192.169.22.0/24
 

--- a/config/samples/l3vni-nodeselector-at-workers.yaml
+++ b/config/samples/l3vni-nodeselector-at-workers.yaml
@@ -11,10 +11,10 @@ spec:
       node-role.kubernetes.io/worker: ""
   vrf: tenant-a
   vni: 5001
-  hostsession:
+  hostSession:
     asn: 64512
-    hostasn: 64600
-    localcidr:
+    hostASN: 64600
+    localCIDR:
       ipv4: 192.169.5.0/24
 ---
 # Tenant B VNI on the same worker nodes
@@ -29,10 +29,10 @@ spec:
       node-role.kubernetes.io/worker: ""
   vrf: tenant-b
   vni: 5002
-  hostsession:
+  hostSession:
     asn: 64512
-    hostasn: 64601
-    localcidr:
+    hostASN: 64601
+    localCIDR:
       ipv4: 192.169.6.0/24
 ---
 # Tenant C VNI on the same worker nodes
@@ -47,9 +47,9 @@ spec:
       node-role.kubernetes.io/worker: ""
   vrf: tenant-c
   vni: 5003
-  hostsession:
+  hostSession:
     asn: 64512
-    hostasn: 64602
-    localcidr:
+    hostASN: 64602
+    localCIDR:
       ipv4: 192.169.7.0/24
 

--- a/config/samples/l3vni-nodeselector-pre-rack.yaml
+++ b/config/samples/l3vni-nodeselector-pre-rack.yaml
@@ -11,11 +11,11 @@ spec:
       topology.kubernetes.io/rack: rack-1
   vrf: tenant-a
   vni: 5001
-  vxlanport: 4789
-  hostsession:
+  vxlanPort: 4789
+  hostSession:
     asn: 64512
-    hostasn: 64600
-    localcidr:
+    hostASN: 64600
+    localCIDR:
       ipv4: 192.169.1.0/24
 ---
 # L3VNI for rack-2 nodes
@@ -30,10 +30,10 @@ spec:
       topology.kubernetes.io/rack: rack-2
   vrf: tenant-a
   vni: 5002
-  vxlanport: 4789
-  hostsession:
+  vxlanPort: 4789
+  hostSession:
     asn: 64512
-    hostasn: 64600
-    localcidr:
+    hostASN: 64600
+    localCIDR:
       ipv4: 192.169.2.0/24
 

--- a/config/samples/l3vni-nodeselector-zone-specific.yaml
+++ b/config/samples/l3vni-nodeselector-zone-specific.yaml
@@ -11,10 +11,10 @@ spec:
       topology.kubernetes.io/zone: us-east-1a
   vrf: tenant-b
   vni: 6001
-  hostsession:
+  hostSession:
     asn: 64512
-    hostasn: 64601
-    localcidr:
+    hostASN: 64601
+    localCIDR:
       ipv4: 192.169.3.0/24
 ---
 # L3VNI for us-west-1a
@@ -29,9 +29,9 @@ spec:
       topology.kubernetes.io/zone: us-west-1a
   vrf: tenant-b
   vni: 6002
-  hostsession:
+  hostSession:
     asn: 64513
-    hostasn: 64601
-    localcidr:
+    hostASN: 64601
+    localCIDR:
       ipv4: 192.169.4.0/24
 

--- a/config/samples/l3vni.yaml
+++ b/config/samples/l3vni.yaml
@@ -5,10 +5,10 @@ metadata:
   namespace: openperouter-system
 spec:
   vrf: red
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.10.0/24
   vni: 100
 ---
@@ -19,9 +19,9 @@ metadata:
   namespace: openperouter-system
 spec:
   vrf: blue
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.11.0/24
   vni: 200

--- a/e2etests/tests/hostconfiguration.go
+++ b/e2etests/tests/hostconfiguration.go
@@ -1514,7 +1514,7 @@ type l3vniParams struct {
 	VTEPIP    string   `json:"vtepip"`
 	LinkIPs   *linkIPs `json:"linkIPs"`
 	VNI       uint32   `json:"vni"`
-	VXLanPort int      `json:"vxlanport"`
+	VXLanPort int      `json:"vxlanPort"`
 }
 
 type linkIPs struct {
@@ -1528,7 +1528,7 @@ type l2vniParams struct {
 	VRF        string   `json:"vrf"`
 	VTEPIP     string   `json:"vtepip"`
 	VNI        uint32   `json:"vni"`
-	VXLanPort  int      `json:"vxlanport"`
+	VXLanPort  int      `json:"vxlanPort"`
 	GatewayIPs []string `json:"gatewayIPs,omitempty"`
 }
 

--- a/e2etests/tests/static_and_api.go
+++ b/e2etests/tests/static_and_api.go
@@ -96,10 +96,10 @@ var _ = Describe("Hybrid mode: static files and API configuration", Label("syste
 
 	staticRedVNIYAML := `l3vnis:
   - vrf: red
-    hostsession:
+    hostSession:
       asn: 64514
-      hostasn: 64515
-      localcidr:
+      hostASN: 64515
+      localCIDR:
         ipv4: "192.169.10.0/24"
         ipv6: "2001:db8:1::/64"
     vni: 100

--- a/e2etests/tests/static_mirror.go
+++ b/e2etests/tests/static_mirror.go
@@ -47,10 +47,10 @@ var staticL3VNIYAML = `l3vnis:
   - name: mirror-red
     vrf: mirror-red
     vni: 8100
-    hostsession:
+    hostSession:
       asn: 64514
-      hostasn: 64515
-      localcidr:
+      hostASN: 64515
+      localCIDR:
         ipv4: "192.169.80.0/24"
 `
 
@@ -58,10 +58,10 @@ var staticL3VNIUpdatedYAML = `l3vnis:
   - name: mirror-red
     vrf: mirror-red
     vni: 8200
-    hostsession:
+    hostSession:
       asn: 64514
-      hostasn: 64515
-      localcidr:
+      hostASN: 64515
+      localCIDR:
         ipv4: "192.169.80.0/24"
 `
 
@@ -265,7 +265,7 @@ var _ = Describe("Mirror static config to Kubernetes", Label("systemdmode"), Ord
 		l2vniYAML := `l2vnis:
   - name: sl2vni8300
     vni: 8300
-    vxlanport: 4789
+    vxlanPort: 4789
 `
 		for _, pod := range configPods {
 			_, err := execInConfigPod(pod, fmt.Sprintf("cat > %s/openpe_l2vni.yaml << 'EOF'\n%s\nEOF",
@@ -282,7 +282,7 @@ var _ = Describe("Mirror static config to Kubernetes", Label("systemdmode"), Ord
 		l2vniYAML := `l2vnis:
   - name: sl2vni8300
     vni: 8300
-    vxlanport: 4789
+    vxlanPort: 4789
 `
 		for _, pod := range configPods {
 			_, err := execInConfigPod(pod, fmt.Sprintf("cat > %s/openpe_l2vni.yaml << 'EOF'\n%s\nEOF",
@@ -465,7 +465,7 @@ var _ = Describe("Mirror static config to Kubernetes", Label("systemdmode"), Ord
 		l2vniYAML := `l2vnis:
   - name: sl2vni8400
     vni: 8400
-    vxlanport: 4789
+    vxlanPort: 4789
 `
 		for _, pod := range configPods {
 			_, err := execInConfigPod(pod, fmt.Sprintf("cat > %s/openpe_l2vni_webhook.yaml << 'EOF'\n%s\nEOF",

--- a/examples/evpn/calico/openpe.yaml
+++ b/examples/evpn/calico/openpe.yaml
@@ -5,10 +5,10 @@ metadata:
   namespace: openperouter-system
 spec:
   vrf: red
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.10.0/24
   vni: 100
 ---

--- a/examples/evpn/cni-underlay/openpe.yaml
+++ b/examples/evpn/cni-underlay/openpe.yaml
@@ -5,10 +5,10 @@ metadata:
   namespace: openperouter-system
 spec:
   vrf: red
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.10.0/24
   vni: 100
 ---
@@ -23,7 +23,7 @@ spec:
     type: L3VNI
     l3vni:
       name: red
-  hostmaster:
+  hostMaster:
     type: linux-bridge
     linuxBridge:
       lifecycle: Managed

--- a/examples/evpn/kubevirt/openpe.yaml
+++ b/examples/evpn/kubevirt/openpe.yaml
@@ -5,10 +5,10 @@ metadata:
   namespace: openperouter-system
 spec:
   vrf: red
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.10.0/24
   vni: 100
 ---
@@ -18,7 +18,7 @@ metadata:
   name: layer2
   namespace: openperouter-system
 spec:
-  hostmaster:
+  hostMaster:
     type: linux-bridge
     linuxBridge:
       lifecycle: Managed
@@ -28,7 +28,7 @@ spec:
     type: L3VNI
     l3vni:
       name: red
-  vxlanport: 4789
+  vxlanPort: 4789
 ---
 apiVersion: network.openperouter.io/v1alpha1
 kind: Underlay

--- a/examples/evpn/layer2/openpe.yaml
+++ b/examples/evpn/layer2/openpe.yaml
@@ -5,10 +5,10 @@ metadata:
   namespace: openperouter-system
 spec:
   vrf: red
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.10.0/24
   vni: 100
 ---
@@ -23,7 +23,7 @@ spec:
     type: L3VNI
     l3vni:
       name: red
-  hostmaster:
+  hostMaster:
     type: linux-bridge
     linuxBridge:
       lifecycle: Managed

--- a/examples/evpn/metallb/openpe.yaml
+++ b/examples/evpn/metallb/openpe.yaml
@@ -5,10 +5,10 @@ metadata:
   namespace: openperouter-system
 spec:
   vrf: red
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.10.0/24
   vni: 100
 ---
@@ -19,10 +19,10 @@ metadata:
   namespace: openperouter-system
 spec:
   vrf: blue
-  hostsession:
+  hostSession:
     asn: 64514
-    hosttype: external
-    localcidr:
+    hostType: external
+    localCIDR:
       ipv4: 192.169.11.0/24
   vni: 200
 ---

--- a/examples/evpn/multi-cluster/cluster-a-migration-l2vni.yaml
+++ b/examples/evpn/multi-cluster/cluster-a-migration-l2vni.yaml
@@ -4,7 +4,7 @@ metadata:
   name: migration-net
   namespace: openperouter-system
 spec:
-  hostmaster:
+  hostMaster:
     type: linux-bridge
     linuxBridge:
       lifecycle: Managed

--- a/examples/evpn/multi-cluster/cluster-a-openpe.yaml
+++ b/examples/evpn/multi-cluster/cluster-a-openpe.yaml
@@ -13,7 +13,7 @@ metadata:
   name: layer2
   namespace: openperouter-system
 spec:
-  hostmaster:
+  hostMaster:
     type: linux-bridge
     linuxBridge:
       lifecycle: Managed

--- a/examples/evpn/multi-cluster/cluster-b-migration-l2vni.yaml
+++ b/examples/evpn/multi-cluster/cluster-b-migration-l2vni.yaml
@@ -4,7 +4,7 @@ metadata:
   name: migration-net
   namespace: openperouter-system
 spec:
-  hostmaster:
+  hostMaster:
     type: linux-bridge
     linuxBridge:
       lifecycle: Managed

--- a/examples/evpn/multi-cluster/cluster-b-openpe.yaml
+++ b/examples/evpn/multi-cluster/cluster-b-openpe.yaml
@@ -13,7 +13,7 @@ metadata:
   name: layer2
   namespace: openperouter-system
 spec:
-  hostmaster:
+  hostMaster:
     type: linux-bridge
     linuxBridge:
       lifecycle: Managed
@@ -34,7 +34,7 @@ spec:
   tunnelEndpoint:
     cidrs:
     - 100.65.1.0/24
-  routeridcidr: 10.0.1.0/24
+  routerIDCIDR: 10.0.1.0/24
   interfaces:
     - type: NetworkDevice
       networkDevice:

--- a/examples/l3vpn/layer2/openpe.yaml
+++ b/examples/l3vpn/layer2/openpe.yaml
@@ -24,7 +24,7 @@ spec:
     - type: NetworkDevice
       networkDevice:
         interfaceName: toswitch1
-  routeridcidr: 10.0.0.0/24
+  routerIDCIDR: 10.0.0.0/24
   isis:
     baseNet: "49.0001.0002.0003.0004.00"
     level: 1
@@ -42,10 +42,10 @@ metadata:
   name: red
   namespace: openperouter-system
 spec:
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.10.0/24
   vrf: red
   rdAssignedNumber: 100
@@ -65,7 +65,7 @@ spec:
     type: L3VPN
     l3vpn:
       name: red
-  hostmaster:
+  hostMaster:
     type: linux-bridge
     linuxBridge:
       lifecycle: Managed

--- a/examples/l3vpn/metallb/openpe.yaml
+++ b/examples/l3vpn/metallb/openpe.yaml
@@ -18,7 +18,7 @@ spec:
     - type: NetworkDevice
       networkDevice:
         interfaceName: toswitch1
-  routeridcidr: 10.0.0.0/24
+  routerIDCIDR: 10.0.0.0/24
   tunnelEndpoint:
     cidrs:
     - 2001:db8:1234:5678::/64
@@ -41,10 +41,10 @@ metadata:
   name: red
   namespace: openperouter-system
 spec:
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.10.0/24
   vrf: red
   rdAssignedNumber: 100
@@ -59,10 +59,10 @@ metadata:
   name: blue
   namespace: openperouter-system
 spec:
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.11.0/24
   vrf: blue
   rdAssignedNumber: 200

--- a/examples/passthrough/metallb/openpe.yaml
+++ b/examples/passthrough/metallb/openpe.yaml
@@ -4,10 +4,10 @@ metadata:
   name: passthrough
   namespace: openperouter-system
 spec:
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.10.0/24
 ---
 apiVersion: network.openperouter.io/v1alpha1

--- a/internal/controller/routerconfiguration/mirror_controller_test.go
+++ b/internal/controller/routerconfiguration/mirror_controller_test.go
@@ -41,7 +41,7 @@ func TestMirrorController(t *testing.T) {
 			files: map[string]string{
 				"openpe_underlay.yaml": `underlays:
   - asn: 64514
-    routeridcidr: "10.0.0.0/24"
+    routerIDCIDR: "10.0.0.0/24"
     interfaces:
       - type: NetworkDevice
         networkDevice:
@@ -86,7 +86,7 @@ func TestMirrorController(t *testing.T) {
 				"openpe_l2vni.yaml": `l2vnis:
   - name: l2vni-300
     vni: 300
-    vxlanport: 4789
+    vxlanPort: 4789
 `,
 			},
 			expectedCRs: expectedResources{

--- a/internal/controller/routerconfiguration/static_configuration_reader_test.go
+++ b/internal/controller/routerconfiguration/static_configuration_reader_test.go
@@ -24,7 +24,7 @@ func TestReadStaticConfigs_L2VNI_DefaultVXLanPort(t *testing.T) {
 	writeYAMLFile(t, dir, "openpe_l2vni.yaml", `
 underlays:
   - asn: 64515
-    routeridcidr: "10.0.0.0/24"
+    routerIDCIDR: "10.0.0.0/24"
     interfaces:
       - type: NetworkDevice
         networkDevice:
@@ -37,7 +37,7 @@ underlays:
       - "100.65.0.0/24"
 l2vnis:
   - vni: 300
-    hostmaster:
+    hostMaster:
       type: linux-bridge
       linuxBridge:
         lifecycle: External
@@ -62,7 +62,7 @@ func TestReadStaticConfigs_L3VNI_DefaultVXLanPort(t *testing.T) {
 	writeYAMLFile(t, dir, "openpe_l3vni.yaml", `
 underlays:
   - asn: 64515
-    routeridcidr: "10.0.0.0/24"
+    routerIDCIDR: "10.0.0.0/24"
     interfaces:
       - type: NetworkDevice
         networkDevice:
@@ -141,7 +141,7 @@ l3vnis:
     vni: 100
 l2vnis:
   - vni: 300
-    hostmaster:
+    hostMaster:
       type: linux-bridge
       linuxBridge:
         lifecycle: External
@@ -169,7 +169,7 @@ func TestReadStaticConfigs_ExplicitVXLanPort(t *testing.T) {
 	writeYAMLFile(t, dir, "openpe_explicit.yaml", `
 underlays:
   - asn: 64515
-    routeridcidr: "10.0.0.0/24"
+    routerIDCIDR: "10.0.0.0/24"
     interfaces:
       - type: NetworkDevice
         networkDevice:
@@ -182,8 +182,8 @@ underlays:
       - "100.65.0.0/24"
 l2vnis:
   - vni: 300
-    vxlanport: 5000
-    hostmaster:
+    vxlanPort: 5000
+    hostMaster:
       type: linux-bridge
       linuxBridge:
         lifecycle: External
@@ -205,7 +205,7 @@ func TestReadStaticConfigs_ExplicitRouterIDCIDR(t *testing.T) {
 	writeYAMLFile(t, dir, "openpe_explicit.yaml", `
 underlays:
   - asn: 64515
-    routeridcidr: "172.16.0.0/16"
+    routerIDCIDR: "172.16.0.0/16"
     interfaces:
       - type: NetworkDevice
         networkDevice:
@@ -249,7 +249,7 @@ underlays:
 	writeYAMLFile(t, dir, "openpe_l2vni.yaml", `
 l2vnis:
   - vni: 300
-    hostmaster:
+    hostMaster:
       type: linux-bridge
       linuxBridge:
         lifecycle: External
@@ -520,7 +520,7 @@ func TestReadStaticConfigs_CELValidation_L2VNIBridgeNameAndLifecycle(t *testing.
 	writeYAMLFile(t, dir, "openpe_invalid.yaml", `
 underlays:
   - asn: 64515
-    routeridcidr: "10.0.0.0/24"
+    routerIDCIDR: "10.0.0.0/24"
     interfaces:
       - type: NetworkDevice
         networkDevice:
@@ -533,7 +533,7 @@ underlays:
       - "100.65.0.0/24"
 l2vnis:
   - vni: 300
-    hostmaster:
+    hostMaster:
       type: linux-bridge
       linuxBridge:
         name: "mybr"
@@ -553,7 +553,7 @@ func TestReadStaticConfigsCELValidationSRv6(t *testing.T) {
 	validSRv6Underlay := `
 underlays:
   - asn: 64514
-    routeridcidr: "10.0.0.0/24"
+    routerIDCIDR: "10.0.0.0/24"
     interfaces:
       - type: NetworkDevice
         networkDevice:
@@ -604,7 +604,7 @@ underlays:
 			yaml: `
 underlays:
   - asn: 64514
-    routeridcidr: "10.0.0.0/24"
+    routerIDCIDR: "10.0.0.0/24"
     interfaces:
       - type: NetworkDevice
         networkDevice:
@@ -629,7 +629,7 @@ underlays:
 			yaml: `
 underlays:
   - asn: 64514
-    routeridcidr: "10.0.0.0/24"
+    routerIDCIDR: "10.0.0.0/24"
     interfaces:
       - type: NetworkDevice
         networkDevice:
@@ -702,7 +702,7 @@ underlays:
       - "100.65.0.0/24"
 l2vnis:
   - vni: 300
-    hostmaster:
+    hostMaster:
       type: linux-bridge
       linuxBridge:
         name: "mybr"
@@ -732,7 +732,7 @@ func TestReadStaticConfigs_MultipleErrors(t *testing.T) {
 	dir := t.TempDir()
 	writeYAMLFile(t, dir, "openpe_multi_invalid.yaml", `
 underlays:
-  - routeridcidr: "10.0.0.0/24"
+  - routerIDCIDR: "10.0.0.0/24"
     interfaces:
       - type: NetworkDevice
         networkDevice:
@@ -745,7 +745,7 @@ underlays:
       - "100.65.0.0/24"
 l2vnis:
   - vni: 300
-    hostmaster:
+    hostMaster:
       type: linux-bridge
       linuxBridge:
         name: "mybr"
@@ -772,7 +772,7 @@ func TestReadStaticConfigs_AtomicRejection(t *testing.T) {
 	writeYAMLFile(t, dir, "openpe_atomic.yaml", `
 underlays:
   - asn: 64515
-    routeridcidr: "10.0.0.0/24"
+    routerIDCIDR: "10.0.0.0/24"
     interfaces:
       - type: NetworkDevice
         networkDevice:
@@ -785,7 +785,7 @@ underlays:
       - "100.65.0.0/24"
 l2vnis:
   - vni: 300
-    hostmaster:
+    hostMaster:
       type: linux-bridge
       linuxBridge:
         name: "mybr"

--- a/internal/crdschema/crdschema_test.go
+++ b/internal/crdschema/crdschema_test.go
@@ -56,24 +56,24 @@ func TestApplyDefaults(t *testing.T) {
 		expected any
 	}{
 		{
-			name:     "Underlay routeridcidr default",
+			name:     "Underlay routerIDCIDR default",
 			gvk:      underlayGVK,
 			obj:      newUnstructured("Underlay", map[string]any{"asn": int64(65000)}),
-			field:    "spec.routeridcidr",
+			field:    "spec.routerIDCIDR",
 			expected: "10.0.0.0/24",
 		},
 		{
 			name:     "L2VNI vxlanport default",
 			gvk:      l2vniGVK,
 			obj:      newUnstructured("L2VNI", map[string]any{}),
-			field:    "spec.vxlanport",
+			field:    "spec.vxlanPort",
 			expected: int64(4789),
 		},
 		{
 			name:     "L3VNI vxlanport default",
 			gvk:      l3vniGVK,
 			obj:      newUnstructured("L3VNI", map[string]any{"vrf": "testvrf"}),
-			field:    "spec.vxlanport",
+			field:    "spec.vxlanPort",
 			expected: int64(4789),
 		},
 		{
@@ -147,24 +147,24 @@ func TestApplyDefaultsPreservation(t *testing.T) {
 		expected any
 	}{
 		{
-			name:     "Underlay explicit routeridcidr preserved",
+			name:     "Underlay explicit routerIDCIDR preserved",
 			gvk:      underlayGVK,
-			obj:      newUnstructured("Underlay", map[string]any{"asn": int64(65000), "routeridcidr": "192.168.0.0/16"}),
-			field:    "spec.routeridcidr",
+			obj:      newUnstructured("Underlay", map[string]any{"asn": int64(65000), "routerIDCIDR": "192.168.0.0/16"}),
+			field:    "spec.routerIDCIDR",
 			expected: "192.168.0.0/16",
 		},
 		{
 			name:     "L2VNI explicit vxlanport preserved",
 			gvk:      l2vniGVK,
-			obj:      newUnstructured("L2VNI", map[string]any{"vxlanport": int64(5000)}),
-			field:    "spec.vxlanport",
+			obj:      newUnstructured("L2VNI", map[string]any{"vxlanPort": int64(5000)}),
+			field:    "spec.vxlanPort",
 			expected: int64(5000),
 		},
 		{
 			name:     "L3VNI explicit vxlanport preserved",
 			gvk:      l3vniGVK,
-			obj:      newUnstructured("L3VNI", map[string]any{"vrf": "testvrf", "vxlanport": int64(9999)}),
-			field:    "spec.vxlanport",
+			obj:      newUnstructured("L3VNI", map[string]any{"vrf": "testvrf", "vxlanPort": int64(9999)}),
+			field:    "spec.vxlanPort",
 			expected: int64(9999),
 		},
 		{
@@ -178,12 +178,12 @@ func TestApplyDefaultsPreservation(t *testing.T) {
 			name: "L2VNI linuxBridge lifecycle preserved",
 			gvk:  l2vniGVK,
 			obj: newUnstructured("L2VNI", map[string]any{
-				"hostmaster": map[string]any{
+				"hostMaster": map[string]any{
 					"type":        "linux-bridge",
 					"linuxBridge": map[string]any{"lifecycle": "Managed"},
 				},
 			}),
-			field:    "spec.hostmaster.linuxBridge.lifecycle",
+			field:    "spec.hostMaster.linuxBridge.lifecycle",
 			expected: "Managed",
 		},
 	}
@@ -209,7 +209,7 @@ func TestApplyDefaultsPreservation(t *testing.T) {
 func TestApplyDefaultsCombinedAndEdgeCases(t *testing.T) {
 	t.Run("multiple defaults applied at once for L2VNI", func(t *testing.T) {
 		obj := newUnstructured("L2VNI", map[string]any{
-			"hostmaster": map[string]any{
+			"hostMaster": map[string]any{
 				"type":        "linux-bridge",
 				"linuxBridge": map[string]any{"lifecycle": "External", "name": "br0"},
 			},
@@ -218,20 +218,20 @@ func TestApplyDefaultsCombinedAndEdgeCases(t *testing.T) {
 			t.Fatalf("ApplyDefaults() returned error: %v", err)
 		}
 
-		val, ok := getNestedField(obj, "spec.vxlanport")
+		val, ok := getNestedField(obj, "spec.vxlanPort")
 		if !ok {
-			t.Fatal("spec.vxlanport not found")
+			t.Fatal("spec.vxlanPort not found")
 		}
 		if val != int64(4789) {
-			t.Errorf("spec.vxlanport = %v, want %v", val, int64(4789))
+			t.Errorf("spec.vxlanPort = %v, want %v", val, int64(4789))
 		}
 
-		val, ok = getNestedField(obj, "spec.hostmaster.linuxBridge.lifecycle")
+		val, ok = getNestedField(obj, "spec.hostMaster.linuxBridge.lifecycle")
 		if !ok {
-			t.Fatal("spec.hostmaster.linuxBridge.lifecycle not found")
+			t.Fatal("spec.hostMaster.linuxBridge.lifecycle not found")
 		}
 		if val != "External" {
-			t.Errorf("spec.hostmaster.linuxBridge.lifecycle = %v, want External", val)
+			t.Errorf("spec.hostMaster.linuxBridge.lifecycle = %v, want External", val)
 		}
 	})
 
@@ -241,12 +241,12 @@ func TestApplyDefaultsCombinedAndEdgeCases(t *testing.T) {
 			t.Fatalf("ApplyDefaults() returned error: %v", err)
 		}
 
-		val, ok := getNestedField(obj, "spec.routeridcidr")
+		val, ok := getNestedField(obj, "spec.routerIDCIDR")
 		if !ok {
-			t.Fatal("spec.routeridcidr not found")
+			t.Fatal("spec.routerIDCIDR not found")
 		}
 		if val != "10.0.0.0/24" {
-			t.Errorf("spec.routeridcidr = %v, want 10.0.0.0/24", val)
+			t.Errorf("spec.routerIDCIDR = %v, want 10.0.0.0/24", val)
 		}
 	})
 
@@ -257,13 +257,13 @@ func TestApplyDefaultsCombinedAndEdgeCases(t *testing.T) {
 			t.Fatalf("first ApplyDefaults() returned error: %v", err)
 		}
 
-		firstVal, _ := getNestedField(obj, "spec.vxlanport")
+		firstVal, _ := getNestedField(obj, "spec.vxlanPort")
 
 		if err := ApplyDefaults(obj, l2vniGVK); err != nil {
 			t.Fatalf("second ApplyDefaults() returned error: %v", err)
 		}
 
-		secondVal, _ := getNestedField(obj, "spec.vxlanport")
+		secondVal, _ := getNestedField(obj, "spec.vxlanPort")
 		if firstVal != secondVal {
 			t.Errorf("idempotency broken: first=%v, second=%v", firstVal, secondVal)
 		}
@@ -342,7 +342,7 @@ func TestValidateSuccessful(t *testing.T) {
 					map[string]any{
 						"address": "192.168.1.1",
 						"asn":     int64(65001),
-						"hostasn": int64(65002),
+						"hostASN": int64(65002),
 					},
 				},
 			}),
@@ -387,7 +387,7 @@ func TestValidateSuccessful(t *testing.T) {
 			gvk:  l2vniGVK,
 			obj: newUnstructured("L2VNI", map[string]any{
 				"vni": int64(100),
-				"hostmaster": map[string]any{
+				"hostMaster": map[string]any{
 					"type": "linux-bridge",
 					"linuxBridge": map[string]any{
 						"name":      "br0",
@@ -401,7 +401,7 @@ func TestValidateSuccessful(t *testing.T) {
 			gvk:  l2vniGVK,
 			obj: newUnstructured("L2VNI", map[string]any{
 				"vni": int64(100),
-				"hostmaster": map[string]any{
+				"hostMaster": map[string]any{
 					"type": "linux-bridge",
 					"linuxBridge": map[string]any{
 						"lifecycle": "Managed",
@@ -414,7 +414,7 @@ func TestValidateSuccessful(t *testing.T) {
 			gvk:  l2vniGVK,
 			obj: newUnstructured("L2VNI", map[string]any{
 				"vni": int64(100),
-				"hostmaster": map[string]any{
+				"hostMaster": map[string]any{
 					"type": "linux-bridge",
 					"linuxBridge": map[string]any{
 						"lifecycle": "Managed",
@@ -436,10 +436,10 @@ func TestValidateSuccessful(t *testing.T) {
 			obj: newUnstructured("L3VNI", map[string]any{
 				"vrf": "testvrf",
 				"vni": int64(200),
-				"hostsession": map[string]any{
+				"hostSession": map[string]any{
 					"asn":     int64(65000),
-					"hostasn": int64(65001),
-					"localcidr": map[string]any{
+					"hostASN": int64(65001),
+					"localCIDR": map[string]any{
 						"ipv4": "10.0.0.0/30",
 					},
 				},
@@ -449,10 +449,10 @@ func TestValidateSuccessful(t *testing.T) {
 			name: "valid L3Passthrough",
 			gvk:  l3passthroughGVK,
 			obj: newUnstructured("L3Passthrough", map[string]any{
-				"hostsession": map[string]any{
+				"hostSession": map[string]any{
 					"asn":     int64(65000),
-					"hostasn": int64(65001),
-					"localcidr": map[string]any{
+					"hostASN": int64(65001),
+					"localCIDR": map[string]any{
 						"ipv4": "10.0.0.0/30",
 					},
 				},
@@ -496,7 +496,7 @@ func TestValidateFailure(t *testing.T) {
 			name: "LinuxBridge with both name and Managed lifecycle",
 			gvk:  l2vniGVK,
 			obj: newUnstructured("L2VNI", map[string]any{
-				"hostmaster": map[string]any{
+				"hostMaster": map[string]any{
 					"type": "linux-bridge",
 					"linuxBridge": map[string]any{
 						"name":      "br0",
@@ -510,7 +510,7 @@ func TestValidateFailure(t *testing.T) {
 			name: "LinuxBridge with External lifecycle and no name",
 			gvk:  l2vniGVK,
 			obj: newUnstructured("L2VNI", map[string]any{
-				"hostmaster": map[string]any{
+				"hostMaster": map[string]any{
 					"type": "linux-bridge",
 					"linuxBridge": map[string]any{
 						"lifecycle": "External",
@@ -523,7 +523,7 @@ func TestValidateFailure(t *testing.T) {
 			name: "OVSBridge with both name and Managed lifecycle",
 			gvk:  l2vniGVK,
 			obj: newUnstructured("L2VNI", map[string]any{
-				"hostmaster": map[string]any{
+				"hostMaster": map[string]any{
 					"type": "ovs-bridge",
 					"ovsBridge": map[string]any{
 						"name":      "br0",
@@ -537,7 +537,7 @@ func TestValidateFailure(t *testing.T) {
 			name: "HostMaster type linux-bridge with ovsBridge field",
 			gvk:  l2vniGVK,
 			obj: newUnstructured("L2VNI", map[string]any{
-				"hostmaster": map[string]any{
+				"hostMaster": map[string]any{
 					"type": "linux-bridge",
 					"ovsBridge": map[string]any{
 						"lifecycle": "Managed",
@@ -550,7 +550,7 @@ func TestValidateFailure(t *testing.T) {
 			name: "HostMaster type ovs-bridge with linuxBridge field",
 			gvk:  l2vniGVK,
 			obj: newUnstructured("L2VNI", map[string]any{
-				"hostmaster": map[string]any{
+				"hostMaster": map[string]any{
 					"type": "ovs-bridge",
 					"linuxBridge": map[string]any{
 						"lifecycle": "Managed",
@@ -755,10 +755,10 @@ func TestValidateOldSelfFiltering(t *testing.T) {
 			gvk:  l3vniGVK,
 			obj: newUnstructured("L3VNI", map[string]any{
 				"vrf": "testvrf",
-				"hostsession": map[string]any{
+				"hostSession": map[string]any{
 					"asn":     int64(65000),
-					"hostasn": int64(65001),
-					"localcidr": map[string]any{
+					"hostASN": int64(65001),
+					"localCIDR": map[string]any{
 						"ipv4": "10.0.0.0/30",
 					},
 				},
@@ -769,10 +769,10 @@ func TestValidateOldSelfFiltering(t *testing.T) {
 			name: "L3Passthrough with hostsession localcidr does not trigger oldSelf error",
 			gvk:  l3passthroughGVK,
 			obj: newUnstructured("L3Passthrough", map[string]any{
-				"hostsession": map[string]any{
+				"hostSession": map[string]any{
 					"asn":     int64(65000),
-					"hostasn": int64(65001),
-					"localcidr": map[string]any{
+					"hostASN": int64(65001),
+					"localCIDR": map[string]any{
 						"ipv4": "10.0.0.0/30",
 					},
 				},
@@ -800,7 +800,7 @@ func TestValidateOldSelfFiltering(t *testing.T) {
 func TestValidateMultipleErrors(t *testing.T) {
 	t.Run("LinuxBridge both name and Managed lifecycle plus type mismatch", func(t *testing.T) {
 		obj := newUnstructured("L2VNI", map[string]any{
-			"hostmaster": map[string]any{
+			"hostMaster": map[string]any{
 				"type": "ovs-bridge",
 				"linuxBridge": map[string]any{
 					"name":      "br0",

--- a/internal/hostnetwork/vni.go
+++ b/internal/hostnetwork/vni.go
@@ -29,7 +29,7 @@ type VNIParams struct {
 	TargetNS  string `json:"targetns"`
 	VTEPIP    string `json:"vtepip"`
 	VNI       int32  `json:"vni"`
-	VXLanPort *int32 `json:"vxlanport,omitempty"`
+	VXLanPort *int32 `json:"vxlanPort,omitempty"`
 }
 
 type L3VNIParams struct {
@@ -54,7 +54,7 @@ type L2VNIParams struct {
 	VNIParams    `json:",inline"`
 	Name         string      `json:"name"`
 	L2GatewayIPs []string    `json:"l2gatewayips"`
-	HostMaster   *HostMaster `json:"hostmaster"`
+	HostMaster   *HostMaster `json:"hostMaster"`
 }
 
 type HostMaster struct {

--- a/internal/staticconfiguration/reader_test.go
+++ b/internal/staticconfiguration/reader_test.go
@@ -131,7 +131,7 @@ func TestReadRouterConfigs(t *testing.T) {
 
 	t.Run("single file", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		writeTestFile(t, tmpDir, "openpe_underlay.yaml", "underlays:\n  - asn: 64515\n    routeridcidr: \"10.0.0.0/24\"\n")
+		writeTestFile(t, tmpDir, "openpe_underlay.yaml", "underlays:\n  - asn: 64515\n    routerIDCIDR: \"10.0.0.0/24\"\n")
 
 		configs, err := ReadRouterConfigs(tmpDir)
 		if err != nil {
@@ -147,7 +147,7 @@ func TestReadRouterConfigs(t *testing.T) {
 
 	t.Run("multiple files", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		writeTestFile(t, tmpDir, "openpe_underlay.yaml", "underlays:\n  - asn: 64515\n    routeridcidr: \"10.0.0.0/24\"\n")
+		writeTestFile(t, tmpDir, "openpe_underlay.yaml", "underlays:\n  - asn: 64515\n    routerIDCIDR: \"10.0.0.0/24\"\n")
 		writeTestFile(t, tmpDir, "openpe_l3vni.yaml", "l3vnis:\n  - vrf: \"vrf-test\"\n    vni: 1000\n")
 		writeTestFile(t, tmpDir, "other.yaml", "test: value\n")
 

--- a/internal/staticconfiguration/testdata/openpe_bgppassthrough.yaml
+++ b/internal/staticconfiguration/testdata/openpe_bgppassthrough.yaml
@@ -1,5 +1,5 @@
 bgppassthrough:
-  hostsession:
+  hostSession:
     asn: 64514
     hostASN: 64517
     localCIDR:

--- a/internal/staticconfiguration/testdata/openpe_l2vni.yaml
+++ b/internal/staticconfiguration/testdata/openpe_l2vni.yaml
@@ -1,24 +1,24 @@
 l2vnis:
   - name: l2vni-storage
     vni: 300
-    vxlanport: 4789
+    vxlanPort: 4789
     routingDomain:
       type: L3VNI
       l3vni:
         name: l3vni-red
-    hostmaster:
+    hostMaster:
       type: linux-bridge
       linuxBridge:
         lifecycle: External
         name: br-storage
   - name: l2vni-management
     vni: 400
-    vxlanport: 4789
+    vxlanPort: 4789
     routingDomain:
       type: L3VNI
       l3vni:
         name: l3vni-blue
-    hostmaster:
+    hostMaster:
       type: ovs-bridge
       ovsBridge:
         lifecycle: External

--- a/internal/staticconfiguration/testdata/openpe_l3vpn.yaml
+++ b/internal/staticconfiguration/testdata/openpe_l3vpn.yaml
@@ -1,9 +1,9 @@
 l3vpns:
   - name: red
-    hostsession:
+    hostSession:
       asn: 64514
-      hostasn: 64515
-      localcidr:
+      hostASN: 64515
+      localCIDR:
         ipv4: 192.169.10.0/24
     vrf: red
     rdAssignedNumber: 100
@@ -18,7 +18,7 @@ l2vnis:
       type: L3VPN
       l3vpn:
         name: red
-    hostmaster:
+    hostMaster:
       type: linux-bridge
       linuxBridge:
         lifecycle: Managed

--- a/operator/bundle/manifests/network.openperouter.io_l2vnis.yaml
+++ b/operator/bundle/manifests/network.openperouter.io_l2vnis.yaml
@@ -57,9 +57,9 @@ spec:
                 x-kubernetes-validations:
                 - message: GatewayIPs cannot be changed
                   rule: self == oldSelf
-              hostmaster:
+              hostMaster:
                 description: |-
-                  hostmaster is the interface on the host the veth should be attached to.
+                  hostMaster is the interface on the host the veth should be attached to.
                   If not set, the host veth will not be attached to any interface and it must be
                   attached manually (or by some other means). This is useful if another controller
                   is leveraging the host interface for the VNI.
@@ -247,9 +247,9 @@ spec:
                 maximum: 16777215
                 minimum: 1
                 type: integer
-              vxlanport:
+              vxlanPort:
                 default: 4789
-                description: vxlanport is the port to be used for VXLan encapsulation.
+                description: vxlanPort is the port to be used for VXLan encapsulation.
                 format: int32
                 type: integer
             required:

--- a/operator/bundle/manifests/network.openperouter.io_l3passthroughs.yaml
+++ b/operator/bundle/manifests/network.openperouter.io_l3passthroughs.yaml
@@ -41,8 +41,8 @@ spec:
           spec:
             description: spec defines the desired state of L3Passthrough.
             properties:
-              hostsession:
-                description: hostsession is the configuration for the host session.
+              hostSession:
+                description: hostSession is the configuration for the host session.
                 properties:
                   asn:
                     description: |-
@@ -52,25 +52,25 @@ spec:
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hostasn:
+                  hostASN:
                     description: |-
-                      hostasn is the expected AS number for a BGP speaking component running in
+                      hostASN is the expected AS number for a BGP speaking component running in
                       the default network namespace. Either HostASN or HostType must be set.
                     format: int64
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hosttype:
+                  hostType:
                     description: |-
-                      hosttype is the AS type of the BGP speaking component running in the
+                      hostType is the AS type of the BGP speaking component running in the
                       default network namespace. Either HostASN or HostType must be set.
                     enum:
                     - external
                     - internal
                     type: string
-                  localcidr:
+                  localCIDR:
                     description: |-
-                      localcidr is the CIDR configuration for the veth pair
+                      localCIDR is the CIDR configuration for the veth pair
                       to connect with the default namespace. The interface under
                       the PERouter side is going to use the first IP of the cidr on all the nodes.
                       At least one of IPv4 or IPv6 must be provided.
@@ -95,13 +95,13 @@ spec:
                       rule: has(self.ipv4) || has(self.ipv6)
                 required:
                 - asn
-                - localcidr
+                - localCIDR
                 type: object
                 x-kubernetes-validations:
                 - message: either HostASN or HostType must be set
-                  rule: has(self.hostasn) || has(self.hosttype)
+                  rule: has(self.hostASN) || has(self.hostType)
                 - message: HostASN and HostType cannot be set together
-                  rule: '!has(self.hostasn) || !has(self.hosttype)'
+                  rule: '!has(self.hostASN) || !has(self.hostType)'
               nodeSelector:
                 description: |-
                   nodeSelector specifies which nodes this L3Passthrough applies to.
@@ -152,7 +152,7 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
             required:
-            - hostsession
+            - hostSession
             type: object
           status:
             description: status defines the observed state of L3Passthrough.

--- a/operator/bundle/manifests/network.openperouter.io_l3vnis.yaml
+++ b/operator/bundle/manifests/network.openperouter.io_l3vnis.yaml
@@ -53,8 +53,8 @@ spec:
                 maxItems: 100
                 type: array
                 x-kubernetes-list-type: atomic
-              hostsession:
-                description: hostsession is the configuration for the host session.
+              hostSession:
+                description: hostSession is the configuration for the host session.
                 properties:
                   asn:
                     description: |-
@@ -64,25 +64,25 @@ spec:
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hostasn:
+                  hostASN:
                     description: |-
-                      hostasn is the expected AS number for a BGP speaking component running in
+                      hostASN is the expected AS number for a BGP speaking component running in
                       the default network namespace. Either HostASN or HostType must be set.
                     format: int64
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hosttype:
+                  hostType:
                     description: |-
-                      hosttype is the AS type of the BGP speaking component running in the
+                      hostType is the AS type of the BGP speaking component running in the
                       default network namespace. Either HostASN or HostType must be set.
                     enum:
                     - external
                     - internal
                     type: string
-                  localcidr:
+                  localCIDR:
                     description: |-
-                      localcidr is the CIDR configuration for the veth pair
+                      localCIDR is the CIDR configuration for the veth pair
                       to connect with the default namespace. The interface under
                       the PERouter side is going to use the first IP of the cidr on all the nodes.
                       At least one of IPv4 or IPv6 must be provided.
@@ -107,13 +107,13 @@ spec:
                       rule: has(self.ipv4) || has(self.ipv6)
                 required:
                 - asn
-                - localcidr
+                - localCIDR
                 type: object
                 x-kubernetes-validations:
                 - message: either HostASN or HostType must be set
-                  rule: has(self.hostasn) || has(self.hosttype)
+                  rule: has(self.hostASN) || has(self.hostType)
                 - message: HostASN and HostType cannot be set together
-                  rule: '!has(self.hostasn) || !has(self.hosttype)'
+                  rule: '!has(self.hostASN) || !has(self.hostType)'
               importRTs:
                 description: |-
                   importRTs are the Route Targets to be used for importing routes.
@@ -197,9 +197,9 @@ spec:
                 minLength: 1
                 pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
                 type: string
-              vxlanport:
+              vxlanPort:
                 default: 4789
-                description: vxlanport is the port to be used for VXLan encapsulation.
+                description: vxlanPort is the port to be used for VXLan encapsulation.
                 format: int32
                 type: integer
             required:
@@ -208,8 +208,8 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: hostASN must be different from asn
-              rule: '!has(self.hostsession) || !has(self.hostsession.hostasn) || self.hostsession.hostasn
-                != self.hostsession.asn'
+              rule: '!has(self.hostSession) || !has(self.hostSession.hostASN) || self.hostSession.hostASN
+                != self.hostSession.asn'
           status:
             description: status defines the observed state of L3VNI.
             type: object

--- a/operator/bundle/manifests/network.openperouter.io_l3vpns.yaml
+++ b/operator/bundle/manifests/network.openperouter.io_l3vpns.yaml
@@ -52,8 +52,8 @@ spec:
                 maxItems: 100
                 type: array
                 x-kubernetes-list-type: atomic
-              hostsession:
-                description: hostsession is the configuration for the host session.
+              hostSession:
+                description: hostSession is the configuration for the host session.
                 properties:
                   asn:
                     description: |-
@@ -63,25 +63,25 @@ spec:
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hostasn:
+                  hostASN:
                     description: |-
-                      hostasn is the expected AS number for a BGP speaking component running in
+                      hostASN is the expected AS number for a BGP speaking component running in
                       the default network namespace. Either HostASN or HostType must be set.
                     format: int64
                     maximum: 4294967295
                     minimum: 1
                     type: integer
-                  hosttype:
+                  hostType:
                     description: |-
-                      hosttype is the AS type of the BGP speaking component running in the
+                      hostType is the AS type of the BGP speaking component running in the
                       default network namespace. Either HostASN or HostType must be set.
                     enum:
                     - external
                     - internal
                     type: string
-                  localcidr:
+                  localCIDR:
                     description: |-
-                      localcidr is the CIDR configuration for the veth pair
+                      localCIDR is the CIDR configuration for the veth pair
                       to connect with the default namespace. The interface under
                       the PERouter side is going to use the first IP of the cidr on all the nodes.
                       At least one of IPv4 or IPv6 must be provided.
@@ -106,13 +106,13 @@ spec:
                       rule: has(self.ipv4) || has(self.ipv6)
                 required:
                 - asn
-                - localcidr
+                - localCIDR
                 type: object
                 x-kubernetes-validations:
                 - message: either HostASN or HostType must be set
-                  rule: has(self.hostasn) || has(self.hosttype)
+                  rule: has(self.hostASN) || has(self.hostType)
                 - message: HostASN and HostType cannot be set together
-                  rule: '!has(self.hostasn) || !has(self.hosttype)'
+                  rule: '!has(self.hostASN) || !has(self.hostType)'
               importRTs:
                 description: |-
                   importRTs are the Route Targets to be used for importing routes.
@@ -198,7 +198,7 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: hostASN must be different from asn
-              rule: '!has(self.hostsession) || self.hostsession.hostasn != self.hostsession.asn'
+              rule: '!has(self.hostSession) || self.hostSession.hostASN != self.hostSession.asn'
           status:
             description: status defines the observed state of L3VPN.
             type: object

--- a/operator/bundle/manifests/network.openperouter.io_underlays.yaml
+++ b/operator/bundle/manifests/network.openperouter.io_underlays.yaml
@@ -578,9 +578,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
-              routeridcidr:
+              routerIDCIDR:
                 default: 10.0.0.0/24
-                description: routeridcidr is the ipv4 cidr to be used to assign a
+                description: routerIDCIDR is the ipv4 cidr to be used to assign a
                   different routerID on each node.
                 type: string
               srv6:

--- a/website/content/docs/api-reference.md
+++ b/website/content/docs/api-reference.md
@@ -249,9 +249,9 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `asn` _integer_ | asn is the local AS number to use to establish a BGP session with<br />the default namespace. |  | Maximum: 4.294967295e+09 <br />Minimum: 1 <br />Required: \{\} <br /> |
-| `hostasn` _integer_ | hostasn is the expected AS number for a BGP speaking component running in<br />the default network namespace. Either HostASN or HostType must be set. |  | Maximum: 4.294967295e+09 <br />Minimum: 1 <br />Optional: \{\} <br /> |
-| `hosttype` _string_ | hosttype is the AS type of the BGP speaking component running in the<br />default network namespace. Either HostASN or HostType must be set. |  | Enum: [external internal] <br />Optional: \{\} <br /> |
-| `localcidr` _[LocalCIDRConfig](#localcidrconfig)_ | localcidr is the CIDR configuration for the veth pair<br />to connect with the default namespace. The interface under<br />the PERouter side is going to use the first IP of the cidr on all the nodes.<br />At least one of IPv4 or IPv6 must be provided. |  | Required: \{\} <br /> |
+| `hostASN` _integer_ | hostASN is the expected AS number for a BGP speaking component running in<br />the default network namespace. Either HostASN or HostType must be set. |  | Maximum: 4.294967295e+09 <br />Minimum: 1 <br />Optional: \{\} <br /> |
+| `hostType` _string_ | hostType is the AS type of the BGP speaking component running in the<br />default network namespace. Either HostASN or HostType must be set. |  | Enum: [external internal] <br />Optional: \{\} <br /> |
+| `localCIDR` _[LocalCIDRConfig](#localCIDRconfig)_ | localCIDR is the CIDR configuration for the veth pair<br />to connect with the default namespace. The interface under<br />the PERouter side is going to use the first IP of the cidr on all the nodes.<br />At least one of IPv4 or IPv6 must be provided. |  | Required: \{\} <br /> |
 
 
 #### IPFamily
@@ -395,9 +395,9 @@ _Appears in:_
 | `nodeSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#labelselector-v1-meta)_ | nodeSelector specifies which nodes this L2VNI applies to.<br />If empty or not specified, applies to all nodes.<br />Multiple L2VNIs can match the same node. |  | Optional: \{\} <br /> |
 | `routingDomain` _[RoutingDomain](#routingdomain)_ | routingDomain optionally attaches this L2VNI to a routing domain<br />provided by a backing resource (L3VNI or L3VPN). When omitted, the<br />L2VNI is a disconnected overlay (east-west L2 only, no VRF, no<br />gateway). |  | Optional: \{\} <br /> |
 | `vni` _integer_ | vni is the VXLan VNI to be used |  | Maximum: 1.6777215e+07 <br />Minimum: 1 <br />Required: \{\} <br /> |
-| `vxlanport` _integer_ | vxlanport is the port to be used for VXLan encapsulation. | 4789 | Optional: \{\} <br /> |
+| `vxlanPort` _integer_ | vxlanPort is the port to be used for VXLan encapsulation. | 4789 | Optional: \{\} <br /> |
 | `underlayAddressFamily` _string_ | underlayAddressFamily selects which VTEP address family to use for this VNI's<br />VXLAN interface. When omitted, defaults to the available family in the underlay<br />(IPv4 preferred in dual-stack). |  | Enum: [ipv4 ipv6] <br />Optional: \{\} <br /> |
-| `hostmaster` _[HostMaster](#hostmaster)_ | hostmaster is the interface on the host the veth should be attached to.<br />If not set, the host veth will not be attached to any interface and it must be<br />attached manually (or by some other means). This is useful if another controller<br />is leveraging the host interface for the VNI. |  | Optional: \{\} <br /> |
+| `hostMaster` _[HostMaster](#hostMaster)_ | hostMaster is the interface on the host the veth should be attached to.<br />If not set, the host veth will not be attached to any interface and it must be<br />attached manually (or by some other means). This is useful if another controller<br />is leveraging the host interface for the VNI. |  | Optional: \{\} <br /> |
 | `gatewayIPs` _string array_ | gatewayIPs is a list of IP addresses in CIDR notation for the<br />distributed anycast gateway on this L2 segment's bridge<br />(Integrated Routing and Bridging interface). It is a property of<br />the L2 segment itself, so it lives on the L2VNI rather than<br />inside the routing-domain reference.<br />Maximum of 2 addresses are allowed. If 2 addresses are provided, one must be IPv4 and one must be IPv6. |  | MaxItems: 2 <br />Optional: \{\} <br /> |
 
 
@@ -448,7 +448,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `nodeSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#labelselector-v1-meta)_ | nodeSelector specifies which nodes this L3Passthrough applies to.<br />If empty or not specified, applies to all nodes.<br />Multiple L3Passthrough with overlapping node selectors will be rejected. |  | Optional: \{\} <br /> |
-| `hostsession` _[HostSession](#hostsession)_ | hostsession is the configuration for the host session. |  | Required: \{\} <br /> |
+| `hostSession` _[HostSession](#hostSession)_ | hostSession is the configuration for the host session. |  | Required: \{\} <br /> |
 
 
 #### L3PassthroughStatus
@@ -516,9 +516,9 @@ _Appears in:_
 | `nodeSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#labelselector-v1-meta)_ | nodeSelector specifies which nodes this L3VNI applies to.<br />If empty or not specified, applies to all nodes.<br />Multiple L3VNIs can match the same node. |  | Optional: \{\} <br /> |
 | `vrf` _string_ | vrf is the name of the linux VRF to be used inside the PERouter namespace. |  | MaxLength: 15 <br />MinLength: 1 <br />Pattern: `^[a-zA-Z][a-zA-Z0-9_-]*$` <br />Required: \{\} <br /> |
 | `vni` _integer_ | vni is the VXLan VNI to be used |  | Maximum: 1.6777215e+07 <br />Minimum: 1 <br />Required: \{\} <br /> |
-| `vxlanport` _integer_ | vxlanport is the port to be used for VXLan encapsulation. | 4789 | Optional: \{\} <br /> |
+| `vxlanPort` _integer_ | vxlanPort is the port to be used for VXLan encapsulation. | 4789 | Optional: \{\} <br /> |
 | `underlayAddressFamily` _string_ | underlayAddressFamily selects which VTEP address family to use for this VNI's<br />VXLAN interface. When omitted, defaults to the available family in the underlay<br />(IPv4 preferred in dual-stack). |  | Enum: [ipv4 ipv6] <br />Optional: \{\} <br /> |
-| `hostsession` _[HostSession](#hostsession)_ | hostsession is the configuration for the host session. |  | Optional: \{\} <br /> |
+| `hostSession` _[HostSession](#hostSession)_ | hostSession is the configuration for the host session. |  | Optional: \{\} <br /> |
 | `exportRTs` _[RouteTarget](#routetarget) array_ | exportRTs are the Route Targets to be used for exporting routes.<br />RouteTarget defines a BGP Extended Community for route filtering. |  | MaxItems: 100 <br />MaxLength: 21 <br />Optional: \{\} <br /> |
 | `importRTs` _[RouteTarget](#routetarget) array_ | importRTs are the Route Targets to be used for importing routes.<br />RouteTarget defines a BGP Extended Community for route filtering. |  | MaxItems: 100 <br />MaxLength: 21 <br />Optional: \{\} <br /> |
 
@@ -589,7 +589,7 @@ _Appears in:_
 | `exportRTs` _[RouteTarget](#routetarget) array_ | exportRTs are the Route Targets to be used for exporting routes.<br />If no exportRTs are provided, defaults to single export Route Target<br /><asn>:<rdAssignedNumber>. |  | MaxItems: 100 <br />MaxLength: 21 <br />Optional: \{\} <br /> |
 | `importRTs` _[RouteTarget](#routetarget) array_ | importRTs are the Route Targets to be used for importing routes.<br />importRTs must always be provided explicitly. |  | MaxItems: 100 <br />MaxLength: 21 <br />Required: \{\} <br /> |
 | `rdAssignedNumber` _integer_ | rdAssignedNumber sets the Route Distinguisher's Assigned Number subfield.<br />The Administrator subfield is automatically set to the value of the router<br />ID. OpenPERouter uses Type 1 Route Distinguishers as defined in RFC4364,<br />meaning <Administrator subfield>:<Assigned Number subfield>. |  | Maximum: 65535 <br />Minimum: 1 <br />Required: \{\} <br /> |
-| `hostsession` _[HostSession](#hostsession)_ | hostsession is the configuration for the host session. |  | Optional: \{\} <br /> |
+| `hostSession` _[HostSession](#hostSession)_ | hostSession is the configuration for the host session. |  | Optional: \{\} <br /> |
 
 
 #### L3VPNStatus
@@ -614,7 +614,7 @@ LinuxBridgeConfig contains configuration for Linux bridge type.
 
 
 _Appears in:_
-- [HostMaster](#hostmaster)
+- [HostMaster](#hostMaster)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -631,7 +631,7 @@ _Appears in:_
 
 
 _Appears in:_
-- [HostSession](#hostsession)
+- [HostSession](#hostSession)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -747,7 +747,7 @@ OVSBridgeConfig contains configuration for OVS bridge type.
 
 
 _Appears in:_
-- [HostMaster](#hostmaster)
+- [HostMaster](#hostMaster)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -1021,7 +1021,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `nodeSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#labelselector-v1-meta)_ | nodeSelector specifies which nodes this Underlay applies to.<br />If empty or not specified, applies to all nodes (backward compatible).<br />Multiple Underlays with overlapping node selectors will be rejected. |  | Optional: \{\} <br /> |
 | `asn` _integer_ | asn is the local AS number to use for the session with the TOR switch. |  | Maximum: 4.294967295e+09 <br />Minimum: 1 <br />Required: \{\} <br /> |
-| `routeridcidr` _string_ | routeridcidr is the ipv4 cidr to be used to assign a different routerID on each node. | 10.0.0.0/24 | Optional: \{\} <br /> |
+| `routerIDCIDR` _string_ | routerIDCIDR is the ipv4 cidr to be used to assign a different routerID on each node. | 10.0.0.0/24 | Optional: \{\} <br /> |
 | `neighbors` _[Neighbor](#neighbor) array_ | neighbors is the list of external BGP neighbors to peer with.<br />Multiple neighbors are supported for connecting to multiple TOR switches<br />or establishing redundant BGP sessions. Each neighbor address must be unique.<br />At least one neighbor is required. |  | MaxItems: 128 <br />MinItems: 1 <br />Required: \{\} <br /> |
 | `interfaces` _[UnderlayInterface](#underlayinterface) array_ | interfaces is the list of interfaces the router uses for underlay<br />connectivity. Each entry is a discriminated union describing how the<br />interface is obtained. At least one interface is required. All the<br />entries must be of the same type: mixing NetworkDevice and CNIDevice<br />interfaces is not supported. |  | MinItems: 1 <br />Required: \{\} <br /> |
 | `tunnelEndpoint` _[TunnelEndpointConfig](#tunnelendpointconfig)_ | tunnelEndpoint contains tunnel endpoint configuration for the underlay. |  | Optional: \{\} <br /> |

--- a/website/content/docs/api-reference.md
+++ b/website/content/docs/api-reference.md
@@ -251,7 +251,7 @@ _Appears in:_
 | `asn` _integer_ | asn is the local AS number to use to establish a BGP session with<br />the default namespace. |  | Maximum: 4.294967295e+09 <br />Minimum: 1 <br />Required: \{\} <br /> |
 | `hostASN` _integer_ | hostASN is the expected AS number for a BGP speaking component running in<br />the default network namespace. Either HostASN or HostType must be set. |  | Maximum: 4.294967295e+09 <br />Minimum: 1 <br />Optional: \{\} <br /> |
 | `hostType` _string_ | hostType is the AS type of the BGP speaking component running in the<br />default network namespace. Either HostASN or HostType must be set. |  | Enum: [external internal] <br />Optional: \{\} <br /> |
-| `localCIDR` _[LocalCIDRConfig](#localCIDRconfig)_ | localCIDR is the CIDR configuration for the veth pair<br />to connect with the default namespace. The interface under<br />the PERouter side is going to use the first IP of the cidr on all the nodes.<br />At least one of IPv4 or IPv6 must be provided. |  | Required: \{\} <br /> |
+| `localCIDR` _[LocalCIDRConfig](#localcidrconfig)_ | localCIDR is the CIDR configuration for the veth pair<br />to connect with the default namespace. The interface under<br />the PERouter side is going to use the first IP of the cidr on all the nodes.<br />At least one of IPv4 or IPv6 must be provided. |  | Required: \{\} <br /> |
 
 
 #### IPFamily
@@ -397,7 +397,7 @@ _Appears in:_
 | `vni` _integer_ | vni is the VXLan VNI to be used |  | Maximum: 1.6777215e+07 <br />Minimum: 1 <br />Required: \{\} <br /> |
 | `vxlanPort` _integer_ | vxlanPort is the port to be used for VXLan encapsulation. | 4789 | Optional: \{\} <br /> |
 | `underlayAddressFamily` _string_ | underlayAddressFamily selects which VTEP address family to use for this VNI's<br />VXLAN interface. When omitted, defaults to the available family in the underlay<br />(IPv4 preferred in dual-stack). |  | Enum: [ipv4 ipv6] <br />Optional: \{\} <br /> |
-| `hostMaster` _[HostMaster](#hostMaster)_ | hostMaster is the interface on the host the veth should be attached to.<br />If not set, the host veth will not be attached to any interface and it must be<br />attached manually (or by some other means). This is useful if another controller<br />is leveraging the host interface for the VNI. |  | Optional: \{\} <br /> |
+| `hostMaster` _[HostMaster](#hostmaster)_ | hostMaster is the interface on the host the veth should be attached to.<br />If not set, the host veth will not be attached to any interface and it must be<br />attached manually (or by some other means). This is useful if another controller<br />is leveraging the host interface for the VNI. |  | Optional: \{\} <br /> |
 | `gatewayIPs` _string array_ | gatewayIPs is a list of IP addresses in CIDR notation for the<br />distributed anycast gateway on this L2 segment's bridge<br />(Integrated Routing and Bridging interface). It is a property of<br />the L2 segment itself, so it lives on the L2VNI rather than<br />inside the routing-domain reference.<br />Maximum of 2 addresses are allowed. If 2 addresses are provided, one must be IPv4 and one must be IPv6. |  | MaxItems: 2 <br />Optional: \{\} <br /> |
 
 
@@ -448,7 +448,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `nodeSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#labelselector-v1-meta)_ | nodeSelector specifies which nodes this L3Passthrough applies to.<br />If empty or not specified, applies to all nodes.<br />Multiple L3Passthrough with overlapping node selectors will be rejected. |  | Optional: \{\} <br /> |
-| `hostSession` _[HostSession](#hostSession)_ | hostSession is the configuration for the host session. |  | Required: \{\} <br /> |
+| `hostSession` _[HostSession](#hostsession)_ | hostSession is the configuration for the host session. |  | Required: \{\} <br /> |
 
 
 #### L3PassthroughStatus
@@ -518,7 +518,7 @@ _Appears in:_
 | `vni` _integer_ | vni is the VXLan VNI to be used |  | Maximum: 1.6777215e+07 <br />Minimum: 1 <br />Required: \{\} <br /> |
 | `vxlanPort` _integer_ | vxlanPort is the port to be used for VXLan encapsulation. | 4789 | Optional: \{\} <br /> |
 | `underlayAddressFamily` _string_ | underlayAddressFamily selects which VTEP address family to use for this VNI's<br />VXLAN interface. When omitted, defaults to the available family in the underlay<br />(IPv4 preferred in dual-stack). |  | Enum: [ipv4 ipv6] <br />Optional: \{\} <br /> |
-| `hostSession` _[HostSession](#hostSession)_ | hostSession is the configuration for the host session. |  | Optional: \{\} <br /> |
+| `hostSession` _[HostSession](#hostsession)_ | hostSession is the configuration for the host session. |  | Optional: \{\} <br /> |
 | `exportRTs` _[RouteTarget](#routetarget) array_ | exportRTs are the Route Targets to be used for exporting routes.<br />RouteTarget defines a BGP Extended Community for route filtering. |  | MaxItems: 100 <br />MaxLength: 21 <br />Optional: \{\} <br /> |
 | `importRTs` _[RouteTarget](#routetarget) array_ | importRTs are the Route Targets to be used for importing routes.<br />RouteTarget defines a BGP Extended Community for route filtering. |  | MaxItems: 100 <br />MaxLength: 21 <br />Optional: \{\} <br /> |
 
@@ -589,7 +589,7 @@ _Appears in:_
 | `exportRTs` _[RouteTarget](#routetarget) array_ | exportRTs are the Route Targets to be used for exporting routes.<br />If no exportRTs are provided, defaults to single export Route Target<br /><asn>:<rdAssignedNumber>. |  | MaxItems: 100 <br />MaxLength: 21 <br />Optional: \{\} <br /> |
 | `importRTs` _[RouteTarget](#routetarget) array_ | importRTs are the Route Targets to be used for importing routes.<br />importRTs must always be provided explicitly. |  | MaxItems: 100 <br />MaxLength: 21 <br />Required: \{\} <br /> |
 | `rdAssignedNumber` _integer_ | rdAssignedNumber sets the Route Distinguisher's Assigned Number subfield.<br />The Administrator subfield is automatically set to the value of the router<br />ID. OpenPERouter uses Type 1 Route Distinguishers as defined in RFC4364,<br />meaning <Administrator subfield>:<Assigned Number subfield>. |  | Maximum: 65535 <br />Minimum: 1 <br />Required: \{\} <br /> |
-| `hostSession` _[HostSession](#hostSession)_ | hostSession is the configuration for the host session. |  | Optional: \{\} <br /> |
+| `hostSession` _[HostSession](#hostsession)_ | hostSession is the configuration for the host session. |  | Optional: \{\} <br /> |
 
 
 #### L3VPNStatus
@@ -614,7 +614,7 @@ LinuxBridgeConfig contains configuration for Linux bridge type.
 
 
 _Appears in:_
-- [HostMaster](#hostMaster)
+- [HostMaster](#hostmaster)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -631,7 +631,7 @@ _Appears in:_
 
 
 _Appears in:_
-- [HostSession](#hostSession)
+- [HostSession](#hostsession)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -747,7 +747,7 @@ OVSBridgeConfig contains configuration for OVS bridge type.
 
 
 _Appears in:_
-- [HostMaster](#hostMaster)
+- [HostMaster](#hostmaster)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |

--- a/website/content/docs/concepts/_index.md
+++ b/website/content/docs/concepts/_index.md
@@ -116,7 +116,7 @@ For each Layer 3 VPN (SRv6), OpenPERouter automatically creates:
 #### IP Allocation Strategy
 
 The IP addresses for the veth pair are allocated from the configured
-`localcidr` for each VNI:
+`localCIDR` for each VNI:
 
 - **Router side**: Always gets the first IP in the CIDR
   (e.g., `192.169.11.0`)

--- a/website/content/docs/concepts/evpn.md
+++ b/website/content/docs/concepts/evpn.md
@@ -61,7 +61,7 @@ In addition to what's described in the [concepts page]({{< ref "concepts/#l3-vpn
 
 #### IP Allocation Strategy
 
-The IP addresses for the veth pair are allocated from the configured `localcidr` for each VNI:
+The IP addresses for the veth pair are allocated from the configured `localCIDR` for each VNI:
 
 - **Router side**: Always gets the first IP in the CIDR (e.g., `192.169.11.0`)
 - **Host side**: Each node gets a different IP from the CIDR, starting from the second value (e.g., `192.169.11.15`)

--- a/website/content/docs/concepts/passthrough.md
+++ b/website/content/docs/concepts/passthrough.md
@@ -43,7 +43,7 @@ OpenPERouter automatically creates a veth pair for passthrough connectivity:
 
 ### IP Allocation Strategy
 
-The IP addresses for the veth pair are allocated from the configured `localcidr`:
+The IP addresses for the veth pair are allocated from the configured `localCIDR`:
 
 - **Router side**: Gets the first IP in the CIDR (e.g., `192.169.10.1`)
 - **Host side**: Gets the second IP in the CIDR (e.g., `192.169.10.2`)

--- a/website/content/docs/concepts/srv6.md
+++ b/website/content/docs/concepts/srv6.md
@@ -80,7 +80,7 @@ OpenPERouter automatically creates:
 #### IP Allocation Strategy
 
 The IP addresses for the veth pair are allocated from the configured
-`localcidr` for each L3VPN:
+`localCIDR` for each L3VPN:
 
 - **Router side**: Always gets the first IP in the CIDR
   (e.g., `192.169.11.0`)

--- a/website/content/docs/configuration/evpn.md
+++ b/website/content/docs/configuration/evpn.md
@@ -79,10 +79,10 @@ metadata:
   namespace: openperouter-system
 spec:
   vrf: blue
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.11.0/24
   vni: 200
 
@@ -95,9 +95,9 @@ spec:
 | `vrf` | string | Name of the VRF (Virtual Routing and Forwarding) instance | Yes |
 | `vni` | integer | Virtual Network Identifier (1-16777215) | Yes |
 | `underlayAddressFamily` | string | VTEP address family for this VNI (`ipv4` or `ipv6`). Defaults to available family (IPv4 preferred in dual-stack). | No |
-| `hostsession.asn` | integer | Router ASN for BGP session with host | Yes |
-| `hostsession.hostasn` | integer | Host ASN for BGP session | Yes |
-| `hostsession.localcidr` | string | CIDR for veth pair IP allocation | Yes |
+| `hostSession.asn` | integer | Router ASN for BGP session with host | Yes |
+| `hostSession.hostASN` | integer | Host ASN for BGP session | Yes |
+| `hostSession.localCIDR` | string | CIDR for veth pair IP allocation | Yes |
 | `nodeSelector` | object | Label selector to target specific nodes (applies to all nodes if omitted) | No |
 
 ### Multiple VNIs Example
@@ -114,10 +114,10 @@ metadata:
 spec:
   vrf: signal
   vni: 100
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.168.10.0/24
 ---
 # Development VNI
@@ -129,10 +129,10 @@ metadata:
 spec:
   vrf: oam
   vni: 200
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.168.20.0/24
 ```
 
@@ -143,7 +143,7 @@ When you create or update VNI configurations, OpenPERouter automatically:
 1. **Creates Network Interfaces**: Sets up VXLAN interface and Linux VRF named after the VNI
 2. **Establishes Connectivity**: Creates veth pair and moves one end to the router's namespace
 3. **Adjusts Veth MTU**: Sets the MTU on both veth legs to the underlay NIC's MTU minus 50 bytes to account for VXLan encapsulation overhead
-4. **Assigns IP Addresses**: Allocates IPs from the `localcidr` range:
+4. **Assigns IP Addresses**: Allocates IPs from the `localCIDR` range:
    - Router side: First IP in the CIDR (e.g., `192.169.11.1`)
    - Host side: Each node gets a free IP in the CIDR, starting from the second (e.g., `192.169.11.15`)
 5. **Creates BGP Session**: Opens BGP session between router and host using the specified ASNs
@@ -163,11 +163,11 @@ L2VNIs provide Layer 2 connectivity across nodes using EVPN tunnels. Unlike L3VN
 | `routingDomain.l3vpn.name` | string | metadata.name of the L3VPN that provides the routing domain | Yes (when type is `L3VPN`) |
 | `gatewayIPs` | string array | IP addresses in CIDR notation for the distributed anycast gateway. Cannot be set without routingDomain. Max 2 (one IPv4, one IPv6). | No |
 | `underlayAddressFamily` | string | VTEP address family for this VNI (`ipv4` or `ipv6`). Defaults to available family (IPv4 preferred in dual-stack). | No |
-| `hostmaster.type` | string | Type of host interface management (`linux-bridge` or `ovs-bridge`) | Yes |
-| `hostmaster.linuxBridge.lifecycle` | string | How the Linux bridge is provisioned (`Managed` or `External`) | Yes |
-| `hostmaster.linuxBridge.name` | string | Name of the Linux bridge to attach to. Only valid when `External` | Only when `External` |
-| `hostmaster.ovsBridge.lifecycle` | string | How the OVS bridge is provisioned (`Managed` or `External`) | Yes |
-| `hostmaster.ovsBridge.name` | string | Name of the OVS bridge to attach to. Only valid when `External` | Only when `External` |
+| `hostMaster.type` | string | Type of host interface management (`linux-bridge` or `ovs-bridge`) | Yes |
+| `hostMaster.linuxBridge.lifecycle` | string | How the Linux bridge is provisioned (`Managed` or `External`) | Yes |
+| `hostMaster.linuxBridge.name` | string | Name of the Linux bridge to attach to. Only valid when `External` | Only when `External` |
+| `hostMaster.ovsBridge.lifecycle` | string | How the OVS bridge is provisioned (`Managed` or `External`) | Yes |
+| `hostMaster.ovsBridge.name` | string | Name of the OVS bridge to attach to. Only valid when `External` | Only when `External` |
 | `nodeSelector` | object | Label selector to target specific nodes (applies to all nodes if omitted) | No |
 
 ### L2VNI Example
@@ -184,7 +184,7 @@ spec:
     type: L3VNI
     l3vni:
       name: red
-  hostmaster:
+  hostMaster:
     type: linux-bridge
     linuxBridge:
       lifecycle: Managed

--- a/website/content/docs/configuration/grout.md
+++ b/website/content/docs/configuration/grout.md
@@ -134,10 +134,10 @@ metadata:
   name: passthrough
   namespace: openperouter-system
 spec:
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.10.0/24
 ```
 

--- a/website/content/docs/configuration/node-selector.md
+++ b/website/content/docs/configuration/node-selector.md
@@ -122,11 +122,11 @@ spec:
       topology.kubernetes.io/rack: rack-1
   vrf: tenant-a
   vni: 5001
-  vxlanport: 4789
-  hostsession:
+  vxlanPort: 4789
+  hostSession:
     asn: 64512
-    hostasn: 64600
-    localcidr:
+    hostASN: 64600
+    localCIDR:
       ipv4: 192.169.1.0/24
 ---
 # L3VNI for rack-2 nodes
@@ -141,11 +141,11 @@ spec:
       topology.kubernetes.io/rack: rack-2
   vrf: tenant-a
   vni: 5002
-  vxlanport: 4789
-  hostsession:
+  vxlanPort: 4789
+  hostSession:
     asn: 64512
-    hostasn: 64600
-    localcidr:
+    hostASN: 64600
+    localCIDR:
       ipv4: 192.169.2.0/24
 ```
 
@@ -166,10 +166,10 @@ spec:
       node-role.kubernetes.io/worker: ""
   vrf: tenant-a
   vni: 5001
-  hostsession:
+  hostSession:
     asn: 64512
-    hostasn: 64600
-    localcidr:
+    hostASN: 64600
+    localCIDR:
       ipv4: 192.169.5.0/24
 ---
 # Tenant B VNI on the same worker nodes
@@ -184,10 +184,10 @@ spec:
       node-role.kubernetes.io/worker: ""
   vrf: tenant-b
   vni: 5002
-  hostsession:
+  hostSession:
     asn: 64512
-    hostasn: 64601
-    localcidr:
+    hostASN: 64601
+    localCIDR:
       ipv4: 192.169.6.0/24
 ---
 # Tenant C VNI on the same worker nodes
@@ -202,10 +202,10 @@ spec:
       node-role.kubernetes.io/worker: ""
   vrf: tenant-c
   vni: 5003
-  hostsession:
+  hostSession:
     asn: 64512
-    hostasn: 64602
-    localcidr:
+    hostASN: 64602
+    localCIDR:
       ipv4: 192.169.7.0/24
 ```
 
@@ -225,12 +225,12 @@ spec:
     matchLabels:
       node-role.kubernetes.io/worker: ""
   vni: 10100
-  vxlanport: 4789
+  vxlanPort: 4789
   routingDomain:
     type: L3VNI
     l3vni:
       name: tenant-a-vni
-  hostmaster:
+  hostMaster:
     type: linux-bridge
     linuxBridge:
       lifecycle: Managed
@@ -253,9 +253,9 @@ spec:
   nodeSelector:
     matchLabels:
       node-role.kubernetes.io/edge: ""
-  hostsession:
+  hostSession:
     asn: 64512
-    hostasn: 64700
-    localcidr:
+    hostASN: 64700
+    localCIDR:
       ipv4: 192.169.20.0/24
 ```

--- a/website/content/docs/configuration/passthrough.md
+++ b/website/content/docs/configuration/passthrough.md
@@ -55,10 +55,10 @@ metadata:
   name: passthrough
   namespace: openperouter-system
 spec:
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.10.0/24
 ```
 
@@ -66,10 +66,10 @@ spec:
 
 | Field | Type | Description | Required |
 |-------|------|-------------|----------|
-| `hostsession.asn` | integer | Router ASN for BGP session with host | Yes |
-| `hostsession.hostasn` | integer | Host ASN for BGP session | Yes |
-| `hostsession.localcidr.ipv4` | string | IPv4 CIDR for veth pair IP allocation | No |
-| `hostsession.localcidr.ipv6` | string | IPv6 CIDR for veth pair IP allocation | No |
+| `hostSession.asn` | integer | Router ASN for BGP session with host | Yes |
+| `hostSession.hostASN` | integer | Host ASN for BGP session | Yes |
+| `hostSession.localCIDR.ipv4` | string | IPv4 CIDR for veth pair IP allocation | No |
+| `hostSession.localCIDR.ipv6` | string | IPv6 CIDR for veth pair IP allocation | No |
 | `nodeSelector` | object | Label selector to target specific nodes (applies to all nodes if omitted) | No |
 
 ### Dual Stack Configuration
@@ -83,17 +83,17 @@ metadata:
   name: passthrough-dual
   namespace: openperouter-system
 spec:
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.10.0/24
       ipv6: 2001:db8:10::/64
 ```
 
 ### IP Allocation Strategy
 
-The IP addresses for the veth pair are allocated from the configured `localcidr`:
+The IP addresses for the veth pair are allocated from the configured `localCIDR`:
 
 - **Router side**: Always gets the first IP in the CIDR (e.g., `192.169.10.1`)
 - **Host side**: Each node gets a different IP from the CIDR, starting from the second value (e.g., `192.169.10.2`)
@@ -105,7 +105,7 @@ This consistent allocation strategy ensures that BGP-speaking components on the 
 When you create or update L3Passthrough configurations, OpenPERouter automatically:
 
 1. **Creates Veth Pair**: Sets up a veth pair named `pt-host` (host side) and `pt-ns` (router side)
-2. **Assigns IP Addresses**: Allocates IPs from the `localcidr` range:
+2. **Assigns IP Addresses**: Allocates IPs from the `localCIDR` range:
    - Router side: First IP in the CIDR (e.g., `192.169.10.1`)
    - Host side: Second IP in the CIDR (e.g., `192.169.10.2`)
 3. **Establishes BGP Session**: Opens BGP session between router and host using the specified ASNs

--- a/website/content/docs/configuration/srv6.md
+++ b/website/content/docs/configuration/srv6.md
@@ -36,7 +36,7 @@ spec:
     - type: NetworkDevice
       networkDevice:
         interfaceName: toswitch1
-  routeridcidr: 10.0.0.0/24
+  routerIDCIDR: 10.0.0.0/24
   tunnelEndpoint:
     cidrs:
     - 2001:db8:1234:5678::/64
@@ -70,7 +70,7 @@ when combining SRv6 with VXLAN for L2VNIs):
 
 ### Router ID
 
-The `routeridcidr` field defines the IPv4 CIDR used for per-node router ID
+The `routerIDCIDR` field defines the IPv4 CIDR used for per-node router ID
 assignment. Each node receives a unique router ID from this range. Defaults
 to `10.0.0.0/24` if omitted.
 
@@ -150,10 +150,10 @@ metadata:
   name: red
   namespace: openperouter-system
 spec:
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.10.0/24
   vrf: red
   rdAssignedNumber: 100
@@ -184,10 +184,10 @@ spec:
   - "64520:100"
   exportRTs:
   - "64514:100"
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.168.10.0/24
 ---
 # OAM VPN
@@ -203,10 +203,10 @@ spec:
   - "64520:200"
   exportRTs:
   - "64514:200"
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.168.20.0/24
 ```
 
@@ -218,7 +218,7 @@ When you create or update L3VPN configurations, OpenPERouter automatically:
    L3VPN
 2. **Establishes Connectivity**: Creates veth pair and moves one end to
    the router's namespace
-3. **Assigns IP Addresses**: Allocates IPs from the `localcidr` range:
+3. **Assigns IP Addresses**: Allocates IPs from the `localCIDR` range:
    - Router side: First IP in the CIDR (e.g., `192.169.10.1`)
    - Host side: Each node gets a free IP in the CIDR, starting from the
      second (e.g., `192.169.10.15`)
@@ -250,7 +250,7 @@ spec:
     type: L3VPN
     l3vpn:
       name: red
-  hostmaster:
+  hostMaster:
     type: linux-bridge
     linuxBridge:
       lifecycle: Managed

--- a/website/content/docs/configuration/systemd-mode.md
+++ b/website/content/docs/configuration/systemd-mode.md
@@ -76,12 +76,12 @@ l3vnis:
 l2vnis:
   - name: storage
     vni: 300
-    vxlanport: 4789
+    vxlanPort: 4789
     routingDomain:
       type: L3VNI
       l3vni:
         name: red
-    hostmaster:
+    hostMaster:
       type: linux-bridge
       linuxBridge:
         name: br-storage

--- a/website/content/docs/examples/evpnexamples/_index.md
+++ b/website/content/docs/examples/evpnexamples/_index.md
@@ -83,10 +83,10 @@ metadata:
 spec:
   vrf: red
   vni: 100
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.10.0/24
 ---
 # Blue VNI (VNI 200)
@@ -98,10 +98,10 @@ metadata:
 spec:
   vrf: blue
   vni: 200
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.11.0/24
 ```
 

--- a/website/content/docs/examples/evpnexamples/calico.md
+++ b/website/content/docs/examples/evpnexamples/calico.md
@@ -51,10 +51,10 @@ metadata:
 spec:
   vrf: red
   vni: 100
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.10.0/24
 ---
 apiVersion: network.openperouter.io/v1alpha1

--- a/website/content/docs/examples/evpnexamples/kubevirt-multi-cluster.md
+++ b/website/content/docs/examples/evpnexamples/kubevirt-multi-cluster.md
@@ -76,7 +76,7 @@ metadata:
   name: layer2
   namespace: openperouter-system
 spec:
-  hostmaster:
+  hostMaster:
     type: linux-bridge
     linuxBridge:
       lifecycle: Managed
@@ -91,7 +91,7 @@ spec:
 **Key Configuration Points:**
 
 - The L2VNI references the L3VNI via the `routingDomain` field, enabling routed traffic
-- `hostmaster.linuxBridge.lifecycle: Managed` creates a `br-hs-110` bridge on the host
+- `hostMaster.linuxBridge.lifecycle: Managed` creates a `br-hs-110` bridge on the host
 - `gatewayIPs` defines the gateway IP for the VM subnet
 
 ### 2. Network Attachment Definition
@@ -301,7 +301,7 @@ We see that the packet comes from the veth interface towards the bridge associat
 
 ### Common Issues
 
-1. **Bridge not created**: Verify the L2VNI has `hostmaster.linuxBridge.lifecycle: Managed`
+1. **Bridge not created**: Verify the L2VNI has `hostMaster.linuxBridge.lifecycle: Managed`
 2. **VM cannot reach gateway**: Check that the VM's IP is in the same subnet as `gatewayIPs`
 3. **No VM-to-VM connectivity**: Ensure both VMs are connected to the same bridge (`br-hs-110`)
 

--- a/website/content/docs/examples/evpnexamples/kubevirt.md
+++ b/website/content/docs/examples/evpnexamples/kubevirt.md
@@ -60,10 +60,10 @@ metadata:
 spec:
   vrf: red
   vni: 100
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.10.0/24
 ---
 apiVersion: network.openperouter.io/v1alpha1
@@ -72,7 +72,7 @@ metadata:
   name: layer2
   namespace: openperouter-system
 spec:
-  hostmaster:
+  hostMaster:
     type: linux-bridge
     linuxBridge:
       lifecycle: Managed
@@ -82,13 +82,13 @@ spec:
     type: L3VNI
     l3vni:
       name: red
-  vxlanport: 4789
+  vxlanPort: 4789
 ```
 
 **Key Configuration Points:**
 
 - The L2VNI references the L3VNI via the `routingDomain` field, enabling routed traffic
-- `hostmaster.linuxBridge.lifecycle: Managed` creates a `br-hs-110` bridge on the host
+- `hostMaster.linuxBridge.lifecycle: Managed` creates a `br-hs-110` bridge on the host
 - `gatewayIPs` defines the gateway IP for the VM subnet
 
 ### 2. Network Attachment Definition
@@ -263,7 +263,7 @@ The ping should continue working throughout the migration process.
 
 ### Common Issues
 
-1. **Bridge not created**: Verify the L2VNI has `hostmaster.linuxBridge.lifecycle: Managed`
+1. **Bridge not created**: Verify the L2VNI has `hostMaster.linuxBridge.lifecycle: Managed`
 2. **VM cannot reach gateway**: Check that the VM's IP is in the same subnet as `gatewayIPs`
 3. **No VM-to-VM connectivity**: Ensure both VMs are connected to the same bridge (`br-hs-110`)
 

--- a/website/content/docs/examples/evpnexamples/layer2.md
+++ b/website/content/docs/examples/evpnexamples/layer2.md
@@ -49,10 +49,10 @@ metadata:
 spec:
   vrf: red
   vni: 100
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.10.0/24
 ---
 apiVersion: network.openperouter.io/v1alpha1
@@ -66,7 +66,7 @@ spec:
     type: L3VNI
     l3vni:
       name: red
-  hostmaster:
+  hostMaster:
     type: linux-bridge
     linuxBridge:
       lifecycle: Managed
@@ -76,7 +76,7 @@ spec:
 **Configuration Notes:**
 
 - **`gatewayIPs` field**: Allows each pod to have the same default gateway and be able to send traffic to the outer L3 domain
-- **hostmaster.linuxBridge.lifecycle**: `Managed` instructs OpenPERouter to create a bridge local to the node that can be used to access the L2 domain
+- **hostMaster.linuxBridge.lifecycle**: `Managed` instructs OpenPERouter to create a bridge local to the node that can be used to access the L2 domain
 
 ### Network Attachment Definition
 

--- a/website/content/docs/examples/evpnexamples/metallb.md
+++ b/website/content/docs/examples/evpnexamples/metallb.md
@@ -67,10 +67,10 @@ metadata:
 spec:
   vrf: red
   vni: 100
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.10.0/24
 ---
 apiVersion: network.openperouter.io/v1alpha1
@@ -81,10 +81,10 @@ metadata:
 spec:
   vrf: blue
   vni: 200
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.11.0/24
 ```
 

--- a/website/content/docs/examples/passthroughexamples/_index.md
+++ b/website/content/docs/examples/passthroughexamples/_index.md
@@ -70,10 +70,10 @@ metadata:
   name: passthrough
   namespace: openperouter-system
 spec:
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.10.0/24
 ```
 

--- a/website/content/docs/examples/passthroughexamples/metallb.md
+++ b/website/content/docs/examples/passthroughexamples/metallb.md
@@ -60,10 +60,10 @@ metadata:
   name: passthrough
   namespace: openperouter-system
 spec:
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.10.0/24
 ```
 

--- a/website/content/docs/examples/srv6examples/_index.md
+++ b/website/content/docs/examples/srv6examples/_index.md
@@ -69,7 +69,7 @@ spec:
     - type: NetworkDevice
       networkDevice:
         interfaceName: toswitch1
-  routeridcidr: 10.0.0.0/24
+  routerIDCIDR: 10.0.0.0/24
   tunnelEndpoint:
     cidrs:
     - 2001:db8:1234:5678::/64
@@ -109,10 +109,10 @@ metadata:
   name: red
   namespace: openperouter-system
 spec:
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.10.0/24
   vrf: red
   rdAssignedNumber: 100
@@ -127,10 +127,10 @@ metadata:
   name: blue
   namespace: openperouter-system
 spec:
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.11.0/24
   vrf: blue
   rdAssignedNumber: 200

--- a/website/content/docs/examples/srv6examples/layer2.md
+++ b/website/content/docs/examples/srv6examples/layer2.md
@@ -60,10 +60,10 @@ metadata:
   name: red
   namespace: openperouter-system
 spec:
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.10.0/24
   vrf: red
   rdAssignedNumber: 100
@@ -83,7 +83,7 @@ spec:
     type: L3VPN
     l3vpn:
       name: red
-  hostmaster:
+  hostMaster:
     type: linux-bridge
     linuxBridge:
       lifecycle: Managed
@@ -93,7 +93,7 @@ spec:
 **Configuration Notes:**
 
 - **`gatewayIPs` field**: Allows each pod to have the same default gateway and be able to send traffic to the outer L3 domain
-- **hostmaster.linuxBridge.lifecycle**: `Managed` instructs OpenPERouter to create a bridge
+- **hostMaster.linuxBridge.lifecycle**: `Managed` instructs OpenPERouter to create a bridge
   local to the node that can be used to access the L2 domain
 
 ### Underlay Configuration
@@ -128,7 +128,7 @@ spec:
     - type: NetworkDevice
       networkDevice:
         interfaceName: toswitch1
-  routeridcidr: 10.0.0.0/24
+  routerIDCIDR: 10.0.0.0/24
   isis:
     baseNet: "49.0001.0002.0003.0004.00"
     level: 1

--- a/website/content/docs/examples/srv6examples/metallb.md
+++ b/website/content/docs/examples/srv6examples/metallb.md
@@ -77,10 +77,10 @@ metadata:
   name: red
   namespace: openperouter-system
 spec:
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.10.0/24
   vrf: red
   rdAssignedNumber: 100
@@ -95,10 +95,10 @@ metadata:
   name: blue
   namespace: openperouter-system
 spec:
-  hostsession:
+  hostSession:
     asn: 64514
-    hostasn: 64515
-    localcidr:
+    hostASN: 64515
+    localCIDR:
       ipv4: 192.169.11.0/24
   vrf: blue
   rdAssignedNumber: 200


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug

/kind cleanup

> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

- Rename all flat-lowercase JSON struct tags in the CRD API types to lowerCamelCase: 
  - hostasn -> hostASN
  - hosttype -> hostType
  - localcidr -> localCIDR
  - hostsession -> hostSession
  - vxlanport -> vxlanPort
  - hostmaster -> hostMaster
  - routeridcidr -> routerIDCIDR
- Update CEL validation rules that reference JSON field names via self.
- Update all documentation, examples, and config samples.
- Regenerate CRDs, all-in-one manifests, operator bundle, and API docs
- Update e2e test inline YAML and internal JSON struct tags
- Document remaining internal host-validator struct tag inconsistencies in the enhancement doc for future work

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
action required: CRD field names in YAML/JSON are renamed from flat-lowercase to lowerCamelCase. Existing manifests must be updated.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected case-sensitive API and configuration field names across networking resources.
  * Updated validation rules and required fields to recognize the corrected names.
  * Aligned CRD schemas, manifests, samples, and integrations for consistent configuration handling.

* **Documentation**
  * Updated API references, examples, enhancement notes, and release documentation to use the corrected field casing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->