### PR TITLE
docs(examples): fix route reflector examples

### DIFF
--- a/config/samples/underlay-route-reflector.yaml
+++ b/config/samples/underlay-route-reflector.yaml
@@ -2,7 +2,7 @@
 # Route reflector running on the control-plane node: no tunnel endpoint, it
 # only reflects ipv4 unicast (VTEP reachability) and evpn routes between the
 # client nodes that connect over the listen range.
-apiVersion: openpe.openperouter.github.io/v1alpha1
+apiVersion: network.openperouter.io/v1alpha1
 kind: Underlay
 metadata:
   name: route-reflector
@@ -20,7 +20,7 @@ spec:
   routeReflector:
     clusterID: 192.0.2.1
   neighbors:
-    - type: internal
+    - type: Internal
       listenRange: 192.168.11.0/24
       addressFamilies:
         - type: ipv4unicast
@@ -32,7 +32,7 @@ spec:
 ---
 # Client nodes (workers): a normal data-plane underlay whose only neighbor is
 # the route reflector, peered as an internal (iBGP) session.
-apiVersion: openpe.openperouter.github.io/v1alpha1
+apiVersion: network.openperouter.io/v1alpha1
 kind: Underlay
 metadata:
   name: client
@@ -51,5 +51,5 @@ spec:
     cidrs:
     - 100.65.0.0/24
   neighbors:
-    - type: internal
+    - type: Internal
       address: 192.168.11.3  # the route reflector on the cluster subnet

--- a/examples/evpn/route-reflector/openpe.yaml
+++ b/examples/evpn/route-reflector/openpe.yaml
@@ -5,7 +5,7 @@
 # reflects both ipv4 unicast (VTEP reachability) and evpn (type-2/type-3)
 # routes between them, so the clients don't need a full iBGP mesh nor the
 # ToR fabric to exchange EVPN routes.
-apiVersion: openpe.openperouter.github.io/v1alpha1
+apiVersion: network.openperouter.io/v1alpha1
 kind: Underlay
 metadata:
   name: route-reflector
@@ -23,7 +23,7 @@ spec:
   routeReflector:
     clusterID: 192.0.2.1
   neighbors:
-    - type: internal
+    - type: Internal
       listenRange: 192.168.11.0/24
       addressFamilies:
         - type: ipv4unicast
@@ -34,8 +34,8 @@ spec:
             - type: routeReflectorClient
 ---
 # The worker nodes are route reflector clients: a normal data-plane underlay
-# whose only BGP session is the internal (iBGP) one to the route reflector.
-apiVersion: openpe.openperouter.github.io/v1alpha1
+# whose only BGP session is the Internal (iBGP) one to the route reflector.
+apiVersion: network.openperouter.io/v1alpha1
 kind: Underlay
 metadata:
   name: client
@@ -54,14 +54,14 @@ spec:
     cidrs:
       - 100.65.0.0/24
   neighbors:
-    - type: internal
+    - type: Internal
       address: 192.168.11.3  # the route reflector on the leafkind1 switch subnet
 ---
 # A disconnected L2VNI (no VRF) stretched between the client nodes. Its
 # type-2/type-3 routes are only distributed through the route reflector.
 # The node selector keeps it off the route reflector node, which has no
 # tunnel endpoint.
-apiVersion: openpe.openperouter.github.io/v1alpha1
+apiVersion: network.openperouter.io/v1alpha1
 kind: L2VNI
 metadata:
   name: reflected
@@ -72,7 +72,7 @@ spec:
     matchExpressions:
       - key: node-role.kubernetes.io/control-plane
         operator: DoesNotExist
-  hostmaster:
-    type: linux-bridge
+  hostMaster:
+    type: LinuxBridge
     linuxBridge:
-      autoCreate: true
+      lifecycle: Managed

