### PR TITLE
fix(grout): add kernel routes for passthrough subnets

### DIFF
--- a/internal/grout/passthrough.go
+++ b/internal/grout/passthrough.go
@@ -56,6 +56,15 @@ func SetupPassthrough(ctx context.Context, client *Client, params hostnetwork.Pa
 	}
 
 	if err := netnamespace.In(peRouterNs, func() error {
+		for _, addr := range []string{params.LinkIPs.NSIPv4, params.LinkIPs.NSIPv6} {
+			if addr == "" {
+				continue
+			}
+			if err := ensureKernelSubnetRoute("main", addr); err != nil {
+				return fmt.Errorf("failed to add kernel route for passthrough subnet %s: %w", addr, err)
+			}
+		}
+
 		// Grout creates a NOARP kernel interface for each port. BGP packets leave
 		// through the `main` interface but return on the port's kernel interface (grout control plane tap),
 		// so rp_filter must be disabled to allow the asymmetric path.


### PR DESCRIPTION
The grout passthrough setup assigns addresses to the grout port via grcli but does not install matching kernel routes. Without them, the kernel falls back to RA-learned defaults (via fabric interfaces), causing BGP OPEN packets to bypass the grout port and never reach bgpd. This explains the flaky IPv6 session failures where the TCP handshake completes but the BGP OPEN is silently lost.

Add ensureKernelSubnetRoute("main", ...) for both IPv4 and IPv6 passthrough addresses, matching what the underlay setup already does.

Fixes: #675, #681

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
/kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network passthrough setup by adding routes for configured IPv4 and IPv6 addresses.
  * Setup now reports a clear error when a required route cannot be added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->