### PR TITLE
test(e2etests): change clab and underlay BGP timers

### DIFF
--- a/clab/multicluster/spine/frr.conf
+++ b/clab/multicluster/spine/frr.conf
@@ -21,11 +21,20 @@ router bgp 64612
  no bgp ebgp-requires-policy
  no bgp network import-check
  no bgp default ipv4-unicast
+ timers bgp 3 9
 
  neighbor 192.168.1.1 remote-as 64520
+ neighbor 192.168.1.1 advertisement-interval 0
+ neighbor 192.168.1.1 timers connect 5
  neighbor 192.168.1.3 remote-as 64520
+ neighbor 192.168.1.3 advertisement-interval 0
+ neighbor 192.168.1.3 timers connect 5
  neighbor 192.168.1.5 remote-as 64512
+ neighbor 192.168.1.5 advertisement-interval 0
+ neighbor 192.168.1.5 timers connect 5
  neighbor 192.168.1.7 remote-as 64516
+ neighbor 192.168.1.7 advertisement-interval 0
+ neighbor 192.168.1.7 timers connect 5
 
  address-family ipv4 unicast
   neighbor 192.168.1.1 activate

--- a/clab/singlecluster/spine/frr.conf
+++ b/clab/singlecluster/spine/frr.conf
@@ -21,11 +21,20 @@ router bgp 64612
  no bgp ebgp-requires-policy
  no bgp network import-check
  no bgp default ipv4-unicast
+ timers bgp 3 9
 
  neighbor 192.168.1.1 remote-as 64520
+ neighbor 192.168.1.1 advertisement-interval 0
+ neighbor 192.168.1.1 timers connect 5
  neighbor 192.168.1.3 remote-as 64520
+ neighbor 192.168.1.3 advertisement-interval 0
+ neighbor 192.168.1.3 timers connect 5
  neighbor 192.168.1.5 remote-as 64512
+ neighbor 192.168.1.5 advertisement-interval 0
+ neighbor 192.168.1.5 timers connect 5
  neighbor 192.168.1.7 remote-as 64513
+ neighbor 192.168.1.7 advertisement-interval 0
+ neighbor 192.168.1.7 timers connect 5
 
  address-family ipv4 unicast
   neighbor 192.168.1.1 activate

--- a/clab/tools/generate_leaf_config/frr_template/frr.conf.template
+++ b/clab/tools/generate_leaf_config/frr_template/frr.conf.template
@@ -33,8 +33,11 @@ router bgp 64520
  no bgp ebgp-requires-policy
  no bgp network import-check
  no bgp default ipv4-unicast
+ timers bgp 3 9
 
  neighbor {{ .NeighborIP }} remote-as 64612
+ neighbor {{ .NeighborIP }} advertisement-interval 0
+ neighbor {{ .NeighborIP }} timers connect 5
  !
  address-family ipv4 unicast
   neighbor {{ .NeighborIP }} activate
@@ -52,6 +55,7 @@ router bgp 64520
 exit
 !
 router bgp 64520 vrf red
+ timers bgp 3 9
 {{- if .RedistributeConnectedFromVRFs }}
  !
  address-family ipv4 unicast
@@ -70,6 +74,7 @@ router bgp 64520 vrf red
 exit
 !
 router bgp 64520 vrf blue
+ timers bgp 3 9
 {{- if .RedistributeConnectedFromVRFs }}
  !
  address-family ipv4 unicast

--- a/clab/tools/generate_leaf_config/frr_template/frr.srv6.conf.template
+++ b/clab/tools/generate_leaf_config/frr_template/frr.srv6.conf.template
@@ -34,12 +34,15 @@ router bgp 64520
  no bgp ebgp-requires-policy
  no bgp network import-check
  no bgp default ipv4-unicast
+ timers bgp 3 9
  !
  neighbor PE peer-group
  neighbor PE remote-as 64514
  neighbor PE update-source {{ .UpdateSource }}
  neighbor PE capability extended-nexthop
  neighbor PE ebgp-multihop