--- a/examplesvalidation/markdown.go
+++ b/examplesvalidation/markdown.go
@@ -12,7 +12,8 @@ import (
 // ExtractYAMLFromMarkdown extracts YAML code blocks from a markdown file.
 // It scans the file for fenced code blocks marked with ```yaml or ```yml,
 // extracts their content, and filters to include only blocks containing
-// OpenPERouter custom resources.
+// OpenPERouter custom resources. The files must contain apiVersionSearchString
+// to be considered.
 // Returns a slice of YAML content strings and any error encountered.
 func extractYAMLFromMarkdown(filePath string) ([]string, error) {
 	file, err := os.Open(filePath)
@@ -45,7 +46,7 @@ func extractYAMLFromMarkdown(filePath string) ([]string, error) {
 		if inYAMLBlock && yamlBlockEnd.MatchString(line) {
 			inYAMLBlock = false
 			yamlContent := currentBlock.String()
-			if containsOpenPERouterCR(yamlContent) {
+			if containsAPIVersionSearchString(yamlContent) {
 				yamlBlocks = append(yamlBlocks, yamlContent)
 			}
 			continue
@@ -55,6 +56,9 @@ func extractYAMLFromMarkdown(filePath string) ([]string, error) {
 			currentBlock.WriteString(line)
 			currentBlock.WriteString("\n")
 		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
 	}
 
 	return yamlBlocks, nil

--- a/examplesvalidation/resource.go
+++ b/examplesvalidation/resource.go
@@ -15,9 +15,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// containsOpenPERouterCR checks if YAML contains OpenPERouter custom resources
-func containsOpenPERouterCR(content string) bool {
-	return strings.Contains(content, "network.openperouter.io")
+const (
+	apiVersionSearchString = "openperouter"
+	apiGroup               = "network.openperouter.io"
+)
+
+func containsAPIVersionSearchString(content string) bool {
+	return strings.Contains(content, apiVersionSearchString)
+}
+
+func containsOpenPERouterAPIGroup(group string) bool {
+	return strings.Contains(group, apiGroup)
 }
 
 // validateResourceFromFile reads a YAML file and validates its resources by
@@ -30,7 +38,6 @@ func validateResourceFromFile(k8sClient client.Client, filePath string) error {
 		return err
 	}
 	return validateResourceYAML(k8sClient, string(data))
-
 }
 
 // validateResourceYAML validates YAML content by attempting to create
@@ -39,12 +46,11 @@ func validateResourceFromFile(k8sClient client.Client, filePath string) error {
 // each resource using the Kubernetes API server for validation.
 // Returns an error if YAML decoding fails, namespace is empty, or resource creation fails.
 func validateResourceYAML(k8sClient client.Client, content string) error {
-
 	documents := strings.SplitSeq(content, "---")
 
 	for doc := range documents {
 		doc = strings.TrimSpace(doc)
-		if doc == "" {
+		if doc == "" || !strings.Contains(doc, "apiVersion:") {
 			continue
 		}
 
@@ -55,7 +61,7 @@ func validateResourceYAML(k8sClient client.Client, content string) error {
 			return fmt.Errorf("failed to decode YAML: %w", err)
 		}
 
-		if !strings.Contains(obj.GetAPIVersion(), "network.openperouter.io") {
+		if !containsAPIVersionSearchString(obj.GetAPIVersion()) {
 			continue
 		}
 
@@ -83,7 +89,7 @@ func cleanupResources(k8sClient client.Client, namespace string) error {
 	}
 
 	for _, crd := range crdList.Items {
-		if !containsOpenPERouterCR(crd.Spec.Group) {
+		if !containsOpenPERouterAPIGroup(crd.Spec.Group) {
 			continue
 		}
 

--- a/website/content/docs/configuration/route-reflector.md
+++ b/website/content/docs/configuration/route-reflector.md
@@ -27,7 +27,7 @@ A typical deployment uses two Underlays selected by node role: one reflector and
 The reflector does not need a tunnel endpoint of its own — it only reflects the control-plane routes. It accepts dynamic neighbors over the cluster subnet and reflects both `ipv4unicast` (so clients learn each other's VTEP addresses) and `evpn` (so clients learn each other's MAC/IP routes).
 
 ```yaml
-apiVersion: openpe.openperouter.github.io/v1alpha1
+apiVersion: network.openperouter.io/v1alpha1
 kind: Underlay
 metadata:
   name: route-reflector
@@ -45,7 +45,7 @@ spec:
   routeReflector:
     clusterID: 192.0.2.1
   neighbors:
-    - type: internal
+    - type: Internal
       listenRange: 192.168.11.0/24
       addressFamilies:
         - type: ipv4unicast
@@ -61,7 +61,7 @@ spec:
 The clients run a normal data-plane Underlay (with a `tunnelEndpoint`) whose only neighbor is the reflector, established as an internal (iBGP) session.
 
 ```yaml
-apiVersion: openpe.openperouter.github.io/v1alpha1
+apiVersion: network.openperouter.io/v1alpha1
 kind: Underlay
 metadata:
   name: client
@@ -80,7 +80,7 @@ spec:
     cidrs:
       - 100.65.0.0/24
   neighbors:
-    - type: internal
+    - type: Internal
       address: 192.168.11.3 # the reflector's address on the cluster subnet
 ```
 
@@ -91,9 +91,9 @@ spec:
 | `routeReflector` | object | Enables route reflection on matching nodes when present. Omit to run as a standard router. | _(disabled)_ | |
 | `routeReflector.clusterID` | string | BGP cluster-id (RFC 4456 §7) shared by all reflectors serving the same clients. Must be a valid IPv4 address and lie **outside** `routeridcidr` so it never collides with an allocated router-id. | `192.0.2.1` | valid IPv4 |
 | `neighbors[].listenRange` | string | CIDR for dynamic neighbor acceptance via `bgp listen range`. Mutually exclusive with `address` and `interface`. IPv6 link-local ranges are rejected. | | valid CIDR |
-| `neighbors[].addressFamilies[].properties[].type` | string | Per-address-family feature. `routeReflectorClient` marks the neighbor as a route reflector client in that address family. Requires the neighbor `type` to be `internal`. | | `routeReflectorClient` |
+| `neighbors[].addressFamilies[].properties[].type` | string | Per-address-family feature. `routeReflectorClient` marks the neighbor as a route reflector client in that address family. Requires the neighbor `type` to be `Internal`. | | `routeReflectorClient` |
 
-> The reflector's listen-range neighbor must use `type: internal`, because route reflection is an iBGP-only concept. Setting `routeReflectorClient` on a neighbor that is not `internal` is rejected at admission.
+> The reflector's listen-range neighbor must use `type: Internal`, because route reflection is an iBGP-only concept. Setting `routeReflectorClient` on a neighbor that is not `Internal` is rejected at admission.
 
 ## What Happens When Route Reflection Is Enabled
 

--- a/website/content/docs/examples/evpnexamples/route-reflector.md
+++ b/website/content/docs/examples/evpnexamples/route-reflector.md
@@ -39,7 +39,7 @@ For details about the configuration fields, see the [Route Reflector configurati
 The route reflector underlay is selected on the control-plane node. It has no `tunnelEndpoint`, and accepts dynamic neighbors from the cluster subnet via `listenRange` instead of enumerating each node:
 
 ```yaml
-apiVersion: openpe.openperouter.github.io/v1alpha1
+apiVersion: network.openperouter.io/v1alpha1
 kind: Underlay
 metadata:
   name: route-reflector
@@ -57,7 +57,7 @@ spec:
   routeReflector:
     clusterID: 192.0.2.1
   neighbors:
-    - type: internal
+    - type: Internal
       listenRange: 192.168.11.0/24
       addressFamilies:
         - type: ipv4unicast
@@ -71,7 +71,7 @@ spec:
 The client underlay is selected on the worker nodes. It is a normal data-plane underlay whose only neighbor is the route reflector, peered as an internal (iBGP) session:
 
 ```yaml
-apiVersion: openpe.openperouter.github.io/v1alpha1
+apiVersion: network.openperouter.io/v1alpha1
 kind: Underlay
 metadata:
   name: client
@@ -90,14 +90,14 @@ spec:
     cidrs:
       - 100.65.0.0/24
   neighbors:
-    - type: internal
+    - type: Internal
       address: 192.168.11.3  # the route reflector on the leafkind1 switch subnet
 ```
 
 Finally, a disconnected L2VNI (no VRF) is stretched between the client nodes. The node selector keeps it off the route reflector node, which has no tunnel endpoint:
 
 ```yaml
-apiVersion: openpe.openperouter.github.io/v1alpha1
+apiVersion: network.openperouter.io/v1alpha1
 kind: L2VNI
 metadata:
   name: reflected
@@ -108,10 +108,10 @@ spec:
     matchExpressions:
       - key: node-role.kubernetes.io/control-plane
         operator: DoesNotExist
-  hostmaster:
-    type: linux-bridge
+  hostMaster:
+    type: LinuxBridge
     linuxBridge:
-      autoCreate: true
+      lifecycle: Managed
 ```
 
 **Configuration Notes:**
@@ -119,7 +119,7 @@ spec:
 - **`routeReflector`**: marks the control-plane router as a route reflector and sets the BGP `cluster-id`
 - **`listenRange`**: accepts dynamic iBGP sessions from any node in the cluster subnet, so nodes can be added without touching the reflector configuration
 - **`routeReflectorClient`**: reflects the routes received in that address family to the other clients; `ipv4unicast` carries the VTEP `/32` reachability, `evpn` carries the type-2/type-3 routes
-- **`hostmaster.autoCreate`**: instructs OpenPERouter to create a bridge local to the node that can be used to access the L2 domain
+- **`hostMaster.lifecycle: Managed`**: instructs OpenPERouter to create a bridge local to the node that can be used to access the L2 domain
 
 ### Network Attachment Definition
 


### PR DESCRIPTION

**Is this a BUG FIX or a FEATURE ?**:

/kind example

**What this PR does / why we need it**:
Examples were outdated and did not deploy.

**Special notes for your reviewer**:
Fixes https://github.com/openperouter/openperouter/issues/687

**Release note**:

```release-note
None
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated EVPN route-reflector, client, and underlay configurations to use the current API version.
  * Corrected BGP neighbor type values for compatibility.
  * Updated L2VNI host configuration to use managed Linux bridge lifecycle settings.
  * Preserved the client’s route-reflector address configuration.
* **Documentation**
  * Updated route-reflector and EVPN examples to reflect the current configuration format.
  * Improved example validation for manifests without API version fields and surfaced scanning errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->