### PR TITLE
test(e2etests): add testNamespace to dumpIfFails in SRv6 tests

### DIFF
--- a/e2etests/tests/l3vpn_l2.go
+++ b/e2etests/tests/l3vpn_l2.go
@@ -165,7 +165,7 @@ var _ = Describe("SRV6 routes between bgp and the fabric", Ordered, func() {
 	})
 
 	AfterEach(func() {
-		dumpIfFails(cs)
+		dumpIfFails(cs, testNamespace)
 		Expect(infra.LeafSRV6Config.Reset()).To(Succeed())
 		Expect(Updater.CleanButUnderlay()).To(Succeed())
 		Expect(k8s.DeleteNamespace(cs, testNamespace)).To(Succeed())

--- a/e2etests/tests/l3vpn_routes.go
+++ b/e2etests/tests/l3vpn_routes.go
@@ -355,7 +355,7 @@ var _ = Describe("SRV6 routes between bgp and the fabric", Ordered, func() {
 		})
 
 		AfterEach(func() {
-			dumpIfFails(cs)
+			dumpIfFails(cs, testNamespace)
 		})
 
 		DescribeTable("should be able to reach the hosts from the test pod and vice versa", func(
@@ -536,7 +536,7 @@ var _ = Describe("SRV6 routes between bgp and the fabric with iBGP testing e2e i
 	})
 
 	AfterEach(func() {
-		dumpIfFails(cs)
+		dumpIfFails(cs, testNamespace)
 
 		By("Deleting the test namespace")
 		Expect(k8s.DeleteNamespace(cs, testNamespace)).To(Succeed())


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:

SRv6 tests were missing testNamespace in dumpIfFails(). Add this
where possible to get the inside view of the test pods, as well.

**Special notes for your reviewer**:

**Release note**:

```release-note
None
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit BGP connection, keepalive, hold, and advertisement timers across supported routing configurations.
  * Improved consistency of BGP session timing for IPv4, IPv6, unnumbered, SRv6, EVPN, and VRF deployments.

* **Tests**
  * Improved failure diagnostics for L3VPN integration tests.
  * Failure dumps now target the relevant test namespace, making troubleshooting more precise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->