### PR TITLE
fix(e2e): use distinct CNI interface names per underlay flavor

### DIFF
--- a/e2etests/pkg/infra/underlay_cni.go
+++ b/e2etests/pkg/infra/underlay_cni.go
@@ -19,10 +19,6 @@ import (
 )
 
 const (
-	// CNIUnderlayInterface is the name of the interface the CNI plugin
-	// creates inside the router netns for CNI provisioned underlays.
-	CNIUnderlayInterface = "underlay0"
-
 	// CNIUnderlayASN is the local AS number of the CNI provisioned underlays.
 	CNIUnderlayASN = 64514
 

--- a/e2etests/tests/cni_lifecycle.go
+++ b/e2etests/tests/cni_lifecycle.go
@@ -25,9 +25,11 @@ import (
 )
 
 const (
-	// cniUnderlayInterfaceRenamed is used to exercise the in-place
+	lcUnderlayStaticInterface = "lc-static"
+	lcUnderlayDHCPInterface   = "lc-dhcp"
+	// cniUnderlayInterfaceRenamed is used to exercise the
 	// reprovisioning flow by changing the desired CNI interface name.
-	cniUnderlayInterfaceRenamed = "underlay1"
+	cniUnderlayInterfaceRenamed = "lc-rename"
 	// controllerLabelSelector selects the controller daemonset pods.
 	controllerLabelSelector = "app=controller"
 	// routerLabelSelector selects the router daemonset pods.
@@ -134,11 +136,11 @@ var _ = Describe("CNI underlay lifecycle", Ordered, func() {
 
 		Expect(infra.ConfigureLeafKind1ForCNIUnderlay(nodes)).To(Succeed())
 
-		err = Updater.Update(config.Resources{Underlays: infra.CNIUnderlaysForNodes(nodes, infra.CNIUnderlayInterface)})
+		err = Updater.Update(config.Resources{Underlays: infra.CNIUnderlaysForNodes(nodes, lcUnderlayStaticInterface)})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("waiting for the CNI interfaces to be provisioned")
-		validateCNIInterfacesPresent(infra.CNIUnderlayInterface)
+		validateCNIInterfacesPresent(lcUnderlayStaticInterface)
 		By("checking the parent device stays in the host netns")
 		for _, node := range nodes {
 			Expect(openperouter.IsInterfaceInDefaultNetns(node.Name, "toswitch1")).To(BeTrue(),
@@ -168,7 +170,7 @@ var _ = Describe("CNI underlay lifecycle", Ordered, func() {
 	})
 
 	It("keeps the CNI interfaces when the controller pods are restarted", func() {
-		indexesBefore, err := cniInterfaceIndexes(nodes, infra.CNIUnderlayInterface)
+		indexesBefore, err := cniInterfaceIndexes(nodes, lcUnderlayStaticInterface)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("restarting the controllers")
@@ -176,7 +178,7 @@ var _ = Describe("CNI underlay lifecycle", Ordered, func() {
 
 		By("checking the interfaces are not reprovisioned by the fresh controllers")
 		Consistently(func() (map[string]string, error) {
-			return cniInterfaceIndexes(nodes, infra.CNIUnderlayInterface)
+			return cniInterfaceIndexes(nodes, lcUnderlayStaticInterface)
 		}, 30*time.Second, 5*time.Second).Should(Equal(indexesBefore),
 			"the interfaces should survive the controller restart untouched")
 
@@ -185,14 +187,14 @@ var _ = Describe("CNI underlay lifecycle", Ordered, func() {
 	})
 
 	It("keeps the CNI interfaces when the router pods are restarted", func() {
-		indexesBefore, err := cniInterfaceIndexes(nodes, infra.CNIUnderlayInterface)
+		indexesBefore, err := cniInterfaceIndexes(nodes, lcUnderlayStaticInterface)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("restarting the routers")
 		restartRouters()
 
 		By("checking the interfaces survived in the persistent netns")
-		indexesAfter, err := cniInterfaceIndexes(nodes, infra.CNIUnderlayInterface)
+		indexesAfter, err := cniInterfaceIndexes(nodes, lcUnderlayStaticInterface)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(indexesAfter).To(Equal(indexesBefore),
 			"the interfaces should survive the router restart untouched")
@@ -202,13 +204,13 @@ var _ = Describe("CNI underlay lifecycle", Ordered, func() {
 	})
 
 	It("reprovisions the CNI interface after external drift is caught by the next reconcile", func() {
-		indexesBefore, err := cniInterfaceIndexes(nodes, infra.CNIUnderlayInterface)
+		indexesBefore, err := cniInterfaceIndexes(nodes, lcUnderlayStaticInterface)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("deleting the CNI interface directly, behind the controller's back")
 		for _, node := range nodes {
 			exec := executor.ForContainer(node.Name)
-			_, err := exec.Exec("ip", "netns", "exec", openperouter.NamedNetns, "ip", "link", "del", infra.CNIUnderlayInterface)
+			_, err := exec.Exec("ip", "netns", "exec", openperouter.NamedNetns, "ip", "link", "del", lcUnderlayStaticInterface)
 			Expect(err).NotTo(HaveOccurred())
 		}
 
@@ -220,8 +222,8 @@ var _ = Describe("CNI underlay lifecycle", Ordered, func() {
 		restartControllers()
 
 		By("checking cni check detects the drift and the interface is reprovisioned")
-		validateCNIInterfacesPresent(infra.CNIUnderlayInterface)
-		indexesAfter, err := cniInterfaceIndexes(nodes, infra.CNIUnderlayInterface)
+		validateCNIInterfacesPresent(lcUnderlayStaticInterface)
+		indexesAfter, err := cniInterfaceIndexes(nodes, lcUnderlayStaticInterface)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(indexesAfter).NotTo(Equal(indexesBefore),
 			"the interface should have been recreated with a new ifindex")
@@ -236,7 +238,7 @@ var _ = Describe("CNI underlay lifecycle", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		validateCNIInterfacesPresent(cniUnderlayInterfaceRenamed)
-		validateCNIInterfacesGone(infra.CNIUnderlayInterface)
+		validateCNIInterfacesGone(lcUnderlayStaticInterface)
 		validateSessionUp()
 	})
 
@@ -262,7 +264,7 @@ var _ = Describe("DHCP underlay lifecycle", Ordered, func() {
 			var ip string
 			Eventually(func(g Gomega) {
 				var err error
-				ip, err = infra.DHCPNeighborIP(node.Name, infra.CNIUnderlayInterface)
+				ip, err = infra.DHCPNeighborIP(node.Name, lcUnderlayDHCPInterface)
 				g.Expect(err).NotTo(HaveOccurred())
 			}, 3*time.Minute, time.Second).Should(Succeed())
 			validateSessionWithNeighbor(leafExec, validationParameters{
@@ -277,7 +279,7 @@ var _ = Describe("DHCP underlay lifecycle", Ordered, func() {
 	dhcpAddresses := func() (map[string]string, error) {
 		res := map[string]string{}
 		for _, node := range nodes {
-			ip, err := infra.DHCPNeighborIP(node.Name, infra.CNIUnderlayInterface)
+			ip, err := infra.DHCPNeighborIP(node.Name, lcUnderlayDHCPInterface)
 			if err != nil {
 				return nil, err
 			}
@@ -313,7 +315,7 @@ var _ = Describe("DHCP underlay lifecycle", Ordered, func() {
 		err := Updater.CleanAll()
 		Expect(err).NotTo(HaveOccurred())
 
-		err = Updater.Update(config.Resources{Underlays: infra.DHCPCNIUnderlaysForNodes(nodes, infra.CNIUnderlayInterface)})
+		err = Updater.Update(config.Resources{Underlays: infra.DHCPCNIUnderlaysForNodes(nodes, lcUnderlayDHCPInterface)})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("waiting for DHCP addresses to be acquired")
@@ -323,7 +325,7 @@ var _ = Describe("DHCP underlay lifecycle", Ordered, func() {
 		}, 3*time.Minute, time.Second).Should(Succeed())
 
 		By("configuring leafkind1 with the DHCP-assigned addresses")
-		Expect(infra.ConfigureLeafKind1ForDHCPUnderlay(nodes, infra.CNIUnderlayInterface)).To(Succeed())
+		Expect(infra.ConfigureLeafKind1ForDHCPUnderlay(nodes, lcUnderlayDHCPInterface)).To(Succeed())
 
 		By("waiting for the sessions to be established")
 		validateDHCPSessionUp()
@@ -386,15 +388,15 @@ var _ = Describe("DHCP underlay lifecycle", Ordered, func() {
 		Expect(Updater.CleanAll()).To(Succeed())
 
 		for nodeName, nodeIP := range addrsBefore {
-			By(fmt.Sprintf("checking interface %q is gone from node %q", infra.CNIUnderlayInterface, nodeName))
+			By(fmt.Sprintf("checking interface %q is gone from node %q", lcUnderlayDHCPInterface, nodeName))
 			Eventually(func() bool {
-				return openperouter.IsInterfaceInNS(nodeName, infra.CNIUnderlayInterface, openperouter.NamedNetns)
+				return openperouter.IsInterfaceInNS(nodeName, lcUnderlayDHCPInterface, openperouter.NamedNetns)
 			}).
 				WithTimeout(time.Minute).
 				WithPolling(5*time.Second).
 				Should(BeFalse(),
 					fmt.Sprintf("interface %s should be gone from the router netns of %s",
-						infra.CNIUnderlayInterface, nodeName))
+						lcUnderlayDHCPInterface, nodeName))
 
 			By(fmt.Sprintf("checking lease for IP %q on node %q is already cleaned", nodeIP, nodeName))
 			Eventually(func() error {

--- a/e2etests/tests/evpn_routes.go
+++ b/e2etests/tests/evpn_routes.go
@@ -49,6 +49,11 @@ type evpnUnderlayParams struct {
 	NeighborIP func(nodeIndex int, node corev1.Node) (string, error)
 }
 
+const (
+	evpnUnderlayStaticInterface = "ev-static"
+	evpnUnderlayDHCPInterface   = "ev-dhcp"
+)
+
 var (
 	// NOTE: we can't advertise any ip via EVPN from the leaves, they
 	// must be reacheable otherwise FRR will skip them.
@@ -64,7 +69,7 @@ var (
 	// of toswitch1 through the CNI mode, with static per-node addresses.
 	macvlanStaticUnderlay = evpnUnderlayParams{
 		Underlays: func(nodes []corev1.Node) []v1alpha1.Underlay {
-			return infra.CNIUnderlaysForNodes(nodes, infra.CNIUnderlayInterface)
+			return infra.CNIUnderlaysForNodes(nodes, evpnUnderlayStaticInterface)
 		},
 		ConfigureLeafKind: infra.ConfigureLeafKind1ForCNIUnderlay,
 		NeighborIP: func(nodeIndex int, _ corev1.Node) (string, error) {
@@ -94,13 +99,13 @@ var (
 	// address acquisition from the dhcp1 dnsmasq server.
 	macvlanDHCPUnderlay = evpnUnderlayParams{
 		Underlays: func(nodes []corev1.Node) []v1alpha1.Underlay {
-			return infra.DHCPCNIUnderlaysForNodes(nodes, infra.CNIUnderlayInterface)
+			return infra.DHCPCNIUnderlaysForNodes(nodes, evpnUnderlayDHCPInterface)
 		},
 		ConfigureLeafKind: func(nodes []corev1.Node) error {
-			return infra.ConfigureLeafKind1ForDHCPUnderlay(nodes, infra.CNIUnderlayInterface)
+			return infra.ConfigureLeafKind1ForDHCPUnderlay(nodes, evpnUnderlayDHCPInterface)
 		},
 		NeighborIP: func(_ int, node corev1.Node) (string, error) {
-			return infra.DHCPNeighborIP(node.Name, infra.CNIUnderlayInterface)
+			return infra.DHCPNeighborIP(node.Name, evpnUnderlayDHCPInterface)
 		},
 	}
 )


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
/kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

Related to https://github.com/openperouter/openperouter/issues/659 , which requires broader discussion, but removes the flake. The scenario is very unlikely to happen.

When a static CNI underlay test runs before a DHCP one, event coalescing can cause the reconciler to miss the cleanup of the old CNI cache entry. If both flavors use the same interface name, the stale cache blocks provisioning with ConfigMismatchError.

Give each flavor its own interface name (ul-static, ul-dhcp, ul-rename) so UnderlayInterfacesToRemove detects the old name and cleans it up regardless of event ordering.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
