### PR TITLE
test(e2e): fix resiliency and frr_restart pod readiness check

### DIFF
--- a/e2etests/pkg/k8s/pods.go
+++ b/e2etests/pkg/k8s/pods.go
@@ -213,6 +213,27 @@ func PodIsReady(p *corev1.Pod) bool {
 		podConditionStatus(p, corev1.ContainersReady) == corev1.ConditionTrue
 }
 
+// WaitForPodReadyConsistently waits until the provided pod is consistently ready.
+// We make sure that the pod is consistently ready 10 consecutive times (roughly 10'ish seconds) to avoid that we catch
+// an invalid ready state early in case the pod is transitioning from ready to not ready.
+// Note: kubernetes' MaxCrashLoopBackOff is hardcoded to 5 minutes:
+// https://github.com/kubernetes/kubernetes/blob/ec9448ceef13adbbcd3fa9f09b4d3c1fa54cc674/pkg/kubelet/kubelet.go#L166
+// https://github.com/kubernetes/kubernetes/issues/57291
+// Therefore, before calling this function, make sure that the crashloop timer is reset, e.g. by a new rollout of the
+// pod.
+func WaitForPodReadyConsistently(cs clientset.Interface, podNamespace, podName string) {
+	By(fmt.Sprintf("waiting for pod %s/%s to become ready", podNamespace, podName))
+	Eventually(func(g Gomega) bool {
+		pod, err := cs.CoreV1().Pods(podNamespace).Get(context.Background(), podName, metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		return PodIsReady(pod)
+	}).
+		WithTimeout(2 * time.Minute).
+		WithPolling(time.Second).
+		MustPassRepeatedly(10).
+		Should(BeTrue())
+}
+
 func PodsForLabel(cs clientset.Interface, namespace, labelSelector string) ([]*corev1.Pod, error) {
 	pods, err := cs.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{
 		LabelSelector: labelSelector,

--- a/e2etests/pkg/openperouter/openperouter.go
+++ b/e2etests/pkg/openperouter/openperouter.go
@@ -3,20 +3,28 @@
 package openperouter
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"iter"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"github.com/openperouter/openperouter/e2etests/pkg/executor"
 	"github.com/openperouter/openperouter/e2etests/pkg/k8s"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 )
 
 const (
-	Namespace           = "openperouter-system"
-	routerLabelSelector = "app=router"
+	Namespace                    = "openperouter-system"
+	RouterDaemonSetLabelSelector = "app.kubernetes.io/component=router"
+	routerLabelSelector          = "app=router"
 )
 
 type Routers interface {
@@ -113,4 +121,101 @@ func DaemonsetRolled(oldRouters Routers, newRouters Routers) error {
 	default:
 		return fmt.Errorf("unknown router type: %T", oldRouters)
 	}
+}
+
+// RestartDaemonSetPods restarts all pods that belong to the DaemonSet identified by namespace + label selector and
+// waits until the DaemonSet reports ready.
+func RestartDaemonSetPods(cs clientset.Interface, namespace, labelSelector string) {
+	By(fmt.Sprintf("getting DaemonSet in namespace %s with label selector %s", namespace, labelSelector))
+	var ds appsv1.DaemonSet
+	var dsName string
+	Eventually(func() error {
+		dsList, err := cs.AppsV1().DaemonSets(namespace).List(
+			context.Background(),
+			metav1.ListOptions{
+				LabelSelector: labelSelector,
+			},
+		)
+		if err != nil {
+			return err
+		}
+		if len(dsList.Items) != 1 {
+			return fmt.Errorf("could not find DaemonSet with label selector %s, unexpected count %d",
+				labelSelector, len(dsList.Items))
+		}
+		ds = dsList.Items[0]
+		dsName = ds.Name
+		return nil
+	}).
+		WithTimeout(1 * time.Minute).
+		WithPolling(time.Second).
+		ShouldNot(HaveOccurred())
+
+	selector := metav1.FormatLabelSelector(ds.Spec.Selector)
+
+	By(fmt.Sprintf("listing DaemonSet %s/%s pods", namespace, dsName))
+	var oldPodNames map[string]struct{}
+	Eventually(func() error {
+		var err error
+		oldPodNames, err = collectPodNames(cs, namespace, selector)
+		return err
+	}).
+		WithTimeout(1 * time.Minute).
+		WithPolling(time.Second).
+		ShouldNot(HaveOccurred())
+
+	By(fmt.Sprintf("deleting DaemonSet %s/%s pods", namespace, dsName))
+	Expect(cs.CoreV1().Pods(namespace).DeleteCollection(
+		context.Background(),
+		metav1.DeleteOptions{},
+		metav1.ListOptions{
+			LabelSelector: selector,
+		},
+	)).To(Succeed())
+
+	By(fmt.Sprintf("waiting for all DaemonSet %s/%s pods to change", namespace, dsName))
+	Eventually(func() error {
+		podNames, err := collectPodNames(cs, namespace, selector)
+		if err != nil {
+			return err
+		}
+		for oldName := range oldPodNames {
+			if _, oldNameFound := podNames[oldName]; oldNameFound {
+				return fmt.Errorf("pod %s hasn't restarted, yet. oldPodNames: %+v, podNames: %+v",
+					oldName, oldPodNames, podNames)
+			}
+		}
+		return nil
+	}).
+		WithTimeout(2 * time.Minute).
+		WithPolling(time.Second).
+		ShouldNot(HaveOccurred())
+
+	By(fmt.Sprintf("waiting for DaemonSet %s/%s to become ready", namespace, dsName))
+	Eventually(func(g Gomega) bool {
+		ds, err := cs.AppsV1().DaemonSets(namespace).Get(context.Background(), dsName, metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		return ds.Status.DesiredNumberScheduled > 0 && ds.Status.DesiredNumberScheduled == ds.Status.NumberReady
+	}).
+		WithTimeout(2 * time.Minute).
+		WithPolling(time.Second).
+		MustPassRepeatedly(10).
+		Should(BeTrue())
+}
+
+func collectPodNames(cs clientset.Interface, namespace, selector string) (map[string]struct{}, error) {
+	podList, err := cs.CoreV1().Pods(namespace).List(
+		context.Background(),
+		metav1.ListOptions{
+			LabelSelector: selector,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	podNames := make(map[string]struct{}, len(podList.Items))
+	for _, pod := range podList.Items {
+		podNames[pod.Name] = struct{}{}
+	}
+	return podNames, nil
 }

--- a/e2etests/tests/frr_restart.go
+++ b/e2etests/tests/frr_restart.go
@@ -3,7 +3,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"time"
@@ -19,7 +18,6 @@ import (
 	"github.com/openperouter/openperouter/e2etests/pkg/k8sclient"
 	"github.com/openperouter/openperouter/e2etests/pkg/openperouter"
 	"github.com/openperouter/openperouter/e2etests/pkg/url"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 )
@@ -61,6 +59,9 @@ var _ = Describe("North/south traffic after FRR container restart", Ordered, fun
 
 		var err error
 		cs = k8sclient.New()
+
+		openperouter.RestartDaemonSetPods(cs, openperouter.Namespace, openperouter.RouterDaemonSetLabelSelector)
+
 		Eventually(func() error {
 			routers, err = openperouter.Get(cs, HostMode)
 			if err != nil {
@@ -91,6 +92,8 @@ var _ = Describe("North/south traffic after FRR container restart", Ordered, fun
 			}
 			return openperouter.AreReady(routers)
 		}, 2*time.Minute, time.Second).ShouldNot(HaveOccurred())
+
+		openperouter.RestartDaemonSetPods(cs, openperouter.Namespace, openperouter.RouterDaemonSetLabelSelector)
 	})
 
 	const testNamespace = "test-namespace"
@@ -164,23 +167,7 @@ var _ = Describe("North/south traffic after FRR container restart", Ordered, fun
 		By("killing the FRR container entrypoint process")
 		killFRREntrypoint(frrExec)
 
-		By("waiting for the FRR container to restart and become ready")
-		Eventually(func(g Gomega) []v1.PodCondition {
-			pod, err := cs.CoreV1().Pods(openperouter.Namespace).Get(context.Background(), routerPod.Name, metav1.GetOptions{})
-			g.Expect(err).NotTo(HaveOccurred())
-			return pod.Status.Conditions
-		}).
-			WithTimeout(2*time.Minute).
-			WithPolling(time.Second).
-			Should(
-				ContainElement(
-					SatisfyAll(
-						HaveField("Type", Equal(v1.PodReady)),
-						HaveField("Status", Equal(v1.ConditionTrue)),
-					),
-				),
-				"router pod should become ready after FRR restart",
-			)
+		k8s.WaitForPodReadyConsistently(cs, openperouter.Namespace, routerPod.Name)
 
 		By("waiting for BGP sessions to re-establish")
 		nodeName := routerPod.Spec.NodeName

--- a/e2etests/tests/frr_restart.go
+++ b/e2etests/tests/frr_restart.go
@@ -57,9 +57,9 @@ var _ = Describe("North/south traffic after FRR container restart", Ordered, fun
 	}
 
 	BeforeAll(func() {
-		err := Updater.CleanAll()
-		Expect(err).NotTo(HaveOccurred())
+		Expect(Updater.CleanAll()).To(Succeed())
 
+		var err error
 		cs = k8sclient.New()
 		Eventually(func() error {
 			routers, err = openperouter.Get(cs, HostMode)
@@ -71,20 +71,18 @@ var _ = Describe("North/south traffic after FRR container restart", Ordered, fun
 
 		routers.Dump(ginkgo.GinkgoWriter)
 
-		err = Updater.Update(config.Resources{
+		Expect(Updater.Update(config.Resources{
 			Underlays: []v1alpha1.Underlay{
 				infra.Underlay,
 			},
-		})
-		Expect(err).NotTo(HaveOccurred())
+		})).To(Succeed())
 
 		Expect(infra.LeafAConfig.RedistributeConnected()).To(Succeed())
 		Expect(infra.LeafBConfig.RedistributeConnected()).To(Succeed())
 	})
 
 	AfterAll(func() {
-		err := Updater.CleanAll()
-		Expect(err).NotTo(HaveOccurred())
+		Expect(Updater.CleanAll()).To(Succeed())
 		By("waiting for all router pods to be ready after removing the underlay")
 		Eventually(func() error {
 			routers, err := openperouter.Get(cs, HostMode)
@@ -101,17 +99,16 @@ var _ = Describe("North/south traffic after FRR container restart", Ordered, fun
 		l2VniRedWithGateway := l2VniRed.DeepCopy()
 		l2VniRedWithGateway.Spec.GatewayIPs = []string{"192.171.24.1/24"}
 
-		err := Updater.Update(config.Resources{
+		Expect(Updater.Update(config.Resources{
 			L3VNIs: []v1alpha1.L3VNI{
 				vniRed,
 			},
 			L2VNIs: []v1alpha1.L2VNI{
 				*l2VniRedWithGateway,
 			},
-		})
-		Expect(err).NotTo(HaveOccurred())
+		})).To(Succeed())
 
-		_, err = k8s.CreateNamespace(cs, testNamespace)
+		_, err := k8s.CreateNamespace(cs, testNamespace)
 		Expect(err).NotTo(HaveOccurred())
 
 		nad, err := k8s.CreateMacvlanNad("110", testNamespace, "br-hs-110", []string{"192.171.24.1/24"})
@@ -121,10 +118,8 @@ var _ = Describe("North/south traffic after FRR container restart", Ordered, fun
 			dumpIfFails(cs, testNamespace)
 			Expect(infra.LeafAConfig.Reset()).To(Succeed())
 			Expect(infra.LeafBConfig.Reset()).To(Succeed())
-			err := Updater.CleanButUnderlay()
-			Expect(err).NotTo(HaveOccurred())
-			err = k8s.DeleteNamespace(cs, testNamespace)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(Updater.CleanButUnderlay()).To(Succeed())
+			Expect(k8s.DeleteNamespace(cs, testNamespace)).To(Succeed())
 		})
 
 		nodes, err := k8s.GetNodes(cs)

--- a/e2etests/tests/resiliency.go
+++ b/e2etests/tests/resiliency.go
@@ -63,9 +63,9 @@ var _ = Describe("Alpha: Named netns and kernel objects survive FRR crash", Orde
 	}
 
 	BeforeAll(func() {
-		err := Updater.CleanAll()
-		Expect(err).NotTo(HaveOccurred())
+		Expect(Updater.CleanAll()).To(Succeed())
 
+		var err error
 		cs = k8sclient.New()
 		Eventually(func() error {
 			routers, err = openperouter.Get(cs, HostMode)
@@ -77,21 +77,19 @@ var _ = Describe("Alpha: Named netns and kernel objects survive FRR crash", Orde
 
 		routers.Dump(ginkgo.GinkgoWriter)
 
-		err = Updater.Update(config.Resources{
+		Expect(Updater.Update(config.Resources{
 			Underlays: []v1alpha1.Underlay{
 				infra.Underlay,
 			},
-		})
-		Expect(err).NotTo(HaveOccurred())
+		})).To(Succeed())
 
 		Expect(infra.LeafAConfig.RedistributeConnected()).To(Succeed())
 		Expect(infra.LeafBConfig.RedistributeConnected()).To(Succeed())
 
-		err = Updater.Update(config.Resources{
+		Expect(Updater.Update(config.Resources{
 			L3VNIs: []v1alpha1.L3VNI{vniRed},
 			L2VNIs: []v1alpha1.L2VNI{l2VniRed},
-		})
-		Expect(err).NotTo(HaveOccurred())
+		})).To(Succeed())
 
 		By("waiting for the controller to provision VRF, bridge, and VXLAN interfaces in the named netns")
 		nodes, err := k8s.GetNodes(cs)
@@ -116,8 +114,7 @@ var _ = Describe("Alpha: Named netns and kernel objects survive FRR crash", Orde
 		dumpUnderlayVeths(cs, "Alpha AfterAll before cleanup")
 		Expect(infra.LeafAConfig.Reset()).To(Succeed())
 		Expect(infra.LeafBConfig.Reset()).To(Succeed())
-		err := Updater.CleanAll()
-		Expect(err).NotTo(HaveOccurred())
+		Expect(Updater.CleanAll()).To(Succeed())
 		By("waiting for all router pods to be ready")
 		Eventually(func(g Gomega) {
 			pods, err := openperouter.RouterPods(cs)
@@ -253,8 +250,7 @@ var _ = Describe("Beta: Named netns auto-rebuilds after deletion", Ordered, func
 	BeforeAll(func() {
 		cs = k8sclient.New()
 
-		err := Updater.CleanAll()
-		Expect(err).NotTo(HaveOccurred())
+		Expect(Updater.CleanAll()).To(Succeed())
 
 		By("waiting for all router pods to be ready after cleanup")
 		Eventually(func() error {
@@ -268,10 +264,9 @@ var _ = Describe("Beta: Named netns auto-rebuilds after deletion", Ordered, func
 		underlayWithGR := infra.Underlay.DeepCopy()
 		underlayWithGR.Spec.GracefulRestart = &v1alpha1.GracefulRestartConfig{}
 
-		err = Updater.Update(config.Resources{
+		Expect(Updater.Update(config.Resources{
 			Underlays: []v1alpha1.Underlay{*underlayWithGR},
-		})
-		Expect(err).NotTo(HaveOccurred())
+		})).To(Succeed())
 
 		By("waiting for all router pods to be ready")
 		Eventually(func() error {
@@ -288,7 +283,7 @@ var _ = Describe("Beta: Named netns auto-rebuilds after deletion", Ordered, func
 		nodes, err := k8s.GetNodes(cs)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = infra.LeafKind1Config.UpdateConfig(
+		Expect(infra.LeafKind1Config.UpdateConfig(
 			nodes,
 			infra.LeafKindConfiguration{
 				ASN:              infra.LeafKind1Config.ASN,
@@ -296,9 +291,7 @@ var _ = Describe("Beta: Named netns auto-rebuilds after deletion", Ordered, func
 				PERouterASN:      64514,
 				NextHopSelf:      true,
 			},
-		)
-
-		Expect(err).NotTo(HaveOccurred())
+		)).To(Succeed())
 
 		By("waiting for BGP sessions to establish after underlay creation")
 		leafExec := executor.ForContainer(infra.KindLeaf)
@@ -328,8 +321,7 @@ var _ = Describe("Beta: Named netns auto-rebuilds after deletion", Ordered, func
 		Expect(infra.LeafKind1Config.UpdateConfig(nodes, infra.LeafKindConfiguration{})).To(Succeed())
 		Expect(infra.LeafKind2Config.UpdateConfig(nodes, infra.LeafKindConfiguration{})).To(Succeed())
 
-		err = Updater.CleanAll()
-		Expect(err).NotTo(HaveOccurred())
+		Expect(Updater.CleanAll()).To(Succeed())
 
 		By("waiting for all router pods to be ready after cleanup")
 		Eventually(func() error {
@@ -346,8 +338,7 @@ var _ = Describe("Beta: Named netns auto-rebuilds after deletion", Ordered, func
 	AfterEach(func() {
 		dumpIfFails(cs, testNamespace)
 		dumpUnderlayVeths(cs, "Beta AfterEach before cleanup")
-		err := Updater.CleanButUnderlay()
-		Expect(err).NotTo(HaveOccurred())
+		Expect(Updater.CleanButUnderlay()).To(Succeed())
 		if err := k8s.DeleteNamespace(cs, testNamespace); err != nil && !apierrors.IsNotFound(err) {
 			Expect(err).NotTo(HaveOccurred())
 		}
@@ -365,13 +356,12 @@ var _ = Describe("Beta: Named netns auto-rebuilds after deletion", Ordered, func
 		l2VniRedWithGateway := l2VniRed.DeepCopy()
 		l2VniRedWithGateway.Spec.GatewayIPs = []string{"192.171.24.1/24"}
 
-		err := Updater.Update(config.Resources{
+		Expect(Updater.Update(config.Resources{
 			L3VNIs: []v1alpha1.L3VNI{vniRed},
 			L2VNIs: []v1alpha1.L2VNI{*l2VniRedWithGateway},
-		})
-		Expect(err).NotTo(HaveOccurred())
+		})).To(Succeed())
 
-		_, err = k8s.CreateNamespace(cs, testNamespace)
+		_, err := k8s.CreateNamespace(cs, testNamespace)
 		Expect(err).NotTo(HaveOccurred())
 
 		nad, err := k8s.CreateMacvlanNad("110", testNamespace, "br-hs-110", []string{"192.171.24.1/24"})
@@ -519,13 +509,12 @@ var _ = Describe("Beta: Named netns auto-rebuilds after deletion", Ordered, func
 		l2VniRedWithGateway := l2VniRed.DeepCopy()
 		l2VniRedWithGateway.Spec.GatewayIPs = []string{"192.171.24.1/24"}
 
-		err := Updater.Update(config.Resources{
+		Expect(Updater.Update(config.Resources{
 			L3VNIs: []v1alpha1.L3VNI{vniRed},
 			L2VNIs: []v1alpha1.L2VNI{*l2VniRedWithGateway},
-		})
-		Expect(err).NotTo(HaveOccurred())
+		})).To(Succeed())
 
-		_, err = k8s.CreateNamespace(cs, testNamespace)
+		_, err := k8s.CreateNamespace(cs, testNamespace)
 		Expect(err).NotTo(HaveOccurred())
 
 		nad, err := k8s.CreateMacvlanNad("110", testNamespace, "br-hs-110", nil)

--- a/e2etests/tests/resiliency.go
+++ b/e2etests/tests/resiliency.go
@@ -22,7 +22,6 @@ import (
 	"github.com/openperouter/openperouter/e2etests/pkg/k8sclient"
 	"github.com/openperouter/openperouter/e2etests/pkg/openperouter"
 	"github.com/openperouter/openperouter/e2etests/pkg/url"
-	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -67,6 +66,9 @@ var _ = Describe("Alpha: Named netns and kernel objects survive FRR crash", Orde
 
 		var err error
 		cs = k8sclient.New()
+
+		openperouter.RestartDaemonSetPods(cs, openperouter.Namespace, openperouter.RouterDaemonSetLabelSelector)
+
 		Eventually(func() error {
 			routers, err = openperouter.Get(cs, HostMode)
 			if err != nil {
@@ -123,6 +125,8 @@ var _ = Describe("Alpha: Named netns and kernel objects survive FRR crash", Orde
 				g.Expect(k8s.PodIsReady(p)).To(BeTrue(), "pod %s must be ready", p.Name)
 			}
 		}).WithTimeout(2 * time.Minute).WithPolling(time.Second).Should(Succeed())
+
+		openperouter.RestartDaemonSetPods(cs, openperouter.Namespace, openperouter.RouterDaemonSetLabelSelector)
 	})
 
 	It("should preserve named netns at /var/run/netns/perouter when FRR process crashes", func() {
@@ -159,23 +163,7 @@ var _ = Describe("Alpha: Named netns and kernel objects survive FRR crash", Orde
 			Expect(present).To(BeTrue(), "interface type %s must survive FRR crash immediately", ifType)
 		}
 
-		By("waiting for the FRR container to restart and become ready")
-		Eventually(func(g Gomega) []v1.PodCondition {
-			pod, err := cs.CoreV1().Pods(openperouter.Namespace).Get(context.Background(), routerPod.Name, metav1.GetOptions{})
-			g.Expect(err).NotTo(HaveOccurred())
-			return pod.Status.Conditions
-		}).
-			WithTimeout(2*time.Minute).
-			WithPolling(time.Second).
-			Should(
-				ContainElement(
-					SatisfyAll(
-						HaveField("Type", Equal(v1.PodReady)),
-						HaveField("Status", Equal(v1.ConditionTrue)),
-					),
-				),
-				"router pod should become ready after FRR restart",
-			)
+		k8s.WaitForPodReadyConsistently(cs, openperouter.Namespace, routerPod.Name)
 
 		By("waiting for BGP sessions to re-establish")
 		neighborIP, err := infra.NeighborIP(infra.KindLeaf, nodeName)


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind flake

**What this PR does / why we need it**:

- **test(e2e): fix resiliency and frr_restart pod readiness check**
- **test(e2etest): resiliency.go and frr_restart.go Expect().To(Succeed())**

Check "waiting for the FRR container to restart and become ready" in
resiliency.go and frr_restart.go was ignored (at least during local
reproduction) because after killing, the tests nearly immediately waited
for pod ready. That status may erroneously still be reported as
ready: true due to timing issues.
This commit refactors the redundant code into a function, makes sure to
use MustPassRepeated so that the ready state is valid for at least 10
seconds. In addition, take into account that kubernetes' max
crashloopbackoff is hardcoded to 5 minutes. Therefore, the timeout must
be North of 5 minutes (6 minutes were chosen for this fix).

**Special notes for your reviewer**:

Fixes https://github.com/openperouter/openperouter/issues/661

Before this PR, command:

```
export GINKGO_ARGS='--focus="Alpha: Named netns and kernel objects survive FRR crash should preserve named netns"'; while make e2etests; do echo -e "\n\n\n=== Test succeeded, running it again ===\n\n\n"; done
```

triggers repeated crashloopbackoffs (counters IIRC are cleared only after 10 minutes) and after a while test runs will fail. With the fix, this does not happen.

Though tbh I'm not sure how useful this fix is ...

**Release note**:

```release-note
None
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by consistently verifying pod readiness after router restarts.
  * Added automated DaemonSet pod restart and readiness checks.
  * Strengthened validation for FRR restart, namespace recovery, and stretched-L2 resiliency scenarios.
  * Simplified test assertions and cleanup checks to provide clearer failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->