### PR TITLE
Use netlink lib functions for setAddrGenMode, neighbor suppression, and new set learning

### DIFF
--- a/internal/hostnetwork/link_properties.go
+++ b/internal/hostnetwork/link_properties.go
@@ -9,8 +9,6 @@ import (
 	"log/slog"
 	"net"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
@@ -106,36 +104,8 @@ func interfaceHasNoIP(link netlink.Link, family int) (bool, error) {
 }
 
 // setAddrGenModeNone sets addr_gen_mode to none (value "1") on the given link.
-// It is idempotent: if already set, it does nothing to avoid unnecessary netlink events.
 func setAddrGenModeNone(l netlink.Link) error {
-	fileName := fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/addr_gen_mode", l.Attrs().Name)
-	fileName = filepath.Clean(fileName)
-	if !strings.HasPrefix(fileName, "/proc/sys/") {
-		panic(fmt.Errorf("attempt to escape")) // TODO: replace with os.Root when Go 1.24 is out
-	}
-
-	currentValue, err := os.ReadFile(fileName)
-	if err != nil {
-		return fmt.Errorf("addrGenModeNone: error reading file: %w", err)
-	}
-	if strings.TrimSpace(string(currentValue)) == "1" {
-		return nil
-	}
-
-	file, err := os.OpenFile(fileName, os.O_WRONLY, 0)
-	if err != nil {
-		return fmt.Errorf("addrGenModeNone: error opening file: %w", err)
-	}
-	defer func() {
-		if err := file.Close(); err != nil {
-			slog.Error("failed to close file", "file", fileName, "error", err)
-		}
-	}()
-
-	if _, err := fmt.Fprintf(file, "%s\n", "1"); err != nil {
-		return fmt.Errorf("addrGenModeNone: error writing to file: %w", err)
-	}
-	return nil
+	return netlink.LinkSetIP6AddrGenMode(l, 1)
 }
 
 // linkSetUp sets the link up only if it's not already up.

--- a/internal/hostnetwork/link_properties.go
+++ b/internal/hostnetwork/link_properties.go
@@ -7,14 +7,12 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"math"
 	"net"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/vishvananda/netlink"
-	"github.com/vishvananda/netlink/nl"
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
 )
@@ -185,28 +183,6 @@ func linkSetMaster(link, master netlink.Link) error {
 	return netlink.LinkSetMaster(link, master)
 }
 
