### PR TITLE
fix(clab): image load on containerd image store and leftover veth cleanup

### DIFF
--- a/clab/clean.sh
+++ b/clab/clean.sh
@@ -63,6 +63,18 @@ for iface in $(ip link show | awk -F': ' '/^[0-9]+: leafkind/ {print $2}' | cut 
     fi
 done
 
+# containerlab wires the kind nodes through veths named clab-<hash>. It removes
+# them on destroy, but only for nodes it knows about: if the kind cluster failed
+# to come up, "clab destroy" reports "no containerlab containers found" and the
+# veths are left dangling in the host namespace. Deleting one end drops the pair.
+echo "=== Cleaning up leftover containerlab veths ==="
+for iface in $(ip -br link show type veth | awk '{print $1}' | cut -d'@' -f1 | grep -E '^clab-' || true); do
+    if [[ -d "/sys/class/net/${iface}" ]]; then
+        echo "Removing veth: ${iface}"
+        sudo ip link delete ${iface} 2>/dev/null || true
+    fi
+done
+
 echo "=== Cleaning up kubeconfig files ==="
 rm -f "${KUBECONFIG_PATH}*" || true
 

--- a/clab/common.sh
+++ b/clab/common.sh
@@ -51,8 +51,22 @@ load_local_image_to_kind() {
     local image_tag=$1
     local file_name=$2
     local temp_file="/tmp/${file_name}.tar"
+    local save_opts=()
+
+    # When docker uses the containerd image store, "docker save" writes an OCI
+    # archive whose index points at the whole multi-platform manifest list,
+    # while only the platform we pulled has its blobs present locally. "kind
+    # load image-archive" then runs "ctr images import --all-platforms", which
+    # tries to resolve every referenced manifest and fails with
+    #   ctr: content digest sha256:...: not found
+    # Restricting the archive to the platform we actually pulled keeps the
+    # index single-manifest and imports cleanly.
+    if [[ $CONTAINER_ENGINE == "docker" ]] && docker save --help 2>&1 | grep -q -- '--platform'; then
+        save_opts=(--platform "${PLATFORM}")
+    fi
+
     rm -f ${temp_file}
-    ${CONTAINER_ENGINE_CLI} save -o ${temp_file} ${image_tag}
+    ${CONTAINER_ENGINE_CLI} save "${save_opts[@]}" -o ${temp_file} ${image_tag}
     ${KIND_COMMAND} load image-archive ${temp_file} --name ${KIND_CLUSTER_NAME}
     load_image_to_podman_on_nodes ${image_tag} ${file_name}
 }


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

Two independent fixes to the containerlab helpers, both hit while bringing
up a dev environment on Fedora with Docker 29.

1. `fix(clab): restrict the saved image archive to the pulled platform`

   When docker uses the containerd image store (the default with recent
   Docker), `docker save` writes an OCI archive whose index points at the
   whole multi-platform manifest list, while only the platform we pulled has
   its blobs present locally. `kind load image-archive` runs
   `ctr images import --all-platforms`, which tries to resolve every
   referenced manifest and fails, so `make deploy` dies at the image load
   step:

   ```
   ERROR: failed to load image: command "docker exec --privileged -i
   pe-kind-worker2 ctr --namespace=k8s.io images import --all-platforms
   --digests --snapshotter=overlayfs -" failed with error: exit status 1
   ctr: rpc error: code = NotFound desc = content digest
   sha256:bdd924c509459b4eeb9df0494cc2e93e3a779884573b6a6eee4dc1298b1b88a7:
   not found
   make: *** [Makefile:370: clab-cluster] Error 1
   ```

   `load_image_to_kind()` already pulls with `--platform ${PLATFORM}`, so pass
   the same platform to `docker save`. Only done for docker, and only when
   `docker save` advertises `--platform`; podman has no such flag and stores a
   single platform anyway.

2. `fix(clab): remove leftover containerlab veths on clean`

   containerlab wires the kind nodes through veths named `clab-<hash>`. It
   removes them on destroy, but only for the nodes it knows about. If the kind
   cluster failed to come up, the nodes were never created, `clab destroy`
   reports `no containerlab containers found`, and the veths are left dangling
   in the host namespace:

   ```
   427: clab-9ebf1c5a@kindctrlpl1: <BROADCAST,MULTICAST> mtu 9500 ...
   428: kindctrlpl1@clab-9ebf1c5a: <NO-CARRIER,BROADCAST,MULTICAST,UP,M-DOWN> ...
   ```

   `make clean` does not clear them because the existing sweep only matches
   `leafkind*`, so they accumulate across failed runs and have to be removed
   by hand. Add a second pass for `clab-*`.

**Special notes for your reviewer**:

The veth sweep is restricted to `type veth` on purpose, so a bridge whose name
happens to start with `clab-` is left alone. Deleting a docker-managed bridge
behind docker's back is how this class of breakage starts.

The `grep` is guarded with `|| true` because `clean.sh` runs under
`set -euo pipefail` and `grep` exits 1 when nothing matches, which would
otherwise abort the kubeconfig and registry cleanup that follow it on a tidy
host.

Both were verified on the affected setup: the image load now completes for all
three images across all three nodes, and `make clean` leaves no `clab-*`
interfaces behind.

**Release note**:

```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup by removing leftover virtual network interfaces after lab teardown.
  - Fixed local image imports for supported platforms, helping prevent failures caused by unavailable multi-platform image manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->