+ neighbor PE advertisement-interval 0
+ neighbor PE timers connect 5
  bgp listen range 2001:db8:1234:5678::/64 peer-group PE
  !
  segment-routing srv6
@@ -59,6 +62,7 @@ exit
 !
 router bgp 64520 vrf red
  bgp router-id {{ .RouterID }}
+ timers bgp 3 9
  sid vpn per-vrf export auto
  !
  address-family ipv4 unicast
@@ -87,6 +91,7 @@ exit
 !
 router bgp 64520 vrf blue
  bgp router-id {{ .RouterID }}
+ timers bgp 3 9
  sid vpn per-vrf export auto
  !
  address-family ipv4 unicast

--- a/clab/tools/generate_leaf_config/frr_template/leafkind.conf.template
+++ b/clab/tools/generate_leaf_config/frr_template/leafkind.conf.template
@@ -19,11 +19,16 @@ router bgp {{ .ASN }}
  no bgp ebgp-requires-policy
  no bgp network import-check
  no bgp default ipv4-unicast
+ timers bgp 3 9
 
  neighbor {{ .SpineIP }} remote-as 64612
+ neighbor {{ .SpineIP }} advertisement-interval 0
+ neighbor {{ .SpineIP }} timers connect 5
 
  neighbor kind-nodes peer-group
  neighbor kind-nodes remote-as 64514
+ neighbor kind-nodes advertisement-interval 0
+ neighbor kind-nodes timers connect 5
 
  bgp listen range {{ .IPv4ListenRange }} peer-group kind-nodes
  bgp listen range {{ .IPv6ListenRange }} peer-group kind-nodes

