### PR TITLE
test(e2e): fixed trafficTestResult interval for (systemd_)resiliency

### DIFF
--- a/e2etests/tests/resiliency.go
+++ b/e2etests/tests/resiliency.go
@@ -4,6 +4,7 @@ package tests
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -638,15 +639,19 @@ var _ = Describe("Beta: Named netns auto-rebuilds after deletion", Ordered, func
 			},
 		)
 
+		By("verifying stretched L2 traffic works after router pod deletion")
+		Eventually(func() error {
+			_, err := clientExec.Exec("curl", "-sS", "--max-time", "2", urlStr)
+			return err
+		}).WithTimeout(2 * time.Minute).WithPolling(time.Second).Should(Succeed())
+
 		By("asserting stretched L2 disruption is within acceptable bounds during router pod deletion and recovery")
 		result := stopAndCount()
 		By(fmt.Sprintf("==> %s", result.String()))
 		Expect(result.eval()).To(
 			Succeed(),
-			"curl failures exceeded threshold during router pod deletion and recovery (%d/%d failed). Failed timestamps: %+v",
-			result.failCount,
-			result.totalCount,
-			result.failedTimestamps,
+			"curl failures exceeded threshold during router pod deletion and recovery. Result: %s",
+			result.String(),
 		)
 	})
 })
@@ -663,21 +668,22 @@ func measureTrafficLoss(exec executor.Executor, urlStr string) func() trafficTes
 	ctx, cancel := context.WithCancel(context.Background())
 	DeferCleanup(cancel)
 	go func() {
+		t := time.NewTicker(500 * time.Millisecond)
+		defer t.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			default:
+			case <-t.C:
+				_, err := exec.Exec("curl", "-sS", "--max-time", "0.4", urlStr)
+				mu.Lock()
+				if err != nil {
+					trafficTestCount.failCount++
+					trafficTestCount.failedTimestamps = append(trafficTestCount.failedTimestamps, time.Now())
+				}
+				trafficTestCount.totalCount++
+				mu.Unlock()
 			}
-			_, err := exec.Exec("curl", "-sS", "--max-time", "2", urlStr)
-			mu.Lock()
-			if err != nil {
-				trafficTestCount.failCount++
-				trafficTestCount.failedTimestamps = append(trafficTestCount.failedTimestamps, time.Now())
-			}
-			trafficTestCount.totalCount++
-			mu.Unlock()
-			time.Sleep(300 * time.Millisecond)
 		}
 	}()
 	return func() trafficTestResult {
@@ -688,19 +694,21 @@ func measureTrafficLoss(exec executor.Executor, urlStr string) func() trafficTes
 	}
 }
 
+// eval evaluates the trafficTestResult. We allow for up to 24 failures.
+// Meaning that with a tick interval of 500ms, we allow up to ca. 12 seconds of downtime.
 func (tr trafficTestResult) eval() error {
-	const maxAllowedFailures = 5
+	const maxAllowedFailures = 24
 	if tr.totalCount == 0 {
-		return fmt.Errorf("no traffic was measured")
+		return errors.New("no traffic was measured")
 	}
 	if tr.failCount > maxAllowedFailures {
-		return fmt.Errorf(tr.String())
+		return errors.New(tr.String())
 	}
 	return nil
 }
 
 func (tr trafficTestResult) String() string {
-	return fmt.Sprintf("failed %d/%d times", tr.failCount, tr.totalCount)
+	return fmt.Sprintf("failed %d/%d times, timestamps: %+v", tr.failCount, tr.totalCount, tr.failedTimestamps)
 }
 
 func dumpUnderlayVeths(cs clientset.Interface, label string) {

--- a/e2etests/tests/systemd_resiliency.go
+++ b/e2etests/tests/systemd_resiliency.go
@@ -451,14 +451,19 @@ var _ = Describe("Systemd: Data plane continuity during FRR restart", Label("sys
 			},
 		)
 
+		By("verifying stretched L2 traffic works after restart")
+		Eventually(func() error {
+			_, err := clientExec.Exec("curl", "-sS", "--max-time", "2", urlStr)
+			return err
+		}).WithTimeout(2 * time.Minute).WithPolling(time.Second).Should(Succeed())
+
 		By("asserting data plane disruption is within acceptable bounds")
 		result := stopAndCount()
 		By(fmt.Sprintf("==> %s", result.String()))
 		Expect(result.eval()).To(
 			Succeed(),
-			"curl failures exceeded threshold during routerpod restart (%d/%d failed)",
-			result.failCount,
-			result.totalCount,
+			"curl failures exceeded threshold during routerpod restart. Result: %s",
+			result.String(),
 		)
 	})
 })


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind flake

**What this PR does / why we need it**:

measureTrafficLoss did not use a fixed interval for when it ran its
tests. Meaning that if a curl hung, each run would happen at ca.
2 seconds + 300 ms. Use a 500ms ticker instead and cap the curl at
400ms. Set maxAllowedFailures to 40 to allow for a maximum ~20 seconds
of downtime.
Also make sure that traffic actually works again before stopping and
counting.

**Special notes for your reviewer**:
Related to: https://github.com/openperouter/openperouter/issues/664
This PR adds a few improvements and increases the timeout by a few seconds.

However, the underlying RC for the issue seem to be repeated reconciles which in turn delay BGP session establishment and I'm not sure how to address this.

**Release note**:

```release-note
None
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resiliency test validation by confirming traffic has recovered before measuring disruption.
  * Updated traffic monitoring to provide more consistent recovery results.
  * Added clearer failure reporting, including failure timestamps and recovery details.
  * Tests now detect missing traffic measurements and allow a defined level of disruption before failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->