### PR TITLE
test(e2etests): fix flake in cni underlay lifecycle reprovision test

### DIFF
--- a/e2etests/tests/cni_lifecycle.go
+++ b/e2etests/tests/cni_lifecycle.go
@@ -211,11 +211,11 @@ var _ = Describe("CNI underlay lifecycle", Ordered, func() {
 			_, err := exec.Exec("ip", "netns", "exec", openperouter.NamedNetns, "ip", "link", "del", infra.CNIUnderlayInterface)
 			Expect(err).NotTo(HaveOccurred())
 		}
-		validateCNIInterfacesGone(infra.CNIUnderlayInterface)
 
 		// Reconciliation is event-driven, not on a timer: the dangling cache
-		// entry is only caught on the next reconcile. Restarting the
-		// controllers forces one without touching the Underlay.
+		// entry is only caught on the next reconcile which may or may not have
+		// been triggered at this point in time. Restarting the
+		// controllers forces a reconcile without touching the Underlay.
 		By("forcing a reconcile by restarting the controllers")
 		restartControllers()
 


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind flake

**What this PR does / why we need it**:

Fix a legit flake in "CNI underlay lifecycle reprovisions the CNI
interface after external drift is caught by the next reconcile".

The test used to delete the underlay interface and then validated in
a next step that the interface was deleted. It then forced a controller
restart to trigger a reconcile run.

However, while reconciliation will always be triggered by a controller
restart, but it can also be triggered by other events.

Therefore, if a reconcile occurs right after the `ip link del` and right
before the validateCNIInterfacesGone, the E2E test would report an
invalid failure.

This commit removes the validateCNIInterfacesGone(). It should not be
necessary as the `ip link del` would report an error if it failed.

Fixes  #657 

**Special notes for your reviewer**:

None

**Release note**:

```release-note
None
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated CNI lifecycle validation to reflect event-driven reconciliation.
  * Confirmed that restarting controllers restores deleted interfaces and recovers sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->