### PR TITLE
fix(grout): bump DPDK/grout from v0.16.0 to v0.17.1

### DIFF
--- a/Dockerfile.grout
+++ b/Dockerfile.grout
@@ -75,9 +75,9 @@ RUN groupadd -r -g 92 frr && \
     usermod -a -G frrvty frr
 
 RUN RPMARCH=$(case ${TARGETARCH} in amd64) echo x86_64;; arm64) echo aarch64;; *) echo ${TARGETARCH};; esac) && \
-    curl -fsSL -o /tmp/frr.rpm https://github.com/DPDK/grout/releases/download/v0.16.0/frr.${RPMARCH}.rpm && \
-    curl -fsSL -o /tmp/grout-frr.rpm https://github.com/DPDK/grout/releases/download/v0.16.0/grout-frr.${RPMARCH}.rpm && \
-    curl -fsSL -o /tmp/grout.rpm https://github.com/DPDK/grout/releases/download/v0.16.0/grout.${RPMARCH}.rpm && \
+    curl -fsSL -o /tmp/frr.rpm https://github.com/DPDK/grout/releases/download/v0.17.1/frr.${RPMARCH}.rpm && \
+    curl -fsSL -o /tmp/grout-frr.rpm https://github.com/DPDK/grout/releases/download/v0.17.1/grout-frr.${RPMARCH}.rpm && \
+    curl -fsSL -o /tmp/grout.rpm https://github.com/DPDK/grout/releases/download/v0.17.1/grout.${RPMARCH}.rpm && \
     dnf install -y /tmp/*.rpm && dnf clean all && rm -rf /tmp/*.rpm
 
 COPY --from=builder /go/openperouter/reloader .


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

/kind bug

**What this PR does / why we need it**:

Bump the grout dataplane RPMs in `Dockerfile.grout` from v0.16.0 to v0.17.1.

grout v0.17.0 includes DPDK/grout#683 (NDP/RA flag bit positions). Without that fix, grout Neighbor Advertisements omit the Solicited flag, Linux IPv6 neighbors go FAILED, and the grout passthrough IPv6 host session never stays up.

Fixes #556.
Also covers #675, the nightly flake-bot issue for the same spec (`flake-id: [grout] … passthrough … translates BGP incoming routes as BGP routes`).

**Special notes for your reviewer**:

Grout 0.17.1 still ships FRR 10.6.1 in its RPM, so this does not widen the kernel vs grout FRR skew (#538). The `grcli` client still string-matches errors; grout 0.16.1+ emits JSON errors when `--json` is set — watch the grout e2e lanes if session setup fails before BGP.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Bump DPDK/grout dataplane to v0.17.1, including the IPv6 NDP/RA flag fix.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.