### PR TITLE
fix(static): print names of failed static resources

### DIFF
--- a/internal/controller/routerconfiguration/static_configuration_reader.go
+++ b/internal/controller/routerconfiguration/static_configuration_reader.go
@@ -237,27 +237,50 @@ func staticConfigToAPIConfig(staticConfig *static.PERouterConfig, nodeName, name
 func applyDefaultsAndValidate[T any](obj *T, gvk schema.GroupVersionKind) (*T, field.ErrorList) {
 	rawMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	if err != nil {
-		return nil, field.ErrorList{field.InternalError(field.NewPath(""), fmt.Errorf("converting to unstructured: %w", err))}
+		return nil, field.ErrorList{
+			field.InternalError(
+				field.NewPath(""),
+				fmt.Errorf("converting to unstructured: %T: %w", *obj, err),
+			),
+		}
 	}
 
 	normalizedMap, err := normalizeGoTypes(rawMap)
 	if err != nil {
-		return nil, field.ErrorList{field.InternalError(field.NewPath(""), fmt.Errorf("normalizing Go types: %w", err))}
+		return nil, field.ErrorList{
+			field.InternalError(
+				field.NewPath(""),
+				fmt.Errorf("normalizing Go types: %T: %w", *obj, err),
+			),
+		}
 	}
 
 	unstrObj := &unstructured.Unstructured{Object: normalizedMap}
 
 	if err := crdschema.ApplyDefaults(unstrObj, gvk); err != nil {
-		return nil, field.ErrorList{field.InternalError(field.NewPath(""), fmt.Errorf("applying defaults: %w", err))}
+		return nil, field.ErrorList{
+			field.InternalError(
+				field.NewPath(""),
+				fmt.Errorf("applying defaults: %T: %w", *obj, err),
+			),
+		}
 	}
 
 	if valErrs := crdschema.Validate(context.Background(), unstrObj, gvk); len(valErrs) > 0 {
+		for i := range valErrs {
+			valErrs[i].Field = fmt.Sprintf("%T: %s", *obj, valErrs[i].Field)
+		}
 		return nil, valErrs
 	}
 
 	var result T
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstrObj.Object, &result); err != nil {
-		return nil, field.ErrorList{field.InternalError(field.NewPath(""), fmt.Errorf("converting from unstructured: %w", err))}
+		return nil, field.ErrorList{
+			field.InternalError(
+				field.NewPath(""),
+				fmt.Errorf("converting from unstructured: %T: %w", *obj, err),
+			),
+		}
 	}
 
 	return &result, nil

--- a/internal/controller/routerconfiguration/static_configuration_reader_test.go
+++ b/internal/controller/routerconfiguration/static_configuration_reader_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openperouter/openperouter/api/v1alpha1"
 	"github.com/openperouter/openperouter/internal/conversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 )
@@ -546,8 +547,11 @@ l2vnis:
 	if err == nil {
 		t.Fatal("expected validation error for L2VNI with bridge name and Managed lifecycle, got nil")
 	}
-	if !strings.Contains(err.Error(), "name must be set when lifecycle is External, and must not be set when it is Managed.") {
-		t.Errorf("expected error containing 'name must be set when lifecycle is External, and must not be set when it is Managed.', got: %v", err)
+	wantErrMsg := `failed to convert static config to API config: validation errors in static config: ` +
+		`v1alpha1.L2VNI: [].spec.hostMaster.linuxBridge: Invalid value: ` +
+		`name must be set when lifecycle is External, and must not be set when it is Managed.`
+	if !strings.Contains(err.Error(), wantErrMsg) {
+		t.Errorf("expected error containing %q, got: %v", wantErrMsg, err)
 	}
 }
 
@@ -597,9 +601,12 @@ underlays:
 			yaml: validSRv6Underlay,
 		},
 		{
-			name:       "invalid encapBehavior value",
-			yaml:       fmt.Sprintf("%s      encapBehavior: \"%s\"\n", validSRv6Underlay, "H.Encaps.Invalid"),
-			wantErrMsg: `Unsupported value: "H.Encaps.Invalid": supported values: "H.Encaps", "H.Encaps.Red"`,
+			name: "invalid encapBehavior value",
+			yaml: fmt.Sprintf("%s      encapBehavior: \"%s\"\n", validSRv6Underlay, "H.Encaps.Invalid"),
+			wantErrMsg: `failed to convert static config to API config: validation errors in static config: ` +
+				`[v1alpha1.Underlay: [].spec.srv6.encapBehavior: Too long: may not be more than 12 bytes, ` +
+				`v1alpha1.Underlay: [].spec.srv6.encapBehavior: Unsupported value: "H.Encaps.Invalid": supported ` +
+				`values: "H.Encaps", "H.Encaps.Red"`,
 		},
 		{
 			name: "srv6 without isis",
@@ -624,7 +631,8 @@ underlays:
         basePrefix: "fd00:0:32::/48"
         format: "usid-f3216"
 `,
-			wantErrMsg: "SRv6 can only be configured if isis is set",
+			wantErrMsg: `failed to convert static config to API config: validation errors in static config: ` +
+				`v1alpha1.Underlay: [].spec: Invalid value: SRv6 can only be configured if isis is set`,
 		},
 		{
 			name: "srv6 without ipv6 tunnel endpoint",
@@ -655,7 +663,9 @@ underlays:
         basePrefix: "fd00:0:32::/48"
         format: "usid-f3216"
 `,
-			wantErrMsg: "SRv6 requires at least one IPv6 CIDR in tunnelEndpoint.cidrs",
+			wantErrMsg: `failed to convert static config to API config: validation errors in static config: ` +
+				`v1alpha1.Underlay: [].spec: Invalid value: ` +
+				`SRv6 requires at least one IPv6 CIDR in tunnelEndpoint.cidrs`,
 		},
 	}
 
