### PR TITLE
fix(controller): handle CNI config mismatch on underlay recreate

### DIFF
--- a/internal/hostnetwork/underlay.go
+++ b/internal/hostnetwork/underlay.go
@@ -135,7 +135,9 @@ func SetupUnderlayNetDevInterface(ctx context.Context, ns netns.NsHandle,
 
 // SetupUnderlayCNIDevInterface provisions a single underlay cni dev interface.
 // A CNI CHECK runs first and, if it fails, the interface is torn down so the
-// subsequent Add provisions it fresh.
+// subsequent Add provisions it fresh. When the cached CNI config differs from
+// the requested one (e.g. after a delete-and-recreate with different IPAM),
+// the stale attachment is removed and the Add is retried.
 func SetupUnderlayCNIDevInterface(ctx context.Context, ns string,
 	iface UnderlayInterface) error {
 	if err := cniinvoker.Invoker.Check(ctx, iface.InterfaceName); err != nil {
@@ -146,12 +148,22 @@ func SetupUnderlayCNIDevInterface(ctx context.Context, ns string,
 		}
 	}
 
-	if err := cniinvoker.Invoker.Add(ctx, cniinvoker.AddParams{
+	addParams := cniinvoker.AddParams{
 		Config:         iface.CNI.Config,
 		NetNS:          ns,
 		IfName:         iface.InterfaceName,
 		CapabilityArgs: iface.CNI.CapabilityArgs,
-	}); err != nil {
+	}
+	err := cniinvoker.Invoker.Add(ctx, addParams)
+	if errors.As(err, &cniinvoker.ConfigMismatchError{}) {
+		slog.WarnContext(ctx, "cni config changed, rebuilding underlay cni device",
+			"interface", iface.InterfaceName)
+		if delErr := cniinvoker.Invoker.Del(ctx, iface.InterfaceName); delErr != nil {
+			return fmt.Errorf("failed to delete mismatched underlay cni device %s: %w", iface.InterfaceName, delErr)
+		}
+		err = cniinvoker.Invoker.Add(ctx, addParams)
+	}
+	if err != nil {
 		return fmt.Errorf("failed to setup underlay cni device %s: %w", iface.InterfaceName, err)
 	}
 	return nil

--- a/internal/hostnetwork/underlay_cnidev_test.go
+++ b/internal/hostnetwork/underlay_cnidev_test.go
@@ -243,6 +243,33 @@ var _ = Describe("Underlay CNI configuration", func() {
 		Expect(loggedCommands()).To(ConsistOf("ADD net1", "DEL net1"))
 	})
 
+	It("rebuilds the cni interface when the config changes", func() {
+		Expect(SetupUnderlay(context.Background(), cniParams("net1"))).To(Succeed())
+
+		// Build a second config with a different network name so the
+		// cached attachment does not match, simulating a delete-and-
+		// recreate with different IPAM (e.g. static -> dhcp).
+		altConfig := fmt.Sprintf(`{
+		  "cniVersion": "1.0.0",
+		  "name": "underlay-cni-alt",
+		  "plugins": [{"type": %q}]
+		}`, underlayCNITestPlugin)
+		altParams := UnderlayParams{
+			TargetNS: underlayCNITestNSPath(),
+			UnderlayInterfaces: []UnderlayInterface{{
+				InterfaceName: "net1",
+				Kind:          UnderlayInterfaceCNIDev,
+				CNI:           &CNIDeviceParams{Config: []byte(altConfig)},
+			}},
+		}
+		Expect(SetupUnderlay(context.Background(), altParams)).To(Succeed())
+
+		Expect(loggedCommands()).To(HaveExactElements(
+			"ADD net1", "CHECK net1", "DEL net1", "ADD net1"),
+			"a config mismatch should tear down and re-provision the interface")
+		validateCNIInterfaceInNS(testNs, "net1")
+	})
+
 	It("provisions again after the namespace is rebuilt and the cache cleared", func() {
 		Expect(SetupUnderlay(context.Background(), cniParams("net1"))).To(Succeed())
 


### PR DESCRIPTION


<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:


Error found in   [FAIL] Routes between bgp and the fabric with Underlay in ipv4 MacvlanDHCP with vnis and frr-k8s [BeforeEach] translates EVPN incoming routes as BGP routes

https://github.com/openperouter/openperouter/actions/runs/30977939400/job/92217350377?pr=509



When an underlay is deleted and recreated with a different CNI config (e.g. static -> dhcp IPAM) for the same interface name, the reconciler can miss the cleanup path. The test deletes old underlays and creates new ones sequentially, but the reconciler is async: by the time it processes the queued delete event, getConfigFromAPI() reads current state which already has the new underlays. Since len(config.Underlays) > 0, restoreUnderlay() is never called and the stale CNI cache entry is never removed.

From the CI logs on worker2: the reconcile for underlay-cni-1 (deleted) found underlay-dhcp-* already in the API. SetupUnderlay tried to provision "underlay0" with DHCP config but the cache held the old static config, producing 265 ConfigMismatchError loops that prevented VRF creation and blocked all BGP sessions on that node.

Handle this by deleting the old attachment and retrying Add when a config mismatch is detected.


**Special notes for your reviewer**:

The way we handle the scenario is debatable, and the scenario itself is related to a very specific edge case which is, quick deletion and recreation of two underlays with the same interface name. We could probably workaround this by using a different interface name per test

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Bug: if the delete of a previous underlay and the add of a new one are squashed together, and both use CNI but with a different configuration, the underlay is not processed.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically detects mismatched network interface configurations.
  * Removes stale interface settings and provisions the interface again with the updated configuration.
  * Reports errors if cleanup or re-provisioning fails.

* **Tests**
  * Added coverage for updating an interface after its configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->