### PR TITLE
fix(frr): skip rendering default GR timer values to avoid BGP session reset

### DIFF
--- a/internal/frr/templates/frr.tmpl
+++ b/internal/frr/templates/frr.tmpl
@@ -47,8 +47,16 @@ router bgp {{ .Underlay.MyASN }}
 {{- if .Underlay.GracefulRestart }}
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
+{{- /* 120 and 360 are FRR's defaults for restart-time and stalepath-time.
+       Rendering them explicitly causes frr-reload.py to re-apply them on
+       every reload (show running-config suppresses defaults), which resets
+       all BGP sessions. https://github.com/FRRouting/frr/issues/22953 */ -}}
+{{- if ne .Underlay.GracefulRestart.RestartTime 120 }}
   bgp graceful-restart restart-time {{ .Underlay.GracefulRestart.RestartTime }}
+{{- end }}
+{{- if ne .Underlay.GracefulRestart.StalePathTime 360 }}
   bgp graceful-restart stalepath-time {{ .Underlay.GracefulRestart.StalePathTime }}
+{{- end }}
 {{- end }}
 
 {{- range $n := .Underlay.Neighbors }}

--- a/internal/frr/testdata/TestGracefulRestart.golden
+++ b/internal/frr/testdata/TestGracefulRestart.golden
@@ -12,8 +12,6 @@ router bgp 64512
   bgp router-id 10.0.0.1
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart restart-time 120
-  bgp graceful-restart stalepath-time 360
   neighbor 192.168.1.2 remote-as 64512
   
   


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

FRR's show running-config suppresses default values for restart-time (120) and stalepath-time (360). This causes frr-reload.py to see a diff on every reload and re-apply them, which triggers BGP session resets.

Skip rendering these values when they match FRR's defaults to prevent the spurious resets.

Fixes https://github.com/openperouter/openperouter/issues/667

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix: session reset after configuration reload when default graceful restart timers are applied
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * BGP graceful-restart configurations now omit default timing settings, reducing unnecessary configuration output.
  * Custom restart and stale-path timing values continue to be rendered when configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->