-// setNeighSuppression sets neighbor suppression to the given link.
-func setNeighSuppression(link netlink.Link) error {
-	req := nl.NewNetlinkRequest(unix.RTM_SETLINK, unix.NLM_F_ACK)
-
-	msg := nl.NewIfInfomsg(unix.AF_BRIDGE)
-	var err error
-	msg.Index, err = intToInt32(link.Attrs().Index)
-	if err != nil {
-		return fmt.Errorf("invalid index for %s", link.Attrs().Name)
-	}
-	req.AddData(msg)
-
-	br := nl.NewRtAttr(unix.IFLA_PROTINFO|unix.NLA_F_NESTED, nil)
-	br.AddRtAttr(32, []byte{1})
-	req.AddData(br)
-	_, err = req.Execute(unix.NETLINK_ROUTE, 0)
-	if err != nil {
-		return fmt.Errorf("error executing request: %w", err)
-	}
-	return nil
-}
-
 // moveInterfaceToNamespace takes the given interface and moves it from the given to the given namespace.
 func MoveInterfaceToNamespace(ctx context.Context, intf string, fromHandle, toHandle *netlink.Handle,
 	toNS netns.NsHandle, groupID uint32) error {
@@ -280,13 +256,6 @@ func DeleteAddressFromInterface(ifaceName string, addr netlink.Addr) error {
 		return fmt.Errorf("failed to find underlay interface %s: %w", ifaceName, err)
 	}
 	return netlink.AddrDel(link, &addr)
-}
-
-func intToInt32(val int) (int32, error) {
-	if val < math.MinInt32 || val > math.MaxInt32 {
-		return 0, fmt.Errorf("can't convert %d to int32", val)
-	}
-	return int32(val), nil
 }
 
 func LinkExists(name string) (bool, error) {

--- a/internal/hostnetwork/vni_test.go
+++ b/internal/hostnetwork/vni_test.go
@@ -678,7 +678,9 @@ func validateL3VNI(g Gomega, params L3VNIParams) {
 
 	bridgeLink, err := netlink.LinkByName(BridgeName(params.VNI))
 	g.Expect(err).NotTo(HaveOccurred(), "bridge not found for addr_gen_mode check", BridgeName(params.VNI))
-	g.Expect(checkAddrGenModeNone(bridgeLink)).To(BeTrue(), "L3VNI bridge must have addr_gen_mode=1")
+	addrGenModeNone, err := checkAddrGenModeNone(bridgeLink)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(addrGenModeNone).To(BeTrue(), "L3VNI bridge must have addr_gen_mode=1")
 
 	vethNames := vethNamesFromVNI(params.VNI)
 	peLegLink, err := netlink.LinkByName(vethNames.NamespaceSide)
@@ -710,7 +712,9 @@ func validateL2VNI(g Gomega, params L2VNIParams) {
 
 	bridgeLinkForMode, err := netlink.LinkByName(BridgeName(params.VNI))
 	g.Expect(err).NotTo(HaveOccurred(), "bridge not found for addr_gen_mode check", BridgeName(params.VNI))
-	g.Expect(checkAddrGenModeNone(bridgeLinkForMode)).To(BeFalse(), "L2VNI bridge must NOT have addr_gen_mode=1")
+	addrGenModeNone, err := checkAddrGenModeNone(bridgeLinkForMode)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(addrGenModeNone).To(BeFalse(), "L2VNI bridge must NOT have addr_gen_mode=1")
 
 	vethNames := vethNamesFromVNI(params.VNI)
 	peLegLink, err := netlink.LinkByName(vethNames.NamespaceSide)
@@ -750,8 +754,7 @@ func validateVNI(g Gomega, params VNIParams) {
 	vxlan := vxlanLink.(*netlink.Vxlan)
 	g.Expect(vxlan.OperState).To(BeEquivalentTo(netlink.OperUnknown))
 
-	addrGenModeNone := checkAddrGenModeNone(vxlan)
-	g.Expect(addrGenModeNone).To(BeTrue())
+	g.Expect(checkVXLanPostSetup(vxlan)).To(Succeed())
 
 	bridgeLink, err := netlink.LinkByName(BridgeName(params.VNI))
 	g.Expect(err).NotTo(HaveOccurred(), "bridge not found", BridgeName(params.VNI))
@@ -773,6 +776,28 @@ func validateVNI(g Gomega, params VNIParams) {
 
 	err = checkVXLanConfigured(vxlan, bridge.Index, vtepDev.Attrs().Index, params)
 	g.Expect(err).NotTo(HaveOccurred())
+}
+
+func checkVXLanPostSetup(vxlan *netlink.Vxlan) error {
+	// Verify 'bridge_slave learning off' to make sure that MAC learning is disabled (note: different from 'nolearning').
+	protinfo, err := netlink.LinkGetProtinfo(vxlan)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve VXLAN protinfo, err: %q", err)
+	}
+	if protinfo.Learning {
+		return errors.New("MAC learning is enabled")
+	}
+	if !protinfo.NeighSuppress {
+		return errors.New("neighbor suppression is disabled")
+	}
+	addrGenModeNone, err := checkAddrGenModeNone(vxlan)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve addr_gen_mode, err: %q", err)
+	}
+	if !addrGenModeNone {
+		return errors.New("addr_gen_mode is not set to none")
+	}
+	return nil
 }
 
 func validateVRF(g Gomega, vrfName string) (netlink.Link, *netlink.Vrf) {
@@ -835,12 +860,14 @@ func validateVNIIsNotConfigured(g Gomega, params VNIParams) {
 	checkLinkdeleted(g, vethNames.NamespaceSide)
 }
 
-func checkAddrGenModeNone(l netlink.Link) bool {
+func checkAddrGenModeNone(l netlink.Link) (bool, error) {
 	fileName := fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/addr_gen_mode", l.Attrs().Name)
 	addrGenMode, err := os.ReadFile(fileName)
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return false, err
+	}
 
-	return strings.Trim(string(addrGenMode), "\n") == "1"
+	return strings.Trim(string(addrGenMode), "\n") == "1", nil
 }
 
 func setupLoopback(ns netns.NsHandle) {

--- a/internal/hostnetwork/vxlan.go
+++ b/internal/hostnetwork/vxlan.go
@@ -26,6 +26,13 @@ func setupVXLan(params VNIParams, bridge *netlink.Bridge) error {
 	if err := netlink.LinkSetBrNeighSuppress(vxlan, true); err != nil {
 		return fmt.Errorf("failed to set neigh suppression for %s: %w", vxlan.Name, err)
 	}
+	// LinkSetLearning disables MAC learning for the bridge_slave. ip link syntax is:
+	// ip link set <...> type bridge_slave learning off
+	// Note that this is different from the VXLAN's 'nolearning' parameter (which we set inside createVXLan via
+	// Learning: false) and which disables VTEP learning.
+	if err := netlink.LinkSetLearning(vxlan, false); err != nil {
+		return fmt.Errorf("failed to disable MAC learning (learning off) for %s: %w", vxlan.Name, err)
+	}
 
 	if err = linkSetUp(vxlan); err != nil {
 		return fmt.Errorf("could not set link up for vxlan %s: %v", vxlan.Name, err)
@@ -54,7 +61,7 @@ func checkVXLanConfigured(vxLan *netlink.Vxlan, bridgeIndex, loopbackIndex int, 
 		return fmt.Errorf("port is not one coming from params: %d, %d", vxLan.Port, paramsVXLanPort)
 	}
 	if vxLan.Learning {
-		return fmt.Errorf("learning is enabled")
+		return errors.New("VTEP learning is enabled")
 	}
 	if err := validateVxlan(vxLan, params); err != nil {
 		return err
@@ -88,7 +95,7 @@ func createVXLan(params VNIParams, bridge *netlink.Bridge) (*netlink.Vxlan, erro
 		},
 		VxlanId:      int(params.VNI),
 		Port:         int(*params.VXLanPort),
-		Learning:     false,
+		Learning:     false, // Disable VTEP learning (ip link add <...> type vxlan <...> nolearning).
 		VtepDevIndex: loopback.Index,
 		SrcAddr:      vtepIP,
 	}

--- a/internal/hostnetwork/vxlan.go
+++ b/internal/hostnetwork/vxlan.go
@@ -23,7 +23,7 @@ func setupVXLan(params VNIParams, bridge *netlink.Bridge) error {
 	if err := setAddrGenModeNone(vxlan); err != nil {
 		return fmt.Errorf("failed to set addr_gen_mode to 1 for %s: %w", vxlan.Name, err)
 	}
-	if err := setNeighSuppression(vxlan); err != nil {
+	if err := netlink.LinkSetBrNeighSuppress(vxlan, true); err != nil {
 		return fmt.Errorf("failed to set neigh suppression for %s: %w", vxlan.Name, err)
 	}
 


### PR DESCRIPTION
- **Use netlink library to configure VXLAN neigh suppress**
- **vxlan: disable bridge MAC learning on the vxlan slave**
- **hostnetwork: use netlink for addr_gen_mode and set it on L2VNI bridges**

**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

This PR is part cleanup, part bugfix. 

1 small bug:
- we never set 'learning off' (for MAC learning) on the VNI, even thought this is part of the documented procedure,
  see https://docs.frrouting.org/en/latest/evpn.html

Cleanup:
- instead of reinventing the wheel, use the netlink library to implement setAddrGenModeNone and to enable neighbor suppression.
- update unit tests

**Special notes for your reviewer**:
None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Set MAC learning to off on VNI/VXLAN interfaces.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VXLAN network setup by reliably configuring neighbor suppression and disabling bridge MAC learning.
  * Corrected IPv6 address-generation configuration for VXLAN interfaces.
  * Added clearer validation errors when VXLAN VTEP learning is configured incorrectly.
* **Tests**
  * Expanded network validation to verify MAC learning, neighbor suppression, IPv6 address-generation settings, and VXLAN tunnel overhead configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->