### PR TITLE
fix(e2e): give each leafkind its own ISIS net

### DIFF
--- a/e2etests/pkg/infra/leaf.go
+++ b/e2etests/pkg/infra/leaf.go
@@ -58,12 +58,14 @@ var (
 		SpinePeerAddress:  "192.168.1.4",
 		Container:         KindLeaf1Container,
 		ToSwitchInterface: "toswitch1",
+		ISISNet:           "49.0001.0000.0000.0004.00",
 	}
 	LeafKind2Config = LeafKind{
 		ASN:               64513,
 		SpinePeerAddress:  "192.168.1.6",
 		Container:         KindLeaf2Container,
 		ToSwitchInterface: "toswitch2",
+		ISISNet:           "49.0001.0000.0000.0005.00",
 	}
 
 	EmptyLeafConfig = LeafConfiguration{
@@ -97,6 +99,7 @@ type LeafKindConfiguration struct {
 	ASN                   int
 	SpinePeerAddress      string
 	ToSwitchInterface     string
+	ISISNet               string
 	EnableBFD             bool
 	RedistributeConnected bool
 	Neighbors             []Neighbor
@@ -140,6 +143,7 @@ type LeafKind struct {
 	ASN               int
 	SpinePeerAddress  string
 	ToSwitchInterface string
+	ISISNet           string
 	frr.Container
 }
 
@@ -230,6 +234,9 @@ func (l LeafKind) UpdateConfig(nodes []corev1.Node, config LeafKindConfiguration
 	if config.ToSwitchInterface == "" {
 		config.ToSwitchInterface = l.ToSwitchInterface
 	}
+	if config.ISISNet == "" {
+		config.ISISNet = l.ISISNet
+	}
 
 	neighbors := []Neighbor{}
 	for _, node := range nodes {
@@ -272,6 +279,9 @@ func (l LeafKind) Configure(config LeafKindConfiguration) error {
 	}
 	if config.ToSwitchInterface == "" {
 		config.ToSwitchInterface = l.ToSwitchInterface
+	}
+	if config.ISISNet == "" {
+		config.ISISNet = l.ISISNet
 	}
 
 	configString, err := LeafKindConfigToFRR(config)

--- a/e2etests/pkg/infra/testdata/leafkind.tmpl
+++ b/e2etests/pkg/infra/testdata/leafkind.tmpl
@@ -68,7 +68,7 @@ exit
 router isis ISIS
   is-type level-1
   advertise-passive-only
-  net 49.0001.0000.0000.0004.00
+  net {{ .ISISNet }}
 exit
 !
 interface eth1


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

`leafkind.tmpl` hardcoded `net 49.0001.0000.0000.0004.00`, and both
`LeafKind1Config` and `LeafKind2Config` render through it. Reconfiguring leafkind2
from a spec therefore hands it leafkind1's ISIS system ID. Both leaves then keep
receiving "their own" LSP back with a different checksum and answer by bumping the
sequence number and reflooding, so ISIS never converges and the routes learned over
it churn.

The clab boot config assigns the nets correctly, so the fabric only breaks once a
spec reconfigures a leaf.

**Special notes for your reviewer**:

Measured locally by flipping leafkind2's net and sampling leafkind1's own LSP
sequence number: 0/s with distinct nets, 3825/s with the duplicate. The CI leafkind
dumps carry over 400k `confused checksum` lines per run, on `main` as well.

**Release note**:

```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
