### PR TITLE
docs(style): prefer positive assertions in tests

### DIFF
--- a/CODING_STYLE.md
+++ b/CODING_STYLE.md
@@ -126,8 +126,6 @@ if err := fetchData(id); err != nil {
 - Controller lifecycle management makes goroutine cleanup complex
 - Prefer controller-runtime's built-in concurrency patterns
 
-
-
 ### Unnecessary Comments
 Remove obvious comments that restate what the code already says. Comments should explain *why*, never *what*. AI-generated boilerplate comments are especially problematic — they add noise without value.
 
@@ -214,6 +212,49 @@ Watch for:
 - Premature abstractions ("in case we need to support X later")
 
 The test: if removing the abstraction makes the code shorter and equally clear, remove it.
+
+### Writing tests
+On unit tests use only the go standard library / testify (at most).
+
+For e2e tests, use the ginkgo / gomega framework.
+
+### Writing gomega based tests
+Favor using "positive" logic (i.e. expect success) over expecting an error
+not to happen. Assert the outcome you want, not the absence of the outcome
+you don't.
+
+This reads better and fails better: `Succeed()` states the intent directly,
+and when the call does fail Gomega prints the actual error in the failure
+message.
+
+**Bad:** expect the error not to happen
+```go
+err := doStuff()
+Expect(err).NotTo(HaveOccurred())
+```
+
+**Good:** expect success
+```go
+Expect(doStuff()).To(Succeed())
+```
+
+The same idea applies to functions that return a value alongside the error.
+Assert on the value directly and let Gomega check the error for you.
+
+**Bad:** check the error, then the value
+```go
+got, err := lookup(id)
+Expect(err).NotTo(HaveOccurred())
+Expect(got).To(Equal(want))
+```
+
+**Good:** assert the value, error handled implicitly
+```go
+Expect(lookup(id)).To(Equal(want))
+```
+
+This applies to setup steps too: `Expect(k8sClient.Create(ctx, obj)).To(Succeed())`
+keeps the precondition and its assertion on one line.
 
 ## Code Review Focus Areas
 


### PR DESCRIPTION
Add a "Writing tests" section to the coding style guide recommending Gomega's positive assertions over checking for the absence of errors.

Prefer Expect(doStuff()).To(Succeed()) over capturing err and asserting NotTo(HaveOccurred()): it states intent directly, surfaces the actual error in the failure message, and drops the throwaway err variable. The same applies to value-returning calls, where Gomega checks the trailing error implicitly, and to test setup steps.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug

/kind cleanup

> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
Add a "Writing tests" section to the coding style guide recommending
Gomega's positive assertions over checking for the absence of errors.
   
Prefer `Expect(doStuff()).To(Succeed())` over capturing err and asserting
`NotTo(HaveOccurred())`: it states intent directly, surfaces the actual
error in the failure message, and drops the throwaway err variable. The
same applies to value-returning calls, where Gomega checks the trailing
error implicitly, and to test setup steps.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized guidance on unnecessary comments for improved readability.
  * Added testing recommendations covering approved frameworks for unit and end-to-end tests.
  * Recommended positive assertions for test results, setup steps, and functions returning values with errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->