@@ -710,7 +720,9 @@ l2vnis:
         name: "mybr"
         lifecycle: Managed
 `,
-			wantContains: "name must be set when lifecycle is External, and must not be set when it is Managed.",
+			wantContains: `failed to convert static config to API config: validation errors in static config: ` +
+				`v1alpha1.L2VNI: [].spec.hostMaster.linuxBridge: Invalid value: ` +
+				`name must be set when lifecycle is External, and must not be set when it is Managed.`,
 		},
 	}
 
@@ -760,11 +772,18 @@ l2vnis:
 	}
 
 	errMsg := err.Error()
-	if !strings.Contains(errMsg, "asn") {
-		t.Errorf("expected error from underlay missing required ASN field, got: %v", err)
+	wantPrefix := `failed to convert static config to API config: validation errors in static config:`
+	if !strings.Contains(errMsg, wantPrefix) {
+		t.Errorf("expected error containing %q, got: %v", wantPrefix, err)
 	}
-	if !strings.Contains(errMsg, "name must be set when lifecycle is External, and must not be set when it is Managed.") {
-		t.Errorf("expected error from L2VNI bridge validation, got: %v", err)
+	wantUnderlayErr := `v1alpha1.Underlay: [].spec.asn: Required value`
+	if !strings.Contains(errMsg, wantUnderlayErr) {
+		t.Errorf("expected error containing %q, got: %v", wantUnderlayErr, err)
+	}
+	wantL2VNIErr := `v1alpha1.L2VNI: [].spec.hostMaster.linuxBridge: Invalid value: ` +
+		`name must be set when lifecycle is External, and must not be set when it is Managed.`
+	if !strings.Contains(errMsg, wantL2VNIErr) {
+		t.Errorf("expected error containing %q, got: %v", wantL2VNIErr, err)
 	}
 }
 
@@ -799,9 +818,11 @@ l2vnis:
 		t.Fatal("expected error for config with 1 valid underlay and 1 invalid L2VNI, got nil -- partial result should not be returned")
 	}
 
-	// Verify the error is about the L2VNI validation, not about the underlay
-	if !strings.Contains(err.Error(), "name must be set when lifecycle is External, and must not be set when it is Managed.") {
-		t.Errorf("expected L2VNI validation error, got: %v", err)
+	wantErr := `failed to convert static config to API config: validation errors in static config: ` +
+		`v1alpha1.L2VNI: [].spec.hostMaster.linuxBridge: Invalid value: ` +
+		`name must be set when lifecycle is External, and must not be set when it is Managed.`
+	if !strings.Contains(err.Error(), wantErr) {
+		t.Errorf("expected error containing %q, got: %v", wantErr, err)
 	}
 }
 
@@ -1298,5 +1319,45 @@ func TestStaticConfigInvalidPassword(t *testing.T) {
 				t.Fatal("expected error for invalid password, got nil")
 			}
 		})
+	}
+}
+
+func TestApplyDefaultsAndValidateToUnstructuredError(t *testing.T) {
+	type unconvertible struct {
+		Bad chan int `json:"bad"`
+	}
+	obj := &unconvertible{Bad: make(chan int)}
+	_, errs := applyDefaultsAndValidate(obj, underlayGVK)
+	if len(errs) == 0 {
+		t.Fatal("expected error for unconvertible type")
+	}
+	errMsg := errs.ToAggregate().Error()
+	wantErrMsg := `Internal error: converting to unstructured: routerconfiguration.unconvertible:`
+	if !strings.Contains(errMsg, wantErrMsg) {
+		t.Errorf("expected error containing %q, got: %s", wantErrMsg, errMsg)
+	}
+}
+
+func TestApplyDefaultsAndValidateApplyDefaultsError(t *testing.T) {
+	obj := &v1alpha1.Underlay{
+		Spec: v1alpha1.UnderlaySpec{
+			ASN: 64514,
+			Interfaces: []v1alpha1.UnderlayInterface{
+				{Type: "NetworkDevice", NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"}},
+			},
+			Neighbors: []v1alpha1.Neighbor{
+				{ASN: new(int64(64512)), Address: new("192.168.11.2")},
+			},
+		},
+	}
+	unknownGVK := schema.GroupVersionKind{Group: "fake.io", Version: "v1", Kind: "Fake"}
+	_, errs := applyDefaultsAndValidate(obj, unknownGVK)
+	if len(errs) == 0 {
+		t.Fatal("expected error for unknown GVK")
+	}
+	errMsg := errs.ToAggregate().Error()
+	wantErrMsg := `Internal error: applying defaults: v1alpha1.Underlay: no CRD schema found for fake.io/v1, Kind=Fake`
+	if !strings.Contains(errMsg, wantErrMsg) {
+		t.Errorf("expected error containing %q, got: %s", wantErrMsg, errMsg)
 	}
 }


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:
Validation errors from applyDefaultsAndValidate did not identify which
resource type failed, making it hard to diagnose misconfigured static
configs with multiple resource kinds. Prepend the Go type (%T) to the
Field of each validation error so the type name (e.g. v1alpha1.Underlay)
appears in the message.

The "normalizing Go types" and "converting from unstructured" internal
error paths could not be unit-tested: normalizeGoTypes is unreachable
after ToUnstructured succeeds (it only produces JSON-safe types), and
FromUnstructured cannot fail on a same-type round-trip. Both paths
retain the %T annotation as defensive error handling.

**Special notes for your reviewer**:
N/A

**Release note**:

```release-note
Print which resource type fails when static resource parsing fails
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration validation errors with clearer resource types and field paths.
  * Enhanced conversion, normalization, defaulting, and validation error messages for easier troubleshooting.
  * Added more descriptive errors for unsupported resource schemas and conversion failures.
  * Improved reporting of multiple configuration errors so relevant issues are easier to identify.

* **Tests**
  * Expanded coverage for validation, defaulting, conversion failures, unsupported schemas, and multiple configuration errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->