### PR TITLE
test(e2e): dump zebra dataplane and EVPN state on failure

### DIFF
--- a/e2etests/pkg/frr/dump.go
+++ b/e2etests/pkg/frr/dump.go
@@ -33,6 +33,22 @@ func RawDump(exec executor.Executor) string {
 		{desc: "BGP route table ipv6", cmd: []string{"vtysh", "-c", "show bgp vrf all ipv6"}},
 		{desc: "EVPN Routes", cmd: []string{"vtysh", "-c", "show bgp l2vpn evpn"}},
 		{desc: "Zebra interface information", cmd: []string{"vtysh", "-c", "show interface"}},
+		// Zebra dataplane and EVPN state. The BGP oriented output above says
+		// nothing about the dplane thread or the EVPN tables zebra keeps, which
+		// is what is needed when a router stops programming routes rather than
+		// losing a session. skipLogOnError keeps this quiet on FRR versions
+		// that do not have a given command.
+		{desc: "Zebra dplane", cmd: []string{"vtysh", "-c", "show zebra dplane detailed"}, skipLogOnError: true},
+		{desc: "Zebra dplane providers", cmd: []string{"vtysh", "-c", "show zebra dplane providers"}, skipLogOnError: true},
+		{desc: "Zebra clients", cmd: []string{"vtysh", "-c", "show zebra client summary"}, skipLogOnError: true},
+		{desc: "Zebra work queues", cmd: []string{"vtysh", "-c", "show work-queues"}, skipLogOnError: true},
+		// "show thread cpu" up to FRR 10.5, renamed to "show event cpu" in 10.6.
+		{desc: "Event CPU", cmd: []string{"vtysh", "-c", "show event cpu"}, skipLogOnError: true},
+		{desc: "Event poll", cmd: []string{"vtysh", "-c", "show event poll"}, skipLogOnError: true},
+		{desc: "Memory", cmd: []string{"vtysh", "-c", "show memory"}, skipLogOnError: true},
+		{desc: "EVPN VNIs", cmd: []string{"vtysh", "-c", "show evpn vni detail"}, skipLogOnError: true},
+		{desc: "EVPN MACs", cmd: []string{"vtysh", "-c", "show evpn mac vni all"}, skipLogOnError: true},
+		{desc: "EVPN ARP cache", cmd: []string{"vtysh", "-c", "show evpn arp-cache vni all"}, skipLogOnError: true},
 		{desc: "ip link", cmd: []string{"bash", "-c", "ip l"}},
 		{desc: "ip address", cmd: []string{"bash", "-c", "ip address"}},
 		{desc: "ip neigh", cmd: []string{"bash", "-c", "ip neigh"}},


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:

Adds to `RawDump`:

- `show zebra dplane detailed`, `show zebra dplane providers`
- `show zebra client summary`, `show work-queues`
- `show event cpu`, `show event poll`, `show memory`
- `show evpn vni detail`, `show evpn mac vni all`, `show evpn arp-cache vni all`

**Special notes for your reviewer**:

Part of #642.

**Release note**:

```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional diagnostics for FRR Zebra dataplane state, clients, work queues, event CPU and polling activity, memory usage, and EVPN tables.
  * Unsupported diagnostic commands are handled gracefully without interrupting diagnostic collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->