### PR TITLE
fix(frr): drop advertise-svi-ip from the underlay EVPN config

### DIFF
--- a/internal/frr/templates/underlay_evpn.tmpl
+++ b/internal/frr/templates/underlay_evpn.tmpl
@@ -19,6 +19,5 @@
 {{- end }}
 {{- end }}
     advertise-all-vni
-    advertise-svi-ip
   exit-address-family
 {{- end }}

--- a/internal/frr/testdata/TestBFDEnabled.golden
+++ b/internal/frr/testdata/TestBFDEnabled.golden
@@ -26,7 +26,6 @@ router bgp 64512
 
   address-family l2vpn evpn
     advertise-all-vni
-    advertise-svi-ip
   exit-address-family
 exit
 !

--- a/internal/frr/testdata/TestBFDProfile.golden
+++ b/internal/frr/testdata/TestBFDProfile.golden
@@ -31,7 +31,6 @@ router bgp 64512
 
   address-family l2vpn evpn
     advertise-all-vni
-    advertise-svi-ip
   exit-address-family
 exit
 !

--- a/internal/frr/testdata/TestBFDProfilePassiveMode.golden
+++ b/internal/frr/testdata/TestBFDProfilePassiveMode.golden
@@ -31,7 +31,6 @@ router bgp 64512
 
   address-family l2vpn evpn
     advertise-all-vni
-    advertise-svi-ip
   exit-address-family
 exit
 !

--- a/internal/frr/testdata/TestBGPUnnumbered.golden
+++ b/internal/frr/testdata/TestBGPUnnumbered.golden
@@ -30,7 +30,6 @@ router bgp 64512
   address-family l2vpn evpn
     neighbor eth1 activate
     advertise-all-vni
-    advertise-svi-ip
   exit-address-family
 exit
 !

--- a/internal/frr/testdata/TestBGPUnnumberedEBGPIPv6.golden
+++ b/internal/frr/testdata/TestBGPUnnumberedEBGPIPv6.golden
@@ -32,7 +32,6 @@ router bgp 64512
     neighbor eth1 activate
     neighbor eth1 allowas-in
     advertise-all-vni
-    advertise-svi-ip
   exit-address-family
 exit
 !

--- a/internal/frr/testdata/TestBasic.golden
+++ b/internal/frr/testdata/TestBasic.golden
@@ -30,7 +30,6 @@ router bgp 64512
     neighbor 192.168.1.2 activate
     neighbor 192.168.1.2 allowas-in
     advertise-all-vni
-    advertise-svi-ip
   exit-address-family
 exit
 !

--- a/internal/frr/testdata/TestBasicWithASNRT.golden
+++ b/internal/frr/testdata/TestBasicWithASNRT.golden
@@ -30,7 +30,6 @@ router bgp 64512
     neighbor 192.168.1.2 activate
     neighbor 192.168.1.2 allowas-in
     advertise-all-vni
-    advertise-svi-ip
   exit-address-family
 exit
 !

--- a/internal/frr/testdata/TestBasicWithIPRT.golden
+++ b/internal/frr/testdata/TestBasicWithIPRT.golden
@@ -30,7 +30,6 @@ router bgp 64512
     neighbor 192.168.1.2 activate
     neighbor 192.168.1.2 allowas-in
     advertise-all-vni
-    advertise-svi-ip
   exit-address-family
 exit
 !

--- a/internal/frr/testdata/TestDualStack.golden
+++ b/internal/frr/testdata/TestDualStack.golden
@@ -30,7 +30,6 @@ router bgp 64512
     neighbor 192.168.1.2 activate
     neighbor 192.168.1.2 allowas-in
     advertise-all-vni
-    advertise-svi-ip
   exit-address-family
 exit
 !

--- a/internal/frr/testdata/TestDualStackWithRT.golden
+++ b/internal/frr/testdata/TestDualStackWithRT.golden
@@ -30,7 +30,6 @@ router bgp 64512
     neighbor 192.168.1.2 activate
     neighbor 192.168.1.2 allowas-in
     advertise-all-vni
-    advertise-svi-ip
   exit-address-family
 exit
 !

--- a/internal/frr/testdata/TestEBGPMultiHopWithTTL.golden
+++ b/internal/frr/testdata/TestEBGPMultiHopWithTTL.golden
@@ -26,7 +26,6 @@ router bgp 64512
 
   address-family l2vpn evpn
     advertise-all-vni
-    advertise-svi-ip
   exit-address-family
 exit
 !

--- a/internal/frr/testdata/TestExternal.golden
+++ b/internal/frr/testdata/TestExternal.golden
@@ -30,7 +30,6 @@ router bgp 64512
     neighbor 192.168.1.2 activate
     neighbor 192.168.1.2 allowas-in
     advertise-all-vni
-    advertise-svi-ip
   exit-address-family
 exit
 !

--- a/internal/frr/testdata/TestGracefulRestart.golden
+++ b/internal/frr/testdata/TestGracefulRestart.golden
@@ -29,7 +29,6 @@ router bgp 64512
 
   address-family l2vpn evpn
     advertise-all-vni
