### PR TITLE
[DNM] feat(clab): add a second worker to the singlecluster topology

### DIFF
--- a/Dockerfile.grout
+++ b/Dockerfile.grout
@@ -75,9 +75,9 @@ RUN groupadd -r -g 92 frr && \
     usermod -a -G frrvty frr
 
 RUN RPMARCH=$(case ${TARGETARCH} in amd64) echo x86_64;; arm64) echo aarch64;; *) echo ${TARGETARCH};; esac) && \
-    curl -fsSL -o /tmp/frr.rpm https://github.com/DPDK/grout/releases/download/v0.16.0/frr.${RPMARCH}.rpm && \
-    curl -fsSL -o /tmp/grout-frr.rpm https://github.com/DPDK/grout/releases/download/v0.16.0/grout-frr.${RPMARCH}.rpm && \
-    curl -fsSL -o /tmp/grout.rpm https://github.com/DPDK/grout/releases/download/v0.16.0/grout.${RPMARCH}.rpm && \
+    curl -fsSL -o /tmp/frr.rpm https://github.com/DPDK/grout/releases/download/edge/frr.${RPMARCH}.rpm && \
+    curl -fsSL -o /tmp/grout-frr.rpm https://github.com/DPDK/grout/releases/download/edge/grout-frr.${RPMARCH}.rpm && \
+    curl -fsSL -o /tmp/grout.rpm https://github.com/DPDK/grout/releases/download/edge/grout.${RPMARCH}.rpm && \
     dnf install -y /tmp/*.rpm && dnf clean all && rm -rf /tmp/*.rpm
 
 COPY --from=builder /go/openperouter/reloader .

--- a/clab/clean.sh
+++ b/clab/clean.sh
@@ -63,6 +63,18 @@ for iface in $(ip link show | awk -F': ' '/^[0-9]+: leafkind/ {print $2}' | cut 
     fi
 done
 
+# containerlab wires the kind nodes through veths named clab-<hash>. It removes
+# them on destroy, but only for nodes it knows about: if the kind cluster failed
+# to come up, "clab destroy" reports "no containerlab containers found" and the
+# veths are left dangling in the host namespace. Deleting one end drops the pair.
+echo "=== Cleaning up leftover containerlab veths ==="
+for iface in $(ip -br link show type veth | awk '{print $1}' | cut -d'@' -f1 | grep -E '^clab-' || true); do
+    if [[ -d "/sys/class/net/${iface}" ]]; then
+        echo "Removing veth: ${iface}"
+        sudo ip link delete ${iface} 2>/dev/null || true
+    fi
+done
+
 echo "=== Cleaning up kubeconfig files ==="
 rm -f "${KUBECONFIG_PATH}*" || true
 

--- a/clab/common.sh
+++ b/clab/common.sh
@@ -51,8 +51,22 @@ load_local_image_to_kind() {
     local image_tag=$1
     local file_name=$2
     local temp_file="/tmp/${file_name}.tar"
+    local save_opts=()
+
+    # When docker uses the containerd image store, "docker save" writes an OCI
+    # archive whose index points at the whole multi-platform manifest list,
+    # while only the platform we pulled has its blobs present locally. "kind
+    # load image-archive" then runs "ctr images import --all-platforms", which
+    # tries to resolve every referenced manifest and fails with
+    #   ctr: content digest sha256:...: not found
+    # Restricting the archive to the platform we actually pulled keeps the
+    # index single-manifest and imports cleanly.
+    if [[ $CONTAINER_ENGINE == "docker" ]] && docker save --help 2>&1 | grep -q -- '--platform'; then
+        save_opts=(--platform "${PLATFORM}")
+    fi
+
     rm -f ${temp_file}
-    ${CONTAINER_ENGINE_CLI} save -o ${temp_file} ${image_tag}
+    ${CONTAINER_ENGINE_CLI} save "${save_opts[@]}" -o ${temp_file} ${image_tag}
     ${KIND_COMMAND} load image-archive ${temp_file} --name ${KIND_CLUSTER_NAME}
     load_image_to_podman_on_nodes ${image_tag} ${file_name}
 }

--- a/clab/scripts/03-kind-configs.sh
+++ b/clab/scripts/03-kind-configs.sh
@@ -29,6 +29,15 @@ generate_kind_configs() {
     echo "=== Kind configuration generation diagnostics ==="
     echo "NODE_IMAGE environment variable: ${NODE_IMAGE:-<not set>}"
 
+    # The singlecluster topology wires two workers so the control plane can act as
+    # a pure non forwarding route reflector, the multicluster labs keep a single worker.
+    if [[ ${#CLUSTER_NAMES[@]} -eq 1 ]]; then
+        KIND_WORKERS=${KIND_WORKERS:-2}
+    else
+        KIND_WORKERS=${KIND_WORKERS:-1}
+    fi
+    echo "Worker nodes per cluster: ${KIND_WORKERS}"
+
     for cluster_name in "${CLUSTER_NAMES[@]}"; do
         KIND_CONFIG_NAME="${cluster_name}-configuration-registry.yaml"
 
@@ -40,7 +49,7 @@ generate_kind_configs() {
         fi
         go run generate_kind_config/generate_kind_config.go \
             --template generate_kind_config/kind_template/kind-configuration-registry.yaml.template \
-            $KIND_CONFIG_ARGS -cluster-name "${cluster_name}" -output "../${KIND_CONFIG_NAME}"
+            $KIND_CONFIG_ARGS -cluster-name "${cluster_name}" -workers "${KIND_WORKERS}" -output "../${KIND_CONFIG_NAME}"
 
         echo "Generated configuration file content:"
         cat "../${KIND_CONFIG_NAME}"

--- a/clab/singlecluster/check-veths.yaml
+++ b/clab/singlecluster/check-veths.yaml
@@ -13,11 +13,19 @@ interfaces:
     requiresTemp: true
 - left:
     bridge: "leafkind1-sw"
-    name: "kindworker1"
+    name: "kindwrk1sw1"
   right:
     container: "pe-kind-worker"
     name: "toswitch1"
     ips: ["192.168.11.4/24", "2001:db8:11::4/64"]
+    requiresTemp: true
+- left:
+    bridge: "leafkind1-sw"
+    name: "kindwrk2sw1"
+  right:
+    container: "pe-kind-worker2"
+    name: "toswitch1"
+    ips: ["192.168.11.5/24", "2001:db8:11::5/64"]
     requiresTemp: true
 
 # leafkind2-sw bridge connections
@@ -31,11 +39,19 @@ interfaces:
     requiresTemp: true
 - left:
     bridge: "leafkind2-sw"
-    name: "kindworker2"
+    name: "kindwrk1sw2"
   right:
     container: "pe-kind-worker"
     name: "toswitch2"
     ips: ["192.168.12.4/24", "2001:db8:12::4/64"]
+    requiresTemp: true
+- left:
+    bridge: "leafkind2-sw"
+    name: "kindwrk2sw2"
+  right:
+    container: "pe-kind-worker2"
+    name: "toswitch2"
+    ips: ["192.168.12.5/24", "2001:db8:12::5/64"]
     requiresTemp: true
 
 # Point to point links for IPv6 unnumbered BGP sessions - leafkind1
@@ -44,6 +60,13 @@ interfaces:
     name: "tokindworker"
   right:
     container: "pe-kind-worker"
+    name: "toleafkind1"
+    requiresTemp: true
+- left:
+    container: "clab-kind-leafkind1"
+    name: "tokindworker2"
+  right:
+    container: "pe-kind-worker2"
     name: "toleafkind1"
     requiresTemp: true
 - left:
@@ -60,6 +83,13 @@ interfaces:
     name: "tokindworker"
   right:
     container: "pe-kind-worker"
+    name: "toleafkind2"
+    requiresTemp: true
+- left:
+    container: "clab-kind-leafkind2"
+    name: "tokindworker2"
+  right:
+    container: "pe-kind-worker2"
     name: "toleafkind2"
     requiresTemp: true
 - left:

--- a/clab/singlecluster/ip_map.txt
+++ b/clab/singlecluster/ip_map.txt
@@ -12,12 +12,16 @@ pe-kind-control-plane,toswitch1,192.168.11.3/24
 pe-kind-control-plane,toswitch1,2001:db8:11::3/64
 pe-kind-worker,toswitch1,192.168.11.4/24
 pe-kind-worker,toswitch1,2001:db8:11::4/64
+pe-kind-worker2,toswitch1,192.168.11.5/24
+pe-kind-worker2,toswitch1,2001:db8:11::5/64
 clab-kind-leafkind2,toswitch2,192.168.12.2/24
 clab-kind-leafkind2,toswitch2,2001:db8:12::2/64
 pe-kind-control-plane,toswitch2,192.168.12.3/24
 pe-kind-control-plane,toswitch2,2001:db8:12::3/64
 pe-kind-worker,toswitch2,192.168.12.4/24
 pe-kind-worker,toswitch2,2001:db8:12::4/64
+pe-kind-worker2,toswitch2,192.168.12.5/24
+pe-kind-worker2,toswitch2,2001:db8:12::5/64
 clab-kind-leafA,ethred,192.168.20.1/24
 clab-kind-leafA,ethred,2001:db8:20::1/64
 clab-kind-hostA_red,eth1,192.168.20.2/24

--- a/clab/singlecluster/kind.clab.yml
+++ b/clab/singlecluster/kind.clab.yml
@@ -92,6 +92,8 @@ topology:
       kind: ext-container
     pe-kind-worker:
       kind: ext-container
+    pe-kind-worker2:
+      kind: ext-container
 
   links:
     - endpoints: ["leafA:eth1", "spine:eth1"]
@@ -112,11 +114,15 @@ topology:
     # Point to point links for IPv6 unnumbered BGP sessions.
     - endpoints: ["leafkind1:tokindworker", "pe-kind-worker:toleafkind1"]
     - endpoints: ["leafkind2:tokindworker", "pe-kind-worker:toleafkind2"]
+    - endpoints: ["leafkind1:tokindworker2", "pe-kind-worker2:toleafkind1"]
+    - endpoints: ["leafkind2:tokindworker2", "pe-kind-worker2:toleafkind2"]
     - endpoints: ["leafkind1:tokindctrlpl", "pe-kind-control-plane:toleafkind1"]
     - endpoints: ["leafkind2:tokindctrlpl", "pe-kind-control-plane:toleafkind2"]
 
     # All kind nodes connect to both leaf switches for redundancy
     - endpoints: ["pe-kind-control-plane:toswitch1", "leafkind1-sw:kindctrlpl1"]
-    - endpoints: ["pe-kind-worker:toswitch1", "leafkind1-sw:kindworker1"]
+    - endpoints: ["pe-kind-worker:toswitch1", "leafkind1-sw:kindwrk1sw1"]
+    - endpoints: ["pe-kind-worker2:toswitch1", "leafkind1-sw:kindwrk2sw1"]
     - endpoints: ["pe-kind-control-plane:toswitch2", "leafkind2-sw:kindctrlpl2"]
-    - endpoints: ["pe-kind-worker:toswitch2", "leafkind2-sw:kindworker2"]
+    - endpoints: ["pe-kind-worker:toswitch2", "leafkind2-sw:kindwrk1sw2"]
+    - endpoints: ["pe-kind-worker2:toswitch2", "leafkind2-sw:kindwrk2sw2"]

--- a/clab/tools/generate_kind_config/generate_kind_config.go
+++ b/clab/tools/generate_kind_config/generate_kind_config.go
@@ -14,6 +14,9 @@ type KindConfig struct {
 	DisableDefaultCNI bool
 	ClusterName       string
 	NodeImage         string
+	// Workers is only used to repeat the worker node block in the template,
+	// its elements carry no data.
+	Workers []struct{}
 }
 
 func main() {
@@ -21,11 +24,16 @@ func main() {
 		disableDefaultCNI = flag.Bool("disable-default-cni", false, "Disable default CNI in kind config")
 		clusterName       = flag.String("cluster-name", "pe-kind", "Name of the kind cluster")
 		nodeImage         = flag.String("node-image", os.Getenv("NODE_IMAGE"), "Kind node image to use")
+		workers           = flag.Int("workers", 1, "Number of worker nodes in the kind cluster")
 		outputFile        = flag.String("output", "../kind-configuration-registry.yaml", "Kind configuration output file")
 		templateFile      = flag.String("template",
 			"../kind_template/kind-configuration-registry.yaml.template", "Kind template file path")
 	)
 	flag.Parse()
+
+	if *workers < 0 {
+		log.Fatalf("Invalid number of workers: %d", *workers)
+	}
 
 	tmplContent, err := os.ReadFile(*templateFile)
 	if err != nil {
@@ -41,6 +49,7 @@ func main() {
 		DisableDefaultCNI: *disableDefaultCNI,
 		ClusterName:       *clusterName,
 		NodeImage:         *nodeImage,
+		Workers:           make([]struct{}, *workers),
 	}
 
 	outputDir := filepath.Dir(*outputFile)

--- a/clab/tools/generate_kind_config/kind_template/kind-configuration-registry.yaml.template
+++ b/clab/tools/generate_kind_config/kind_template/kind-configuration-registry.yaml.template
@@ -10,6 +10,10 @@ nodes:
 {{- if .NodeImage }}
   image: {{.NodeImage}}
 {{- end }}
+- role: worker
+{{- if .NodeImage }}
+  image: {{.NodeImage}}
+{{- end }}
 networking:
 {{- if .DisableDefaultCNI }}
   disableDefaultCNI: true

--- a/clab/tools/generate_kind_config/kind_template/kind-configuration-registry.yaml.template
+++ b/clab/tools/generate_kind_config/kind_template/kind-configuration-registry.yaml.template
@@ -6,13 +6,11 @@ nodes:
 {{- if .NodeImage }}
   image: {{.NodeImage}}
 {{- end }}
+{{- range .Workers }}
 - role: worker
-{{- if .NodeImage }}
-  image: {{.NodeImage}}
+{{- if $.NodeImage }}
+  image: {{$.NodeImage}}
 {{- end }}
-- role: worker
-{{- if .NodeImage }}
-  image: {{.NodeImage}}
 {{- end }}
 networking:
 {{- if .DisableDefaultCNI }}

--- a/e2etests/pkg/infra/leaf.go
+++ b/e2etests/pkg/infra/leaf.go
@@ -58,12 +58,14 @@ var (
 		SpinePeerAddress:  "192.168.1.4",
 		Container:         KindLeaf1Container,
 		ToSwitchInterface: "toswitch1",
+		ISISNet:           "49.0001.0000.0000.0004.00",
 	}
 	LeafKind2Config = LeafKind{
 		ASN:               64513,
 		SpinePeerAddress:  "192.168.1.6",
 		Container:         KindLeaf2Container,
 		ToSwitchInterface: "toswitch2",
+		ISISNet:           "49.0001.0000.0000.0005.00",
 	}
 
 	EmptyLeafConfig = LeafConfiguration{
@@ -97,6 +99,7 @@ type LeafKindConfiguration struct {
 	ASN                   int
 	SpinePeerAddress      string
 	ToSwitchInterface     string
+	ISISNet               string
 	EnableBFD             bool
 	RedistributeConnected bool
 	Neighbors             []Neighbor
@@ -140,6 +143,10 @@ type LeafKind struct {
 	ASN               int
 	SpinePeerAddress  string
 	ToSwitchInterface string
+	// ISISNet must match the net the clab topology assigns to this leaf. Every
+	// leaf in the area needs its own system ID: two leaves sharing one makes
+	// them fight over the same LSP forever, which stops ISIS from converging.
+	ISISNet string
 	frr.Container
 }
 
@@ -230,6 +237,9 @@ func (l LeafKind) UpdateConfig(nodes []corev1.Node, config LeafKindConfiguration
 	if config.ToSwitchInterface == "" {
 		config.ToSwitchInterface = l.ToSwitchInterface
 	}
+	if config.ISISNet == "" {
+		config.ISISNet = l.ISISNet
+	}
 
 	neighbors := []Neighbor{}
 	for _, node := range nodes {
@@ -272,6 +282,9 @@ func (l LeafKind) Configure(config LeafKindConfiguration) error {
 	}
 	if config.ToSwitchInterface == "" {
 		config.ToSwitchInterface = l.ToSwitchInterface
+	}
+	if config.ISISNet == "" {
+		config.ISISNet = l.ISISNet
 	}
 
 	configString, err := LeafKindConfigToFRR(config)

--- a/e2etests/pkg/infra/routers.go
+++ b/e2etests/pkg/infra/routers.go
@@ -55,6 +55,9 @@ func init() {
 	addLinkIPs("clab-kind-leafkind1", "pe-kind-worker", "192.168.11.2", "192.168.11.4")
 	addLinkIPv6s("clab-kind-leafkind1", "pe-kind-worker", "2001:db8:11::2", "2001:db8:11::4")
 	addLinkInterfaces("clab-kind-leafkind1", "pe-kind-worker", "tokindworker", "toleafkind1")
+	addLinkIPs("clab-kind-leafkind1", "pe-kind-worker2", "192.168.11.2", "192.168.11.5")
+	addLinkIPv6s("clab-kind-leafkind1", "pe-kind-worker2", "2001:db8:11::2", "2001:db8:11::5")
+	addLinkInterfaces("clab-kind-leafkind1", "pe-kind-worker2", "tokindworker2", "toleafkind1")
 	addLinkIPs("clab-kind-leafkind1", "clab-kind-spine", "192.168.1.5", "192.168.1.4")
 
 	// leafkind2 links - bridge connections use toswitch2
@@ -64,6 +67,9 @@ func init() {
 	addLinkIPs("clab-kind-leafkind2", "pe-kind-worker", "192.168.12.2", "192.168.12.4")
 	addLinkIPv6s("clab-kind-leafkind2", "pe-kind-worker", "2001:db8:12::2", "2001:db8:12::4")
 	addLinkInterfaces("clab-kind-leafkind2", "pe-kind-worker", "tokindworker", "toleafkind2")
+	addLinkIPs("clab-kind-leafkind2", "pe-kind-worker2", "192.168.12.2", "192.168.12.5")
+	addLinkIPv6s("clab-kind-leafkind2", "pe-kind-worker2", "2001:db8:12::2", "2001:db8:12::5")
+	addLinkInterfaces("clab-kind-leafkind2", "pe-kind-worker2", "tokindworker2", "toleafkind2")
 	addLinkIPs("clab-kind-leafkind2", "clab-kind-spine", "192.168.1.7", "192.168.1.6")
 
 	// Other leaf links

--- a/e2etests/pkg/infra/testdata/leafkind.tmpl
+++ b/e2etests/pkg/infra/testdata/leafkind.tmpl
@@ -68,7 +68,7 @@ exit
 router isis ISIS
   is-type level-1
   advertise-passive-only
-  net 49.0001.0000.0000.0004.00
+  net {{ .ISISNet }}
 exit
 !
 interface eth1

--- a/e2etests/tests/evpn_l2.go
+++ b/e2etests/tests/evpn_l2.go
@@ -26,8 +26,11 @@ import (
 )
 
 var _ = Describe("Routes between bgp and the fabric with Underlay in ipv4", Ordered, func() {
-	var cs clientset.Interface
-	var routers openperouter.Routers
+	var (
+		cs      clientset.Interface
+		routers openperouter.Routers
+		nodes   []corev1.Node
+	)
 
 	vniRed := v1alpha1.L3VNI{
 		ObjectMeta: metav1.ObjectMeta{
@@ -80,10 +83,10 @@ var _ = Describe("Routes between bgp and the fabric with Underlay in ipv4", Orde
 		Expect(err).NotTo(HaveOccurred())
 
 		// Create pre-existing OVS bridges on Kind nodes for testing
-		nodes := []string{infra.KindControlPlane, infra.KindWorker}
-		for _, nodeName := range nodes {
-			exec := executor.ForContainer(nodeName)
-			// Create OVS bridge (ignore error if bridge already exists)
+		nodes, err = k8s.GetNodes(cs)
+		Expect(err).NotTo(HaveOccurred())
+		for _, node := range nodes {
+			exec := executor.ForContainer(node.Name)
 			_, err = exec.Exec("ovs-vsctl", "add-br", preExistingOVSBridge)
 			Expect(err).NotTo(HaveOccurred())
 		}
@@ -101,10 +104,8 @@ var _ = Describe("Routes between bgp and the fabric with Underlay in ipv4", Orde
 			return openperouter.AreReady(routers)
 		}, 2*time.Minute, time.Second).ShouldNot(HaveOccurred())
 
-		// Clean up pre-existing OVS bridges
-		nodes := []string{infra.KindControlPlane, infra.KindWorker}
-		for _, nodeName := range nodes {
-			exec := executor.ForContainer(nodeName)
+		for _, node := range nodes {
+			exec := executor.ForContainer(node.Name)
 			_, err = exec.Exec("ovs-vsctl", "--if-exists", "del-br", preExistingOVSBridge)
 			Expect(err).NotTo(HaveOccurred())
 		}

--- a/e2etests/tests/resiliency.go
+++ b/e2etests/tests/resiliency.go
@@ -734,7 +734,7 @@ func dumpUnderlayVeths(cs clientset.Interface, label string) {
 		}
 	}
 
-	for _, port := range []string{"kindctrlpl1", "kindworker1", "kindctrlpl2", "kindworker2"} {
+	for _, port := range []string{"kindctrlpl1", "kindwrk1sw1", "kindwrk2sw1", "kindctrlpl2", "kindwrk1sw2", "kindwrk2sw2"} {
 		out, err := executor.Host.Exec("ip", "-d", "link", "show", port)
 		if err != nil {
 			w.Printf("DIAG [%s]: bridge port %s: not found\n", label, port)


### PR DESCRIPTION
The route reflector test needs two workers so the control plane can act as a pure non forwarding reflector. Wire pe-kind-worker2 into the singlecluster topology following the existing addressing scheme. The multicluster labs keep a single worker.


<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single-cluster test environments now support a second worker node with IPv4, IPv6, and unnumbered BGP connectivity.
  * Worker counts can be configured when generating cluster environments, with topology-aware defaults.
  * Leaf configurations now support distinct IS-IS network identifiers.

* **Bug Fixes**
  * Improved cleanup removes dangling virtual interfaces after topology teardown.
  * Container image loading now better respects the target platform.
  * End-to-end tests dynamically discover nodes and support expanded worker topologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->