--- a/e2etests/pkg/infra/underlay.go
+++ b/e2etests/pkg/infra/underlay.go
@@ -35,12 +35,18 @@ var Underlay = v1alpha1.Underlay{
 		Interfaces: defaultInterfaces,
 		Neighbors: []v1alpha1.Neighbor{
 			{
-				ASN:     new(int64(64512)),
-				Address: new("192.168.11.2"),
+				ASN:                  new(int64(64512)),
+				Address:              new("192.168.11.2"),
+				ConnectTimeSeconds:   new(int64(5)),
+				KeepaliveTimeSeconds: new(int64(3)),
+				HoldTimeSeconds:      new(int64(9)),
 			},
 			{
-				ASN:     new(int64(64513)),
-				Address: new("192.168.12.2"),
+				ASN:                  new(int64(64513)),
+				Address:              new("192.168.12.2"),
+				ConnectTimeSeconds:   new(int64(5)),
+				KeepaliveTimeSeconds: new(int64(3)),
+				HoldTimeSeconds:      new(int64(9)),
 			},
 		},
 		TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
@@ -59,12 +65,18 @@ var UnderlayIPv6 = v1alpha1.Underlay{
 		Interfaces: defaultInterfaces,
 		Neighbors: []v1alpha1.Neighbor{
 			{
-				ASN:     new(int64(64512)),
-				Address: new("2001:db8:11::2"),
+				ASN:                  new(int64(64512)),
+				Address:              new("2001:db8:11::2"),
+				ConnectTimeSeconds:   new(int64(5)),
+				KeepaliveTimeSeconds: new(int64(3)),
+				HoldTimeSeconds:      new(int64(9)),
 			},
 			{
-				ASN:     new(int64(64513)),
-				Address: new("2001:db8:12::2"),
+				ASN:                  new(int64(64513)),
+				Address:              new("2001:db8:12::2"),
+				ConnectTimeSeconds:   new(int64(5)),
+				KeepaliveTimeSeconds: new(int64(3)),
+				HoldTimeSeconds:      new(int64(9)),
 			},
 		},
 		TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
@@ -88,8 +100,11 @@ var UnderlayUnnumbered = v1alpha1.Underlay{
 		},
 		Neighbors: []v1alpha1.Neighbor{
 			{
-				ASN:       new(int64(64512)),
-				Interface: new("toleafkind1"),
+				ASN:                  new(int64(64512)),
+				Interface:            new("toleafkind1"),
+				ConnectTimeSeconds:   new(int64(5)),
+				KeepaliveTimeSeconds: new(int64(3)),
+				HoldTimeSeconds:      new(int64(9)),
 			},
 		},
 		TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{
@@ -108,9 +123,12 @@ var UnderlaySRv6 = v1alpha1.Underlay{
 		Interfaces: defaultInterfaces,
 		Neighbors: []v1alpha1.Neighbor{
 			{
-				ASN:        new(int64(64520)),
-				Address:    new("2001:db8:1234::1"),
-				Properties: []v1alpha1.NeighborProperty{{Type: v1alpha1.NeighborPropertyEBGPMultiHop}},
+				ASN:                  new(int64(64520)),
+				Address:              new("2001:db8:1234::1"),
+				Properties:           []v1alpha1.NeighborProperty{{Type: v1alpha1.NeighborPropertyEBGPMultiHop}},
+				ConnectTimeSeconds:   new(int64(5)),
+				KeepaliveTimeSeconds: new(int64(3)),
+				HoldTimeSeconds:      new(int64(9)),
 			},
 		},
 		RouterIDCIDR: new("10.0.0.0/24"),
@@ -148,9 +166,12 @@ var UnderlaySRv6EncapRed = v1alpha1.Underlay{
 		Interfaces: defaultInterfaces,
 		Neighbors: []v1alpha1.Neighbor{
 			{
-				ASN:        new(int64(64520)),
-				Address:    new("2001:db8:1234::1"),
-				Properties: []v1alpha1.NeighborProperty{{Type: v1alpha1.NeighborPropertyEBGPMultiHop}},
+				ASN:                  new(int64(64520)),
+				Address:              new("2001:db8:1234::1"),
+				Properties:           []v1alpha1.NeighborProperty{{Type: v1alpha1.NeighborPropertyEBGPMultiHop}},
+				ConnectTimeSeconds:   new(int64(5)),
+				KeepaliveTimeSeconds: new(int64(3)),
+				HoldTimeSeconds:      new(int64(9)),
 			},
 		},
 		RouterIDCIDR: new("10.0.0.0/24"),
@@ -190,14 +211,20 @@ var UnderlayEVPNandSRv6 = v1alpha1.Underlay{
 		Neighbors: []v1alpha1.Neighbor{
 			// leafSRV6 - use automatically derived address families.
 			{
-				ASN:        new(int64(64520)),
-				Address:    new("2001:db8:1234::1"),
-				Properties: []v1alpha1.NeighborProperty{{Type: v1alpha1.NeighborPropertyEBGPMultiHop}},
+				ASN:                  new(int64(64520)),
+				Address:              new("2001:db8:1234::1"),
+				Properties:           []v1alpha1.NeighborProperty{{Type: v1alpha1.NeighborPropertyEBGPMultiHop}},
+				ConnectTimeSeconds:   new(int64(5)),
+				KeepaliveTimeSeconds: new(int64(3)),
+				HoldTimeSeconds:      new(int64(9)),
 			},
 			// leafkind
 			{
-				ASN:     new(int64(64512)),
-				Address: new("192.168.11.2"),
+				ASN:                  new(int64(64512)),
+				Address:              new("192.168.11.2"),
+				ConnectTimeSeconds:   new(int64(5)),
+				KeepaliveTimeSeconds: new(int64(3)),
+				HoldTimeSeconds:      new(int64(9)),
 			},
 		},
 		TunnelEndpoint: &v1alpha1.TunnelEndpointConfig{


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind flake

**What this PR does / why we need it**:

Change the clab and E2E underlay BGP timers to use timers as recommended
in "BGP in the Data Center".

keep-alive: 3
hold-down: 9
connect: 5

OpenPERouter currently has no setting for the advertisement interval,
but we change it on the clab nodes to:

advertisement-interval: 0

**Special notes for your reviewer**:

It doesn't really matter but FYI:
keepalive and holddown timers are negotiated to the smaller proposed value by each peer:
https://networkgeekstuff.com/networking/cisco-bgp-timers-re-explained/:
"the smaller timer win the negotiation"

**Release note**:

```release-note
None
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