-    advertise-svi-ip
   exit-address-family
 exit
 !

--- a/internal/frr/testdata/TestGracefulRestartCustomTimers.golden
+++ b/internal/frr/testdata/TestGracefulRestartCustomTimers.golden
@@ -29,7 +29,6 @@ router bgp 64512
 
   address-family l2vpn evpn
     advertise-all-vni
-    advertise-svi-ip
   exit-address-family
 exit
 !

--- a/internal/frr/testdata/TestIPv6Only.golden
+++ b/internal/frr/testdata/TestIPv6Only.golden
@@ -36,7 +36,6 @@ router bgp 64512
     neighbor 2001:db8::2 activate
     neighbor 2001:db8::2 allowas-in
     advertise-all-vni
-    advertise-svi-ip
   exit-address-family
 exit
 !

--- a/internal/frr/testdata/TestIPv6OnlyWithRT.golden
+++ b/internal/frr/testdata/TestIPv6OnlyWithRT.golden
@@ -35,7 +35,6 @@ router bgp 64512
     neighbor 2001:db8::2 activate
     neighbor 2001:db8::2 allowas-in
     advertise-all-vni
-    advertise-svi-ip
   exit-address-family
 exit
 !

--- a/internal/frr/testdata/TestInternal.golden
+++ b/internal/frr/testdata/TestInternal.golden
@@ -29,7 +29,6 @@ router bgp 64512
   address-family l2vpn evpn
     neighbor 192.168.1.2 activate
     advertise-all-vni
-    advertise-svi-ip
   exit-address-family
 exit
 !

--- a/internal/frr/testdata/TestL3VNIWithLocalNeighborAndRedistributeConnected.golden
+++ b/internal/frr/testdata/TestL3VNIWithLocalNeighborAndRedistributeConnected.golden
@@ -30,7 +30,6 @@ router bgp 64512
     neighbor 192.168.1.2 activate
     neighbor 192.168.1.2 allowas-in
     advertise-all-vni
-    advertise-svi-ip
   exit-address-family
 exit
 !

--- a/internal/frr/testdata/TestL3VNIWithoutLocalNeighborAndAdvertise.golden
+++ b/internal/frr/testdata/TestL3VNIWithoutLocalNeighborAndAdvertise.golden
@@ -30,7 +30,6 @@ router bgp 64512
     neighbor 192.168.1.2 activate
     neighbor 192.168.1.2 allowas-in
     advertise-all-vni
-    advertise-svi-ip
   exit-address-family
 exit
 !

--- a/internal/frr/testdata/TestNoVNIs.golden
+++ b/internal/frr/testdata/TestNoVNIs.golden
@@ -25,7 +25,6 @@ router bgp 64512
 
   address-family l2vpn evpn
     advertise-all-vni
-    advertise-svi-ip
   exit-address-family
 exit
 !

--- a/internal/frr/testdata/TestSegmentRoutingWithL2VNI.golden
+++ b/internal/frr/testdata/TestSegmentRoutingWithL2VNI.golden
@@ -45,7 +45,6 @@ router bgp 65000
     neighbor 2001:db8:192:168:1::1 activate
     neighbor 2001:db8:192:168:1::1 allowas-in
     advertise-all-vni
-    advertise-svi-ip
   exit-address-family
   address-family ipv4 vpn
     neighbor 2001:db8:192:168:1::1 activate

--- a/internal/frr/testdata/TestTunnelEndpointConfig.golden
+++ b/internal/frr/testdata/TestTunnelEndpointConfig.golden
@@ -34,7 +34,6 @@ router bgp 64512
     neighbor 192.168.1.2 activate
     neighbor 192.168.1.2 allowas-in
     advertise-all-vni
-    advertise-svi-ip
   exit-address-family
 exit
 !


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

`advertise-svi-ip` is documented for VTEPs that have unique SVI IPs. We
deploy the opposite: every node's L2VNI bridge carries the same gateway IP
and, since 43a163a6, the same MAC, so that a VM keeps its gateway when it
migrates. That is a distributed anycast gateway.

Advertised as a plain SVI MAC-IP, each node receives its own gateway MAC and
IP from every peer and treats it as a host that moved:

```
BGP: evicting local evpn prefix [2]:...:[32]:[192.171.24.1] as remote won
```

Nothing needs the advertisement: the gateway is local on every node, so
workloads always resolve it locally.

It also avoids FRRouting/frr#22884.

**Special notes for your reviewer**:
Closes https://github.com/openperouter/openperouter/issues/632
Closes https://github.com/FRRouting/frr/issues/22061

**Release note**:

```release-note
Do not add advertise-svi-ip in the generated frr configuration as it's not needed (ip and mac are the same at all nodes) and triggers crash on zebra.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated EVPN routing configuration to stop advertising SVI IP addresses.
  - Retained advertisement of all configured VNIs, preserving EVPN route distribution behavior.

- **Tests**
  - Updated configuration validation coverage across BFD, BGP, dual-stack, IPv6, VNI, and restart scenarios to reflect the revised EVPN output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->