### PR TITLE
Bridge refresher E2E - fix potential flake, refactor and collect additional data

### DIFF
--- a/e2etests/pkg/executor/executor.go
+++ b/e2etests/pkg/executor/executor.go
@@ -3,6 +3,7 @@
 package executor
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -15,6 +16,11 @@ var Kubectl string
 
 type Executor interface {
 	Exec(cmd string, args ...string) (string, error)
+}
+
+type ExecutorWithContext interface {
+	Executor
+	CommandContext(ctx context.Context, cmd string, args ...string) (string, error)
 }
 
 type hostExecutor struct{}
@@ -35,7 +41,7 @@ func (hostExecutor) Exec(cmd string, args ...string) (string, error) {
 	return string(out), err
 }
 
-func ForContainer(containerName string) Executor {
+func ForContainer(containerName string) ExecutorWithContext {
 	return &containerExecutor{container: containerName}
 }
 
@@ -46,6 +52,12 @@ type containerExecutor struct {
 func (e *containerExecutor) Exec(cmd string, args ...string) (string, error) {
 	newArgs := append([]string{"exec", e.container, cmd}, args...)
 	out, err := exec.Command(ContainerRuntime, newArgs...).CombinedOutput()
+	return string(out), err
+}
+
+func (e *containerExecutor) CommandContext(ctx context.Context, cmd string, args ...string) (string, error) {
+	newArgs := append([]string{"exec", e.container, cmd}, args...)
+	out, err := exec.CommandContext(ctx, ContainerRuntime, newArgs...).CombinedOutput()
 	return string(out), err
 }
 

--- a/e2etests/pkg/sysctl/sysctl.go
+++ b/e2etests/pkg/sysctl/sysctl.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package sysctl
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const (
+	NeighDefaultGcThreshMax = "2147483647"
+)
+
+// Sysctl represents a sysctl setting to be enabled.
+type Sysctl struct {
+	Path        string // The sysctl path under /proc/sys/
+	Description string // Human-readable description for logging
+	Value       string // Value to configure or to read
+}
+
+// Ensure enables the given sysctls.
+// Each sysctl is checked and only written if not already set to the target value.
+func Ensure(sysctls ...Sysctl) error {
+	var errs []error
+	for _, s := range sysctls {
+		if err := ensureSysctl(s); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// Read reads the given sysctls and stores the value in Value.
+func Read(sysctls ...*Sysctl) error {
+	for _, s := range sysctls {
+		if err := readSysctl(s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func IPv4NeighDefaultGcThresh1(targetValue string) Sysctl {
+	return Sysctl{
+		Path: "net/ipv4/neigh/default/gc_thresh1",
+		Description: "Minimum number of entries to keep. " +
+			"Garbage collector will not purge entries if there are fewer than this number.",
+		Value: targetValue,
+	}
+}
+
+func IPv4NeighDefaultGcThresh2(targetValue string) Sysctl {
+	return Sysctl{
+		Path: "net/ipv4/neigh/default/gc_thresh2",
+		Description: "Threshold when garbage collector becomes more aggressive about purging entries. " +
+			"Entries older than 5 seconds will be cleared when over this number.",
+		Value: targetValue,
+	}
+}
+
+func IPv4NeighDefaultGcThresh3(targetValue string) Sysctl {
+	return Sysctl{
+		Path: "net/ipv4/neigh/default/gc_thresh3",
+		Description: "Maximum number of non-PERMANENT neighbor entries allowed. " +
+			"Increase this when using large numbers of interfaces and when communicating " +
+			"with large numbers of directly-connected peers.",
+		Value: targetValue,
+	}
+}
+
+func IPv6NeighDefaultGcThresh1(targetValue string) Sysctl {
+	return Sysctl{
+		Path: "net/ipv6/neigh/default/gc_thresh1",
+		Description: "Minimum number of entries to keep. " +
+			"Garbage collector will not purge entries if there are fewer than this number.",
+		Value: targetValue,
+	}
+}
+
+func IPv6NeighDefaultGcThresh2(targetValue string) Sysctl {
+	return Sysctl{
+		Path: "net/ipv6/neigh/default/gc_thresh2",
+		Description: "Threshold when garbage collector becomes more aggressive about purging entries. " +
+			"Entries older than 5 seconds will be cleared when over this number.",
+		Value: targetValue,
+	}
+}
+
+func IPv6NeighDefaultGcThresh3(targetValue string) Sysctl {
+	return Sysctl{
+		Path: "net/ipv6/neigh/default/gc_thresh3",
+		Description: "Maximum number of non-PERMANENT neighbor entries allowed. " +
+			"Increase this when using large numbers of interfaces and when communicating " +
+			"with large numbers of directly-connected peers.",
+		Value: targetValue,
+	}
+}
+
+// ensureSysctl reads the sysctl at the given path and writes the desired value with sudo if it differs
+// from the current one.
+func ensureSysctl(s Sysctl) error {
+	path := "/proc/sys/" + s.Path
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", path, err)
+	}
+	currentValue := strings.TrimSpace(string(data))
+	if currentValue == s.Value {
+		return nil
+	}
+
+	cmd := []string{"/bin/bash", "-c", fmt.Sprintf("echo %s > %s", s.Value, path)}
+	if out, err := exec.Command("sudo", cmd...).CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to write to %s: %w (%s)", path, err, out)
+	}
+
+	data, err = os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", path, err)
+	}
+	currentValue = strings.TrimSpace(string(data))
+	if currentValue != s.Value {
+		return fmt.Errorf("failed to set %s to target value %s, current: %s", path, s.Value, currentValue)
+	}
+
+	slog.Info("sysctl enabled", "path", s.Path, "value", s.Value)
+	return nil
+}
+
+// readSysctl reads the sysctl at the given path and writes it to s.Value.
+func readSysctl(s *Sysctl) error {
+	path := "/proc/sys/" + s.Path
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", path, err)
+	}
+	currentValue := strings.TrimSpace(string(data))
+	s.Value = currentValue
+
+	slog.Info("sysctl read", "path", s.Path, "value", s.Value)
+	return nil
+}

--- a/e2etests/tests/bridgerefresh.go
+++ b/e2etests/tests/bridgerefresh.go
@@ -341,7 +341,11 @@ var _ = Describe("BridgeRefresher E2E - Type 2 Route Persistence", Ordered, func
 				By(fmt.Sprintf("Verifying stationary pod (%s) can reach migrating pod (%s) before migration",
 					stationaryPod.Name, migratingPod.Name))
 				stationaryExec := executor.ForPod(testNamespace, stationaryPod.Name, "agnhost")
-				checkPodIsReachable(stationaryExec, stationaryPodIPOnly, migratingPodIPOnly)
+				// Use a ping here instead of checkPodIsReachable which uses curl. The reason: TCP sessions exchange
+				// a bunch of packets during the FIN/ACK dance and we want to get reliably into STALE, so we want to
+				// test connectivity yet be sure that no more packets are exchanged between the hosts once connectivity
+				// is confirmed (stray packets might otherwise bring us from STALE to REACHABLE or from STALE to FAILED).
+				canPingFromPod(stationaryExec, migratingPodIPOnly)
 
 				By(fmt.Sprintf("Verifying Type 2 MAC+IP route exists for migrating pod (%s) "+
 					"on migration source node (%s)", migratingPod.Name, nodeSource.Name))
@@ -355,6 +359,28 @@ var _ = Describe("BridgeRefresher E2E - Type 2 Route Persistence", Ordered, func
 				Eventually(func() error {
 					return checkType2RouteExists(cs, migratingPodIPOnly, vtepIPOnly, l2VNI)
 				}, 3*time.Minute, 5*time.Second).ShouldNot(HaveOccurred())
+
+				// We need the entry for the pod IP to be STALE before the migration.
+				// "STALE: The entry has not been used for a certain period, making the mapping potentially outdated.
+				// The kernel does not immediately remove it but will transition the entry to another state if further
+				// communication occurs." (https://blogs.oracle.com/linux/arp-internals)
+				// Being stale before the migration is important to trigger the deadlock situation described in
+				// https://github.com/FRRouting/frr/issues/14156.
+				// Given that we sent traffic from/to the pod moments ago, we have to wait here until all traffic
+				// between the pods / between the gateway and the pod settles so that we eventually get into STALE state.
+				// To complicate things further, for some reason, the router at br-be-110 often sends an ARP request
+				// a bit later.
+				// If we deleted the pod now without waiting, it would be much more likely that we triggered a state
+				// transition to FAILED early without reproducing the issue because the aforementioned ARP request would
+				// occur while the pod was already deleted.
+				// Note: We are guaranteed to go STALE eventually: we're not sending any more traffic, the bridge
+				// refresher runs every 30 seconds, and we probe every 2 for 3 minutes.
+				By(fmt.Sprintf("Waiting for neighbor entry (%s) on bridge br-pe-%d to go STALE on the "+
+					"router on the same node (%s)",
+					migratingPodIPOnly, l2VNI, migratingPod.Spec.NodeName))
+				Eventually(func() error {
+					return checkNeighborStale(cs, migratingPodIPOnly, l2VNI, migratingPod.Spec.NodeName)
+				}).WithPolling(2 * time.Second).WithTimeout(3 * time.Minute).Should(Succeed())
 
 				By("Deleting migrating pod (simulating pod eviction/migration)")
 				err = cs.CoreV1().Pods(testNamespace).Delete(
@@ -374,14 +400,6 @@ var _ = Describe("BridgeRefresher E2E - Type 2 Route Persistence", Ordered, func
 					return err != nil
 				}, 2*time.Minute, time.Second).Should(BeTrue())
 
-				// This is important to trigger the deadlock situation described in https://github.com/FRRouting/frr/issues/14156
-				By(fmt.Sprintf("Waiting for neighbor entry (%s) on bridge br-pe-%d to go STALE or FAILED on the "+
-					"router on the same node (%s)",
-					migratingPodIPOnly, l2VNI, migratingPod.Spec.NodeName))
-				Eventually(func() error {
-					return checkNeighborStale(cs, migratingPodIPOnly, l2VNI, migratingPod.Spec.NodeName)
-				}, 3*time.Minute, 2*time.Second).ShouldNot(HaveOccurred())
-
 				By(fmt.Sprintf("Recreating migrating pod on migration destination node (%s) with same IP (%s)",
 					nodeDestination.Name, tc.migratingPodIP))
 				migratingPod, err = k8s.CreateAgnhostPod(
@@ -398,7 +416,7 @@ var _ = Describe("BridgeRefresher E2E - Type 2 Route Persistence", Ordered, func
 
 				By(fmt.Sprintf("Verifying migrating pod (%s) can ping the local gateway", migratingPod.Name))
 				newMigratingExec := executor.ForPod(testNamespace, migratingPod.Name, "agnhost")
-				canPingFromPod(newMigratingExec, l2GatewayIPOnly)
+				canPingFromPodWithTimeout(newMigratingExec, l2GatewayIPOnly, 60*time.Second)
 
 				By(fmt.Sprintf("Verifying stationary pod (%s) can reach migrating pod (%s) after migration",
 					stationaryPod.Name, migratingPod.Name))
@@ -453,7 +471,7 @@ func checkNeighborStale(cs clientset.Interface, podIP string, vni int, nodeName 
 	if out == "" {
 		return fmt.Errorf("no neighbor entry for %s on %s in router %s", podIP, bridgeDev, exec.Name())
 	}
-	if strings.Contains(out, "STALE") || strings.Contains(out, "FAILED") {
+	if strings.Contains(out, "STALE") {
 		return nil
 	}
 	return fmt.Errorf("neighbor %s on %s in router %s is not STALE yet: %s", podIP, bridgeDev, exec.Name(), out)

--- a/e2etests/tests/bridgerefresh.go
+++ b/e2etests/tests/bridgerefresh.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openperouter/openperouter/e2etests/pkg/k8s"
 	"github.com/openperouter/openperouter/e2etests/pkg/k8sclient"
 	"github.com/openperouter/openperouter/e2etests/pkg/openperouter"
+	"github.com/openperouter/openperouter/e2etests/pkg/sysctl"
 	"github.com/openperouter/openperouter/internal/ipfamily"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -212,6 +213,33 @@ var _ = Describe("BridgeRefresher E2E - Type 2 Route Persistence", Ordered, func
 			migratingPodIP  string
 			stationaryPodIP string
 		}
+
+		BeforeAll(func() {
+			By("Storing original neighbor GC thresholds")
+			ipv4GcThresh1 := sysctl.IPv4NeighDefaultGcThresh1("")
+			ipv4GcThresh2 := sysctl.IPv4NeighDefaultGcThresh2("")
+			ipv4GcThresh3 := sysctl.IPv4NeighDefaultGcThresh3("")
+			ipv6GcThresh1 := sysctl.IPv6NeighDefaultGcThresh1("")
+			ipv6GcThresh2 := sysctl.IPv6NeighDefaultGcThresh2("")
+			ipv6GcThresh3 := sysctl.IPv6NeighDefaultGcThresh3("")
+			Expect(sysctl.Read(&ipv4GcThresh1, &ipv4GcThresh2, &ipv4GcThresh3,
+				&ipv6GcThresh1, &ipv6GcThresh2, &ipv6GcThresh3)).To(Succeed())
+			DeferCleanup(func() {
+				By("Resetting neighbor GC thresholds to original values")
+				Expect(sysctl.Ensure(ipv4GcThresh1, ipv4GcThresh2, ipv4GcThresh3,
+					ipv6GcThresh1, ipv6GcThresh2, ipv6GcThresh3)).To(Succeed())
+			})
+
+			By("Setting neighbor GC thresholds to max")
+			Expect(sysctl.Ensure(
+				sysctl.IPv4NeighDefaultGcThresh1(sysctl.NeighDefaultGcThreshMax),
+				sysctl.IPv4NeighDefaultGcThresh2(sysctl.NeighDefaultGcThreshMax),
+				sysctl.IPv4NeighDefaultGcThresh3(sysctl.NeighDefaultGcThreshMax),
+				sysctl.IPv6NeighDefaultGcThresh1(sysctl.NeighDefaultGcThreshMax),
+				sysctl.IPv6NeighDefaultGcThresh2(sysctl.NeighDefaultGcThreshMax),
+				sysctl.IPv6NeighDefaultGcThresh3(sysctl.NeighDefaultGcThreshMax),
+			)).To(Succeed())
+		})
 
 		DescribeTable("should maintain connectivity after pod migrates to another node",
 			func(tc migrationTestCase) {

--- a/e2etests/tests/bridgerefresh.go
+++ b/e2etests/tests/bridgerefresh.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	nad "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -213,6 +214,8 @@ var _ = Describe("BridgeRefresher E2E - Type 2 Route Persistence", Ordered, func
 	// In order to have a solid reproducer we need to ping the local gateway so the neighbor table is filled, and
 	// then trigger the migration to the other node.
 	Context("Pod migrates to a different node", func() {
+		var cancelIPNeighMonitorNodeSource, cancelIPNeighMonitorNodeDestination func() (string, error)
+
 		type migrationTestCase struct {
 			l2GatewayIP     string
 			migratingPodIP  string
@@ -291,6 +294,21 @@ var _ = Describe("BridgeRefresher E2E - Type 2 Route Persistence", Ordered, func
 
 				nodeSource := nodes[0]
 				nodeDestination := nodes[1]
+
+				By("Collecting ip neigh monitor during the test")
+				exec := executor.ForContainer(nodeSource.Name)
+				cancelIPNeighMonitorNodeSource = ipNeighMonitor(exec, openperouter.NamedNetns)
+				exec = executor.ForContainer(nodeDestination.Name)
+				cancelIPNeighMonitorNodeDestination = ipNeighMonitor(exec, openperouter.NamedNetns)
+				DeferCleanup(func() {
+					By("Printing ip neigh monitor output after the test for migration source node")
+					output, err := cancelIPNeighMonitorNodeSource()
+					fmt.Fprintf(GinkgoWriter, "ip neigh monitor output: %s; err: %q\n", output, err)
+
+					By("Printing ip neigh monitor output after the test for migration destination node")
+					output, err = cancelIPNeighMonitorNodeDestination()
+					fmt.Fprintf(GinkgoWriter, "ip neigh monitor output: %s; err: %q\n", output, err)
+				})
 
 				By(fmt.Sprintf("Creating stationary pod on migration destination node (%s)", nodeDestination.Name))
 				stationaryPod, err := k8s.CreateAgnhostPod(
@@ -439,4 +457,24 @@ func checkNeighborStale(cs clientset.Interface, podIP string, vni int, nodeName 
 		return nil
 	}
 	return fmt.Errorf("neighbor %s on %s in router %s is not STALE yet: %s", podIP, bridgeDev, exec.Name(), out)
+}
+
+func ipNeighMonitor(exec executor.ExecutorWithContext, namespace string) func() (string, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var mu sync.Mutex
+	var output string
+	var err error
+	go func() {
+		mu.Lock()
+		defer mu.Unlock()
+		output, err = exec.CommandContext(ctx, "ip", "netns", "exec", namespace, "ip", "-ts", "monitor", "neigh")
+	}()
+
+	return func() (string, error) {
+		cancel()
+		mu.Lock()
+		defer mu.Unlock()
+		return output, err
+	}
 }

--- a/e2etests/tests/bridgerefresh.go
+++ b/e2etests/tests/bridgerefresh.go
@@ -71,17 +71,20 @@ var _ = Describe("BridgeRefresher E2E - Type 2 Route Persistence", Ordered, func
 	}
 
 	BeforeAll(func() {
+		By("Cleaning all perouter objects before running the tests")
 		Expect(Updater.CleanAll()).To(Succeed())
 
 		cs = k8sclient.New()
 
-		err := Updater.Update(config.Resources{
+		By("Creating the underlay")
+		Expect(Updater.Update(config.Resources{
 			Underlays: []v1alpha1.Underlay{
 				infra.Underlay,
 			},
-		})
-		Expect(err).NotTo(HaveOccurred())
+		})).To(Succeed())
 
+		By("Getting and dumping the router pods")
+		var err error
 		Eventually(func() error {
 			routers, err = openperouter.Get(cs, HostMode)
 			if err != nil {
@@ -92,15 +95,16 @@ var _ = Describe("BridgeRefresher E2E - Type 2 Route Persistence", Ordered, func
 
 		routers.Dump(ginkgo.GinkgoWriter)
 
-		By("setting redistribute connected on leaves")
+		By("Setting redistribute connected on leaves")
 		Expect(infra.LeafAConfig.RedistributeConnected()).To(Succeed())
 		Expect(infra.LeafBConfig.RedistributeConnected()).To(Succeed())
 	})
 
 	AfterAll(func() {
+		By("Cleaning all perouter objects after running the tests")
 		Expect(Updater.CleanAll()).To(Succeed())
 
-		By("waiting for all router pods to be ready after removing the underlay")
+		By("Waiting for all router pods to be ready after removing the underlay")
 		Eventually(func() error {
 			routers, err := openperouter.Get(cs, HostMode)
 			if err != nil {
@@ -109,6 +113,7 @@ var _ = Describe("BridgeRefresher E2E - Type 2 Route Persistence", Ordered, func
 			return openperouter.AreReady(routers)
 		}, 2*time.Minute, time.Second).ShouldNot(HaveOccurred())
 
+		By("Resetting leaves")
 		Expect(infra.LeafAConfig.Reset()).To(Succeed())
 		Expect(infra.LeafBConfig.Reset()).To(Succeed())
 	})
@@ -201,7 +206,7 @@ var _ = Describe("BridgeRefresher E2E - Type 2 Route Persistence", Ordered, func
 	})
 
 	// This test validates the corner case where a pod migrates from one node to another while having a stale route
-	// to its ip on the local router. The stale router is reflected in a corresponding NOARP route
+	// to its ip on the local router. The stale router is reflected in a corresponding NOARP extern_learn neighbor entry
 	// on other routers, leading to a deadlock situation where the route advertised belongs to the wrong
 	// node and arp coming from the right node are ignored because frr installs the route with NOARP.
 
@@ -284,23 +289,26 @@ var _ = Describe("BridgeRefresher E2E - Type 2 Route Persistence", Ordered, func
 					Expect(Updater.CleanButUnderlay()).To(Succeed())
 				})
 
-				By("Creating stationary pod on node B")
+				nodeSource := nodes[0]
+				nodeDestination := nodes[1]
+
+				By(fmt.Sprintf("Creating stationary pod on migration destination node (%s)", nodeDestination.Name))
 				stationaryPod, err := k8s.CreateAgnhostPod(
 					cs,
 					"stationary-pod",
 					testNamespace,
 					k8s.WithNad(testNad.Name, testNamespace, []string{tc.stationaryPodIP}),
-					k8s.OnNode(nodes[1].Name),
+					k8s.OnNode(nodeDestination.Name),
 				)
 				Expect(err).NotTo(HaveOccurred())
 
-				By("Creating migrating pod on node A")
+				By(fmt.Sprintf("Creating migrating pod on migration source node (%s)", nodeSource.Name))
 				migratingPod, err := k8s.CreateAgnhostPod(
 					cs,
 					"migrating-pod",
 					testNamespace,
 					k8s.WithNad(testNad.Name, testNamespace, []string{tc.migratingPodIP}),
-					k8s.OnNode(nodes[0].Name),
+					k8s.OnNode(nodeSource.Name),
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -308,16 +316,19 @@ var _ = Describe("BridgeRefresher E2E - Type 2 Route Persistence", Ordered, func
 				Expect(removeGatewayFromPod(stationaryPod)).To(Succeed())
 				Expect(removeGatewayFromPod(migratingPod)).To(Succeed())
 
-				By("Verifying migrating pod can ping the local gateway")
+				By(fmt.Sprintf("Verifying migrating pod (%s) can ping the local gateway", migratingPod.Name))
 				migratingExec := executor.ForPod(testNamespace, migratingPod.Name, "agnhost")
 				canPingFromPod(migratingExec, l2GatewayIPOnly)
 
-				By("Verifying stationary pod can reach migrating pod before migration")
+				By(fmt.Sprintf("Verifying stationary pod (%s) can reach migrating pod (%s) before migration",
+					stationaryPod.Name, migratingPod.Name))
 				stationaryExec := executor.ForPod(testNamespace, stationaryPod.Name, "agnhost")
 				checkPodIsReachable(stationaryExec, stationaryPodIPOnly, migratingPodIPOnly)
 
-				By("Verifying Type 2 MAC+IP route exists for migrating pod on node A")
-				migratingPodNode, err := cs.CoreV1().Nodes().Get(context.Background(), migratingPod.Spec.NodeName, metav1.GetOptions{})
+				By(fmt.Sprintf("Verifying Type 2 MAC+IP route exists for migrating pod (%s) "+
+					"on migration source node (%s)", migratingPod.Name, nodeSource.Name))
+				migratingPodNode, err := cs.CoreV1().Nodes().Get(context.Background(), migratingPod.Spec.NodeName,
+					metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				vtepIP, err := openperouter.GetVtepIPv4ForNode(infra.Underlay.Spec.TunnelEndpoint, migratingPodNode)
 				Expect(err).NotTo(HaveOccurred())
@@ -346,29 +357,33 @@ var _ = Describe("BridgeRefresher E2E - Type 2 Route Persistence", Ordered, func
 				}, 2*time.Minute, time.Second).Should(BeTrue())
 
 				// This is important to trigger the deadlock situation described in https://github.com/FRRouting/frr/issues/14156
-				By("Waiting for neighbor entry to go STALE on the router on the same node")
+				By(fmt.Sprintf("Waiting for neighbor entry (%s) on bridge br-pe-%d to go STALE or FAILED on the "+
+					"router on the same node (%s)",
+					migratingPodIPOnly, l2VNI, migratingPod.Spec.NodeName))
 				Eventually(func() error {
 					return checkNeighborStale(cs, migratingPodIPOnly, l2VNI, migratingPod.Spec.NodeName)
 				}, 3*time.Minute, 2*time.Second).ShouldNot(HaveOccurred())
 
-				By("Recreating migrating pod on node B (the other node) with same IP")
+				By(fmt.Sprintf("Recreating migrating pod on migration destination node (%s) with same IP (%s)",
+					nodeDestination.Name, tc.migratingPodIP))
 				migratingPod, err = k8s.CreateAgnhostPod(
 					cs,
 					"migrating-pod-new",
 					testNamespace,
 					k8s.WithNad(testNad.Name, testNamespace, []string{tc.migratingPodIP}),
-					k8s.OnNode(nodes[1].Name),
+					k8s.OnNode(nodeDestination.Name),
 				)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Removing default gateway on recreated pod")
 				Expect(removeGatewayFromPod(migratingPod)).To(Succeed())
 
-				By("Verifying migrated pod can ping the local gateway on new node")
+				By(fmt.Sprintf("Verifying migrating pod (%s) can ping the local gateway", migratingPod.Name))
 				newMigratingExec := executor.ForPod(testNamespace, migratingPod.Name, "agnhost")
 				canPingFromPod(newMigratingExec, l2GatewayIPOnly)
 
-				By("Verifying stationary pod can reach migrated pod on new node")
+				By(fmt.Sprintf("Verifying stationary pod (%s) can reach migrating pod (%s) after migration",
+					stationaryPod.Name, migratingPod.Name))
 				checkPodIsReachable(stationaryExec, stationaryPodIPOnly, migratingPodIPOnly)
 			},
 			Entry("ipv4", migrationTestCase{

--- a/e2etests/tests/validate_pods.go
+++ b/e2etests/tests/validate_pods.go
@@ -40,13 +40,17 @@ func checkPodIsReachableWithExpected(exec executor.Executor, from, to, expected 
 }
 
 func canPingFromPod(exec executor.Executor, ip string) {
+	canPingFromPodWithTimeout(exec, ip, 40*time.Second)
+}
+
+func canPingFromPodWithTimeout(exec executor.Executor, ip string, timeout time.Duration) {
 	GinkgoHelper()
 	Eventually(func(g Gomega) {
 		By(fmt.Sprintf("pinging %s via net1", ip))
 		out, err := exec.Exec("ping", "-c", "1", "-W", "2", "-I", "net1", ip)
 		g.Expect(err).ToNot(HaveOccurred(), "ping to %s failed: %s", ip, out)
 	}).
-		WithTimeout(40 * time.Second).
+		WithTimeout(timeout).
 		WithPolling(time.Second).
 		Should(Succeed())
 }


### PR DESCRIPTION
- **fix(e2e): fix potential flake in bridgerefresher due to neigh tbl prune**
- **refactor(e2e): refactor bridgerefresher e2e tests**
- **fix(e2e): collect ip monitor neigh for bridge refresher e2e tests**
- **fix(e2e): fix triggering bridge refresher STALE condition**

**Is this a BUG FIX or a FEATURE ?**:

/kind flake

**What this PR does / why we need it**:

Address a potential cause for https://github.com/openperouter/openperouter/issues/400
The bridgerefresher E2E test requires that the neighbor entries for the migrated pod go to STALE or FAILED.
However, if the kernel garbage collects the STALE or FAILED entries, the test will fail.
Whereas I'm not sure if the flakes that we see are indeed caused by garbage collection, I can say with certainty
that the exact same symptoms can indeed be triggered by garbage collection.
Therefore, increase the gh_thresh values to their maximum to make garbage collection near impossible.
Refactor the tests slightly to gather some extra data.
And collect ip monitor neigh output in case flakes happen again in the future.

**Special notes for your reviewer**:

While testing, I found that the current test does not reliably reproduce the issue. 
a) The original test case checked for STALE | FAILED. However, a FAILED entry will be purged from the neighbor table and does not reproduce the issue. 
b) The entry must be in STALE _before_ the migration. Otherwise, if the pod's neighbor entry goes into FAILED after the pod was deleted, the issue cannot be reproduced.

**Release note**:

```release-note
None
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration validation by monitoring neighbor events across router nodes.
  * Added clearer diagnostics for migration and connectivity failures.
  * Prevented failed neighbor states from being treated as successful.

* **Testing**
  * Added configurable timeouts for pod connectivity checks.
  * Added automatic neighbor-cache configuration and restoration during migration tests.
  * Added cancellable command execution for more reliable end-to-end testing.
  * Improved handling of interrupted test commands and connectivity checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->