### PR TITLE
fix(hostnetwork): protect externally managed bridges from deletion

### DIFF
--- a/api/v1alpha1/l2vni_types.go
+++ b/api/v1alpha1/l2vni_types.go
@@ -142,6 +142,7 @@ const (
 
 // LinuxBridgeConfig contains configuration for Linux bridge type.
 // +kubebuilder:validation:XValidation:rule="(self.?name.orValue(\"\") != \"\") != (self.?lifecycle.orValue(\"\") == 'Managed')",message="name must be set when lifecycle is External, and must not be set when it is Managed."
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf) || self.lifecycle == oldSelf.lifecycle",message="lifecycle is immutable once set"
 type LinuxBridgeConfig struct {
 	// lifecycle determines if the bridge is managed by the controller or
 	// provided by the user.
@@ -159,6 +160,7 @@ type LinuxBridgeConfig struct {
 
 // OVSBridgeConfig contains configuration for OVS bridge type.
 // +kubebuilder:validation:XValidation:rule="(self.?name.orValue(\"\") != \"\") != (self.?lifecycle.orValue(\"\") == 'Managed')",message="name must be set when lifecycle is External, and must not be set when it is Managed."
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf) || self.lifecycle == oldSelf.lifecycle",message="lifecycle is immutable once set"
 type OVSBridgeConfig struct {
 	// lifecycle determines if the OVS bridge is managed by the controller or
 	// provided by the user.

--- a/internal/controller/routerconfiguration/host_config.go
+++ b/internal/controller/routerconfiguration/host_config.go
@@ -36,7 +36,7 @@ func (k *KernelDatapathConfigurator) Configure(ctx context.Context, config inter
 		return fmt.Errorf("failed to check if target namespace %s has underlay: %w", config.targetNamespace, err)
 	}
 	if len(currentUnderlayIfaces) > 0 && len(config.Underlays) == 0 {
-		restoreUnderlay(ctx, config.targetNamespace, currentUnderlayIfaces)
+		restoreUnderlay(ctx, config.targetNamespace, currentUnderlayIfaces, externalBridgeNames(config.L2VNIs))
 		return nil
 	}
 
@@ -70,7 +70,7 @@ func (k *KernelDatapathConfigurator) Configure(ctx context.Context, config inter
 		// VXLAN tunnels are bound to the current underlay interfaces. If all underlay interfaces are being
 		// replaced, tear down the VNIs first so they don't reference stale interfaces; they'll be recreated
 		// on top of the new underlay.
-		if err := hostnetwork.RemoveAllVNIs(config.targetNamespace); err != nil {
+		if err := hostnetwork.RemoveAllVNIs(config.targetNamespace, externalBridgeNames(config.L2VNIs)); err != nil {
 			slog.Warn("failed to remove vnis during underlay change", "err", err)
 		}
 		bridgerefresh.StopAllVNIs()
@@ -173,7 +173,7 @@ func (k *KernelDatapathConfigurator) Configure(ctx context.Context, config inter
 	}
 
 	slog.InfoContext(ctx, "removing deleted vnis")
-	if err := hostnetwork.RemoveNonConfiguredVNIs(config.targetNamespace, configuredVNIs); err != nil {
+	if err := hostnetwork.RemoveNonConfiguredVNIs(config.targetNamespace, configuredVNIs, externalBridgeNames(config.L2VNIs)); err != nil {
 		return fmt.Errorf("failed to remove deleted vnis: %w", err)
 	}
 	bridgerefresh.StopForRemovedVNIs(configuredL2VNIs)
@@ -202,10 +202,11 @@ func restoreUnderlay(
 	ctx context.Context,
 	targetNamespace string,
 	currentUnderlayIfaces []hostnetwork.UnderlayInterface,
+	externalBridges map[string]struct{},
 ) {
 	slog.InfoContext(ctx, "underlay removed, cleaning up VNIs and underlay interfaces")
 
-	if err := hostnetwork.RemoveAllVNIs(targetNamespace); err != nil {
+	if err := hostnetwork.RemoveAllVNIs(targetNamespace, externalBridges); err != nil {
 		slog.Warn("failed to remove vnis after underlay removal", "err", err)
 	}
 
@@ -275,4 +276,24 @@ func areAllUnderlayInterfacesToBeRemoved(
 		)
 	}
 	return allRemoved, nil
+}
+
+func externalBridgeNames(l2vnis []v1alpha1.L2VNI) map[string]struct{} {
+	res := map[string]struct{}{}
+	for _, l2vni := range l2vnis {
+		if l2vni.Spec.HostMaster == nil {
+			continue
+		}
+		switch {
+		case l2vni.Spec.HostMaster.LinuxBridge != nil &&
+			l2vni.Spec.HostMaster.LinuxBridge.Lifecycle == v1alpha1.BridgeLifecycleExternal &&
+			l2vni.Spec.HostMaster.LinuxBridge.Name != nil:
+			res[*l2vni.Spec.HostMaster.LinuxBridge.Name] = struct{}{}
+		case l2vni.Spec.HostMaster.OVSBridge != nil &&
+			l2vni.Spec.HostMaster.OVSBridge.Lifecycle == v1alpha1.BridgeLifecycleExternal &&
+			l2vni.Spec.HostMaster.OVSBridge.Name != nil:
+			res[*l2vni.Spec.HostMaster.OVSBridge.Name] = struct{}{}
+		}
+	}
+	return res
 }

--- a/internal/hostnetwork/l3vpn_test.go
+++ b/internal/hostnetwork/l3vpn_test.go
@@ -333,7 +333,7 @@ var _ = Describe("L3 VPN configuration", func() {
 		deletedL3vpnParams = l3vpnParams[1:2]
 		l3vpnParams = l3vpnParams[0:1]
 		Expect(RemoveNonConfiguredL3VPNs(testNSPath(), l3vpnParams)).To(Succeed())
-		Expect(RemoveNonConfiguredVNIs(testNSPath(), allVNIParams())).To(Succeed())
+		Expect(RemoveNonConfiguredVNIs(testNSPath(), allVNIParams(), nil)).To(Succeed())
 		Expect(RemoveNonConfiguredVRFs(testNSPath(), allVRFs())).To(Succeed())
 		validateAll()
 
@@ -341,7 +341,7 @@ var _ = Describe("L3 VPN configuration", func() {
 		deletedL2vniParams = l2vniParams[0:1]
 		l2vniParams = []L2VNIParams{}
 		Expect(RemoveNonConfiguredL3VPNs(testNSPath(), l3vpnParams)).To(Succeed())
-		Expect(RemoveNonConfiguredVNIs(testNSPath(), allVNIParams())).To(Succeed())
+		Expect(RemoveNonConfiguredVNIs(testNSPath(), allVNIParams(), nil)).To(Succeed())
 		Expect(RemoveNonConfiguredVRFs(testNSPath(), allVRFs())).To(Succeed())
 		validateAll()
 
@@ -349,7 +349,7 @@ var _ = Describe("L3 VPN configuration", func() {
 		deletedL3vpnParams = append(deletedL3vpnParams, l3vpnParams[0])
 		l3vpnParams = []L3VPNParams{}
 		Expect(RemoveNonConfiguredL3VPNs(testNSPath(), l3vpnParams)).To(Succeed())
-		Expect(RemoveNonConfiguredVNIs(testNSPath(), allVNIParams())).To(Succeed())
+		Expect(RemoveNonConfiguredVNIs(testNSPath(), allVNIParams(), nil)).To(Succeed())
 		Expect(RemoveNonConfiguredVRFs(testNSPath(), allVRFs())).To(Succeed())
 		validateAll()
 	})

--- a/internal/hostnetwork/ovs_bridge.go
+++ b/internal/hostnetwork/ovs_bridge.go
@@ -58,9 +58,8 @@ func EnsureBridge(ctx context.Context, ovs libovsclient.Client, bridgeName strin
 
 	namedUUID := "new_bridge"
 	br = &ovsmodel.Bridge{
-		UUID:        namedUUID,
-		Name:        bridgeName,
-		ExternalIDs: map[string]string{"created-by": "openperouter"},
+		UUID: namedUUID,
+		Name: bridgeName,
 	}
 
 	insertOp, err := ovs.Create(br)

--- a/internal/hostnetwork/vni.go
+++ b/internal/hostnetwork/vni.go
@@ -277,20 +277,23 @@ func setupVNI(ctx context.Context, params VNIParams, bridgeOptions ...NetlinkOpt
 }
 
 // RemoveAllVNIs removes from the target namespace the bridges / veths
-// for all VNIs.
-func RemoveAllVNIs(targetNS string) error {
-	return RemoveNonConfiguredVNIs(targetNS, []VNIParams{})
+// for all VNIs. Bridges whose name appears in externalBridges are never
+// deleted — they are user-managed.
+func RemoveAllVNIs(targetNS string, externalBridges map[string]struct{}) error {
+	return RemoveNonConfiguredVNIs(targetNS, []VNIParams{}, externalBridges)
 }
 
 // RemoveNonConfiguredVNIs removes from the target namespace the
 // leftovers corresponding to VNIs that are not configured anymore.
-func RemoveNonConfiguredVNIs(targetNS string, params []VNIParams) error {
+// Bridges whose name appears in externalBridges are never deleted —
+// they are user-managed; only veth ports are detached.
+func RemoveNonConfiguredVNIs(targetNS string, params []VNIParams, externalBridges map[string]struct{}) error {
 	vnis := map[int32]bool{}
 	for _, p := range params {
 		vnis[p.VNI] = true
 	}
 
-	errs := removeHostSideVNIs(vnis)
+	errs := removeHostSideVNIs(vnis, externalBridges)
 
 	ns, err := netns.GetFromPath(targetNS)
 	if err != nil {
@@ -315,17 +318,17 @@ func RemoveNonConfiguredVNIs(targetNS string, params []VNIParams) error {
 	return nil
 }
 
-func removeHostSideVNIs(vnis map[int32]bool) []error {
+func removeHostSideVNIs(vnis map[int32]bool, externalBridges map[string]struct{}) []error {
 	var failedDeletes []error
 
 	hostLinks, err := netlink.LinkList()
 	if err != nil {
 		return []error{fmt.Errorf("remove non configured vnis: failed to list links: %w", err)}
 	}
-	if err := deleteLinksForType(BridgeLinkType, vnis, hostLinks, vniFromHostBridgeName); err != nil {
+	if err := deleteLinksForType(BridgeLinkType, vnis, hostLinks, vniFromHostBridgeName, externalBridges); err != nil {
 		failedDeletes = append(failedDeletes, fmt.Errorf("remove bridge links: %w", err))
 	}
-	if err := removeOVSBridgesForVNIs(context.Background(), vnis); err != nil {
+	if err := removeOVSBridgesForVNIs(context.Background(), vnis, externalBridges); err != nil {
 		failedDeletes = append(failedDeletes, fmt.Errorf("remove OVS bridges: %w", err))
 	}
 
@@ -339,21 +342,26 @@ func removeNamespaceSideVNIs(vnis map[int32]bool) []error {
 	if err != nil {
 		return []error{fmt.Errorf("remove non configured vnis: failed to list links: %w", err)}
 	}
-	if err := deleteLinksForType(VXLanLinkType, vnis, links, vniFromVXLanName); err != nil {
+	if err := deleteLinksForType(VXLanLinkType, vnis, links, vniFromVXLanName, nil); err != nil {
 		failedDeletes = append(failedDeletes, fmt.Errorf("remove vlan links: %w", err))
 	}
-	if err := deleteLinksForType(BridgeLinkType, vnis, links, vniFromBridgeName); err != nil {
+	if err := deleteLinksForType(BridgeLinkType, vnis, links, vniFromBridgeName, nil); err != nil {
 		failedDeletes = append(failedDeletes, fmt.Errorf("remove bridge links: %w", err))
 	}
 	return failedDeletes
 }
 
-// deleteLinks deletes all the links of the given type that do not correspond to
-// any VNI.
-func deleteLinksForType(linkType string, vnis map[int32]bool, links []netlink.Link, vniFromName func(string) (int32, error)) error {
+// deleteLinksForType deletes all the links of the given type that do not
+// correspond to any configured VNI. Links whose name appears in
+// externalBridges are never deleted — they are user-managed.
+func deleteLinksForType(linkType string, vnis map[int32]bool, links []netlink.Link, vniFromName func(string) (int32, error), externalBridges map[string]struct{}) error {
 	deleteErrors := []error{}
 	for _, l := range links {
 		if l.Type() != netlinkTypeFor(linkType) {
+			continue
+		}
+		if _, ok := externalBridges[l.Attrs().Name]; ok {
+			slog.Debug("skipping externally managed bridge", "name", l.Attrs().Name)
 			continue
 		}
 		vni, err := vniFromName(l.Attrs().Name)
@@ -385,9 +393,10 @@ func netlinkTypeFor(linkType string) string {
 	return linkType
 }
 
-// removeOVSBridgesForVNIs removes auto-created OVS bridges that are not in the configured VNIs list.
-// Only deletes bridges with external_id "created-by: openperouter" (auto-created bridges).
-func removeOVSBridgesForVNIs(ctx context.Context, vnis map[int32]bool) error {
+// removeOVSBridgesForVNIs removes OVS bridges that are not in the configured
+// VNIs list. Bridges whose name appears in externalBridges are never deleted —
+// only veth ports are detached.
+func removeOVSBridgesForVNIs(ctx context.Context, vnis map[int32]bool, externalBridges map[string]struct{}) error {
 	ovs, err := NewOVSClient(ctx)
 	if err != nil {
 		// OVS not available, skip cleanup gracefully
@@ -413,14 +422,10 @@ func removeOVSBridgesForVNIs(ctx context.Context, vnis map[int32]bool) error {
 	deleteErrors := []error{}
 	var ops []ovsdb.Operation
 	for _, bridge := range bridges {
-		slog.Debug("checking OVS bridge for cleanup", "name", bridge.Name, "uuid", bridge.UUID, "external_ids", bridge.ExternalIDs)
+		slog.Debug("checking OVS bridge for cleanup", "name", bridge.Name, "uuid", bridge.UUID)
 
-		createdBy, hasMarker := bridge.ExternalIDs["created-by"]
-		managedByUs := hasMarker && createdBy == "openperouter"
-
-		if !managedByUs {
-			// For non-managed bridges, only detach our veth ports for removed VNIs.
-			// vnis is the set of VNIs we want to keep; ports for any other VNI are removed.
+		if _, ok := externalBridges[bridge.Name]; ok {
+			slog.Debug("skipping externally managed OVS bridge, detaching ports only", "name", bridge.Name)
 			if err := detachOurPortsFromBridge(ctx, ovs, bridge, vnis); err != nil {
 				deleteErrors = append(deleteErrors, err)
 			}

--- a/internal/hostnetwork/vni_ovs_bridge_test.go
+++ b/internal/hostnetwork/vni_ovs_bridge_test.go
@@ -55,7 +55,7 @@ var _ = Describe("L2 VNI configuration with OVS bridges", func() {
 		}, 30*time.Second, 1*time.Second).Should(Succeed())
 
 		By("removing the VNI")
-		err = RemoveNonConfiguredVNIs(testNSPath(), []VNIParams{})
+		err = RemoveNonConfiguredVNIs(testNSPath(), []VNIParams{}, nil)
 		Expect(err).NotTo(HaveOccurred())
 		err = RemoveNonConfiguredVRFs(testNSPath(), map[string]bool{})
 		Expect(err).NotTo(HaveOccurred())
@@ -98,7 +98,7 @@ var _ = Describe("L2 VNI configuration with OVS bridges", func() {
 		}, 30*time.Second, 1*time.Second).Should(Succeed())
 
 		By("removing the VNI")
-		err = RemoveNonConfiguredVNIs(testNSPath(), []VNIParams{})
+		err = RemoveNonConfiguredVNIs(testNSPath(), []VNIParams{}, map[string]struct{}{bridgeName: {}})
 		Expect(err).NotTo(HaveOccurred())
 		err = RemoveNonConfiguredVRFs(testNSPath(), map[string]bool{})
 		Expect(err).NotTo(HaveOccurred())
@@ -149,7 +149,7 @@ var _ = Describe("L2 VNI configuration with OVS bridges", func() {
 		}, 30*time.Second, 1*time.Second).Should(Succeed())
 
 		By("removing VNI 100, keeping VNI 101")
-		err = RemoveNonConfiguredVNIs(testNSPath(), []VNIParams{params2.VNIParams})
+		err = RemoveNonConfiguredVNIs(testNSPath(), []VNIParams{params2.VNIParams}, nil)
 		Expect(err).NotTo(HaveOccurred())
 		err = RemoveNonConfiguredVRFs(testNSPath(), map[string]bool{params2.VRF: true})
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/hostnetwork/vni_test.go
+++ b/internal/hostnetwork/vni_test.go
@@ -169,7 +169,7 @@ var _ = Describe("L3 VNI configuration", func() {
 		toDelete := params[1]
 
 		By("removing non configured L3VNIs")
-		err := RemoveNonConfiguredVNIs(testNSPath(), []VNIParams{remaining.VNIParams})
+		err := RemoveNonConfiguredVNIs(testNSPath(), []VNIParams{remaining.VNIParams}, nil)
 		Expect(err).NotTo(HaveOccurred())
 		err = RemoveNonConfiguredVRFs(testNSPath(), map[string]bool{remaining.VRF: true})
 		Expect(err).NotTo(HaveOccurred())
@@ -366,7 +366,7 @@ var _ = Describe("L2 VNI configuration", func() {
 		}, 30*time.Second, 1*time.Second).Should(Succeed())
 
 		By("removing the VNI")
-		err = RemoveNonConfiguredVNIs(testNSPath(), []VNIParams{})
+		err = RemoveNonConfiguredVNIs(testNSPath(), []VNIParams{}, nil)
 		Expect(err).NotTo(HaveOccurred())
 		err = RemoveNonConfiguredVRFs(testNSPath(), map[string]bool{})
 		Expect(err).NotTo(HaveOccurred())
@@ -382,6 +382,101 @@ var _ = Describe("L2 VNI configuration", func() {
 				if params.VRF != "" {
 					checkLinkdeleted(g, params.VRF)
 				}
+				return nil
+			})
+		}, 30*time.Second, 1*time.Second).Should(Succeed())
+	})
+
+	It("should not delete an external bridge whose name matches br-hs-*", func() {
+		const externalBridgeName = "br-hs-666"
+		createLinuxBridge(externalBridgeName)
+
+		params := L2VNIParams{
+			VNIParams: VNIParams{
+				VRF:       "testred",
+				TargetNS:  testNSPath(),
+				VTEPIP:    "192.170.0.9/32",
+				VNI:       100,
+				VXLanPort: new(int32(4789)),
+			},
+			L2GatewayIPs: []string{"192.168.1.0/24"},
+			HostMaster: &HostMaster{
+				Name: new(externalBridgeName),
+				Type: BridgeLinkType,
+			},
+		}
+
+		createVRFInNamespace(testNS, params.VRF)
+		err := SetupL2VNI(context.Background(), params)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func(g Gomega) {
+			validateL2HostLeg(g, params)
+			_ = netnamespace.In(testNS, func() error {
+				validateL2VNI(g, params)
+				return nil
+			})
+		}, 30*time.Second, 1*time.Second).Should(Succeed())
+
+		By("removing the L2VNI")
+		err = RemoveNonConfiguredVNIs(testNSPath(), []VNIParams{}, map[string]struct{}{externalBridgeName: {}})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("checking the external bridge still exists")
+		Eventually(func(g Gomega) {
+			checkLinkExists(g, externalBridgeName)
+
+			vethNames := vethNamesFromVNI(params.VNI)
+			checkLinkdeleted(g, vethNames.HostSide)
+			_ = netnamespace.In(testNS, func() error {
+				validateVNIIsNotConfigured(g, params.VNIParams)
+				return nil
+			})
+		}, 30*time.Second, 1*time.Second).Should(Succeed())
+	})
+
+	It("should delete a managed bridge whose name matches br-hs-*", func() {
+		params := L2VNIParams{
+			VNIParams: VNIParams{
+				VRF:       "testred",
+				TargetNS:  testNSPath(),
+				VTEPIP:    "192.170.0.9/32",
+				VNI:       100,
+				VXLanPort: new(int32(4789)),
+			},
+			L2GatewayIPs: []string{"192.168.1.0/24"},
+			HostMaster: &HostMaster{
+				AutoCreate: new(true),
+				Type:       BridgeLinkType,
+			},
+		}
+
+		createVRFInNamespace(testNS, params.VRF)
+		err := SetupL2VNI(context.Background(), params)
+		Expect(err).NotTo(HaveOccurred())
+
+		managedBridgeName := hostBridgeName(params.VNI)
+		Eventually(func(g Gomega) {
+			checkLinkExists(g, managedBridgeName)
+			validateL2HostLeg(g, params)
+			_ = netnamespace.In(testNS, func() error {
+				validateL2VNI(g, params)
+				return nil
+			})
+		}, 30*time.Second, 1*time.Second).Should(Succeed())
+
+		By("removing the L2VNI")
+		err = RemoveNonConfiguredVNIs(testNSPath(), []VNIParams{}, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("checking the managed bridge is deleted")
+		Eventually(func(g Gomega) {
+			checkLinkdeleted(g, managedBridgeName)
+
+			vethNames := vethNamesFromVNI(params.VNI)
+			checkLinkdeleted(g, vethNames.HostSide)
+			_ = netnamespace.In(testNS, func() error {
+				validateVNIIsNotConfigured(g, params.VNIParams)
 				return nil
 			})
 		}, 30*time.Second, 1*time.Second).Should(Succeed())
@@ -436,7 +531,7 @@ var _ = Describe("L2 VNI configuration", func() {
 		toDelete := params[1]
 
 		By("removing non configured L2VNIs")
-		err := RemoveNonConfiguredVNIs(testNSPath(), []VNIParams{remaining.VNIParams})
+		err := RemoveNonConfiguredVNIs(testNSPath(), []VNIParams{remaining.VNIParams}, nil)
 		Expect(err).NotTo(HaveOccurred())
 		err = RemoveNonConfiguredVRFs(testNSPath(), map[string]bool{remaining.VRF: true})
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>

/kind bug

> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
deleteLinksForType extracts VNIs from bridge names and deletes bridges whose VNI is not in the configured set. External bridges encode a user-chosen number that differs from the L2VNI's actual VNI, causing wrongful deletion. Thread externalBridges set (map[string]struct{}) from API-level L2VNIs through the cleanup chain so both Linux and OVS paths skip bridges with External lifecycle. Drop the redundant OVS created-by external ID. Make lifecycle immutable via CEL XValidation.

**Special notes for your reviewer**:
Fixes: #662 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix external bridge deletion: bridges with External lifecycle are no longer wrongly removed by the reconciler when their name matches the br-hs-* pattern.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved externally managed Linux and OVS bridges during VNI cleanup and underlay transitions.
  - Detached relevant virtual ports without deleting bridges managed outside the system.
  - Removed reliance on internal bridge metadata when identifying externally managed bridges.
  - Prevented changes to an L2 VNI’s lifecycle setting after it has been configured.
- **Tests**
  - Added coverage confirming externally managed bridges are preserved while automatically managed bridges are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->