### PR TITLE
fix(hostmode): fix setup of loglevel

### DIFF
--- a/cmd/hostcontroller/main.go
+++ b/cmd/hostcontroller/main.go
@@ -197,6 +197,21 @@ func main() {
 	// Initialize OVS socket path for the hostnetwork package
 	hostnetwork.OVSSocketPath = args.ovsSocketPath
 
+	// In case of modeHost, parse nodeConfig early so that the correct logLevel is set for the logger.
+	var nodeConfig *static.NodeConfig
+	if args.mode == modeHost {
+		var err error
+		nodeConfig, err = staticconfiguration.ReadNodeConfig(hostModeParams.nodeConfigPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to load the node configuration file: %q", err)
+			os.Exit(1)
+		}
+		if err := overrideHostMode(&args, *nodeConfig); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to override host mode arguments: %q", err)
+			os.Exit(1)
+		}
+	}
+
 	logger, err := logging.New(args.logLevel)
 	if err != nil {
 		fmt.Println("unable to init logger", err)
@@ -229,7 +244,7 @@ func main() {
 		return
 	}
 
-	runHostMode(ctx, args, hostModeParams, logger)
+	runHostMode(ctx, args, hostModeParams, logger, nodeConfig)
 }
 
 func runK8sMode(
@@ -262,18 +277,9 @@ func runHostMode(
 	args parameters,
 	hostModeParams hostModeParameters,
 	logger *slog.Logger,
+	nodeConfig *static.NodeConfig,
 ) {
 	// host mode: run the host reconciler and keep polling until the k8s api is available.
-	nodeConfig, err := staticconfiguration.ReadNodeConfig(hostModeParams.nodeConfigPath)
-	if err != nil {
-		logger.Error("failed to load the node configuration file", "error", err)
-		os.Exit(1)
-	}
-	if err := overrideHostMode(&args, *nodeConfig); err != nil {
-		logger.Error("failed to override host mode arguments", "error", err)
-		os.Exit(1)
-	}
-
 	dhcpSupervisor := dhcp.NewLazySupervisor(logger)
 	cniinvoker.Init(args.cniPluginDirs.values, args.cniCacheDir, args.nodeName, dhcpSupervisor)
 	setupLog.Info("CNI plugin invoker initialized for host mode",


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

In modeHost, parse nodeConfig early so that the logger is initialized
with the correct logLevel. Prior to this commit, FRR would receive the
correct logLevel as configured in /etc/openperouter/node-config.yaml
but the controller itself would ignore it.

Fixes https://github.com/openperouter/openperouter/issues/673

**Special notes for your reviewer**:

None

**Release note**:

```release-note
fix: logLevel is ignored in controller container when specified in the nodeConfig when running in systemd mode
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* **Bug Fixes**
  * Host mode now applies the configured log level during logger initialization.
  * Configuration and host-mode override errors are reported immediately with clear failure output.
  * Host mode exits promptly when required configuration cannot be loaded or applied, preventing startup with incomplete settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->