### PR TITLE
docs(examples): update web examples to match current API

### DIFF
--- a/website/content/docs/examples/evpnexamples/route-reflector.md
+++ b/website/content/docs/examples/evpnexamples/route-reflector.md
@@ -39,7 +39,7 @@ For details about the configuration fields, see the [Route Reflector configurati
 The route reflector underlay is selected on the control-plane node. It has no `tunnelEndpoint`, and accepts dynamic neighbors from the cluster subnet via `listenRange` instead of enumerating each node:
 
 ```yaml
-apiVersion: openpe.openperouter.github.io/v1alpha1
+apiVersion: network.openperouter.io/v1alpha1
 kind: Underlay
 metadata:
   name: route-reflector
@@ -71,7 +71,7 @@ spec:
 The client underlay is selected on the worker nodes. It is a normal data-plane underlay whose only neighbor is the route reflector, peered as an internal (iBGP) session:
 
 ```yaml
-apiVersion: openpe.openperouter.github.io/v1alpha1
+apiVersion: network.openperouter.io/v1alpha1
 kind: Underlay
 metadata:
   name: client
@@ -97,7 +97,7 @@ spec:
 Finally, a disconnected L2VNI (no VRF) is stretched between the client nodes. The node selector keeps it off the route reflector node, which has no tunnel endpoint:
 
 ```yaml
-apiVersion: openpe.openperouter.github.io/v1alpha1
+apiVersion: network.openperouter.io/v1alpha1
 kind: L2VNI
 metadata:
   name: reflected
@@ -108,10 +108,10 @@ spec:
     matchExpressions:
       - key: node-role.kubernetes.io/control-plane
         operator: DoesNotExist
-  hostmaster:
-    type: linux-bridge
+  hostMaster:
+    type: LinuxBridge
     linuxBridge:
-      autoCreate: true
+      lifecycle: Managed
 ```
 
 **Configuration Notes:**
@@ -119,7 +119,7 @@ spec:
 - **`routeReflector`**: marks the control-plane router as a route reflector and sets the BGP `cluster-id`
 - **`listenRange`**: accepts dynamic iBGP sessions from any node in the cluster subnet, so nodes can be added without touching the reflector configuration
 - **`routeReflectorClient`**: reflects the routes received in that address family to the other clients; `ipv4unicast` carries the VTEP `/32` reachability, `evpn` carries the type-2/type-3 routes
-- **`hostmaster.autoCreate`**: instructs OpenPERouter to create a bridge local to the node that can be used to access the L2 domain
+- **`hostMaster.linuxBridge.lifecycle`**: `Managed` instructs OpenPERouter to create a bridge local to the node that can be used to access the L2 domain
 
 ### Network Attachment Definition
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug

/kind cleanup

> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
- Fix API group from openpe.openperouter.github.io to network.openperouter.io
- Rename L2VNI hostmaster to hostMaster with correct type capitalization
- Replace autoCreate with lifecycle: Managed for bridge configuration
- Rename l2gatewayips to gatewayIPs
- Rename vxlanport to vxlanPort
- Rename hostsession to hostSession, hostasn to hostASN, localcidr to localCIDR
- Update L2VNI VRF references to use routingDomain discriminated union
- Update documentation to reflect RoutingDomain API changes

The tests in internal/webhooks/l2vni_webhook_test.go were already using the correct API, which is why the discrepancy wasn't caught - the tests weren't being compared against the web examples documentation.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
