### PR TITLE
Fix/pr 567 issue 682 followup

### DIFF
--- a/e2etests/tests/password_secret.go
+++ b/e2etests/tests/password_secret.go
@@ -27,6 +27,7 @@ var _ = Describe("Neighbor passwordSecret", Ordered, func() {
 		rotatedPassword     = "RotatedSecret456"
 		secretName          = "bgp-auth-test"
 		customKeySecretName = "bgp-auth-test-custom-key"
+		customKey           = "bgp-password"
 	)
 
 	var cs clientset.Interface
@@ -138,8 +139,6 @@ var _ = Describe("Neighbor passwordSecret", Ordered, func() {
 	})
 
 	It("should resolve password from a custom Secret key", func() {
-		const customKey = "bgp-password"
-
 		By("creating an Opaque Secret with the password under a custom key")
 		Expect(
 			k8s.CreateOpaqueSecret(cs, customKeySecretName, openperouter.Namespace, customKey, bgpPassword),

--- a/internal/controller/routerconfiguration/frr.go
+++ b/internal/controller/routerconfiguration/frr.go
@@ -24,6 +24,7 @@ type frrConfigData struct {
 type frrConfiguratorType func(ctx context.Context, data frrConfigData) error
 
 func configureFRR(ctx context.Context, data frrConfigData) error {
+	slog.DebugContext(ctx, "reloading FRR config", "config", redactFrrConfigData(data))
 	frrConfig, err := conversion.APItoFRR(data.APIConfigData, data.nodeIndex, data.logLevel)
 	emptyConfig := conversion.NoUnderlaysError("")
 	if errors.As(err, &emptyConfig) {
@@ -51,4 +52,11 @@ func configureFRR(ctx context.Context, data frrConfigData) error {
 		slog.InfoContext(ctx, "FRR configuration updated", "config", frr.RedactPasswords(string(newConfig)))
 	}
 	return nil
+}
+
+// redactFrrConfigData returns a copy of data safe for logging, with resolved
+// BGP passwords and any passwords in raw FRR snippets redacted.
+func redactFrrConfigData(data frrConfigData) frrConfigData {
+	data.APIConfigData = conversion.RedactAPIConfigData(data.APIConfigData)
+	return data
 }

--- a/internal/controller/routerconfiguration/password_secret_test.go
+++ b/internal/controller/routerconfiguration/password_secret_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/openperouter/openperouter/api/v1alpha1"
 	"github.com/openperouter/openperouter/internal/conversion"
 	openpeerrors "github.com/openperouter/openperouter/internal/errors"
@@ -22,13 +24,13 @@ func TestResolvePasswordSecrets(t *testing.T) {
 	_ = corev1.AddToScheme(scheme)
 
 	tests := []struct {
-		name              string
-		neighbors         []v1alpha1.Neighbor
-		secrets           []corev1.Secret
-		prePasswords      map[string]string
-		wantPassword      string
-		wantNeighborCount int
-		wantErrContains   string
+		name            string
+		neighbors       []v1alpha1.Neighbor
+		secrets         []corev1.Secret
+		prePasswords    map[string]string
+		wantNeighbors   []v1alpha1.Neighbor
+		wantPasswords   map[string]string
+		wantErrContains string
 	}{
 		{
 			name: "resolves password from secret",
@@ -46,8 +48,12 @@ func TestResolvePasswordSecrets(t *testing.T) {
 					Data:       map[string][]byte{"password": []byte("secret-password")},
 				},
 			},
-			wantPassword:      "secret-password",
-			wantNeighborCount: 1,
+			wantNeighbors: []v1alpha1.Neighbor{{
+				Address:        new("192.168.1.2"),
+				ASN:            new(int64(64513)),
+				PasswordSecret: &v1alpha1.SecretKeyRef{Name: "bgp-auth"},
+			}},
+			wantPasswords: map[string]string{"192.168.1.2": "secret-password"},
 		},
 		{
 			name: "any secret type is accepted, not just basic-auth",
@@ -65,8 +71,12 @@ func TestResolvePasswordSecrets(t *testing.T) {
 					Data:       map[string][]byte{"password": []byte("secret-password")},
 				},
 			},
-			wantPassword:      "secret-password",
-			wantNeighborCount: 1,
+			wantNeighbors: []v1alpha1.Neighbor{{
+				Address:        new("192.168.1.2"),
+				ASN:            new(int64(64513)),
+				PasswordSecret: &v1alpha1.SecretKeyRef{Name: "opaque-secret"},
+			}},
+			wantPasswords: map[string]string{"192.168.1.2": "secret-password"},
 		},
 		{
 			name: "resolves password from custom key",
@@ -84,8 +94,12 @@ func TestResolvePasswordSecrets(t *testing.T) {
 					Data:       map[string][]byte{"bgp-password": []byte("secret-password")},
 				},
 			},
-			wantPassword:      "secret-password",
-			wantNeighborCount: 1,
+			wantNeighbors: []v1alpha1.Neighbor{{
+				Address:        new("192.168.1.2"),
+				ASN:            new(int64(64513)),
+				PasswordSecret: &v1alpha1.SecretKeyRef{Name: "bgp-auth-custom-key", Key: new("bgp-password")},
+			}},
+			wantPasswords: map[string]string{"192.168.1.2": "secret-password"},
 		},
 		{
 			name: "secret missing the configured custom key",
@@ -103,8 +117,7 @@ func TestResolvePasswordSecrets(t *testing.T) {
 					Data:       map[string][]byte{"password": []byte("secret-password")},
 				},
 			},
-			wantNeighborCount: 0,
-			wantErrContains:   "missing key",
+			wantErrContains: "missing key \"bgp-password\"",
 		},
 		{
 			name: "pre-resolved password preserved (systemd mode)",
@@ -114,9 +127,12 @@ func TestResolvePasswordSecrets(t *testing.T) {
 					ASN:     new(int64(64513)),
 				},
 			},
-			prePasswords:      map[string]string{"192.168.1.2": "inline-password"},
-			wantPassword:      "inline-password",
-			wantNeighborCount: 1,
+			prePasswords: map[string]string{"192.168.1.2": "inline-password"},
+			wantNeighbors: []v1alpha1.Neighbor{{
+				Address: new("192.168.1.2"),
+				ASN:     new(int64(64513)),
+			}},
+			wantPasswords: map[string]string{"192.168.1.2": "inline-password"},
 		},
 		{
 			name: "no password fields set",
@@ -126,8 +142,10 @@ func TestResolvePasswordSecrets(t *testing.T) {
 					ASN:     new(int64(64513)),
 				},
 			},
-			wantPassword:      "",
-			wantNeighborCount: 1,
+			wantNeighbors: []v1alpha1.Neighbor{{
+				Address: new("192.168.1.2"),
+				ASN:     new(int64(64513)),
+			}},
 		},
 		{
 			name: "secret not found removes neighbor",
@@ -138,8 +156,7 @@ func TestResolvePasswordSecrets(t *testing.T) {
 					PasswordSecret: &v1alpha1.SecretKeyRef{Name: "missing-secret"},
 				},
 			},
-			wantNeighborCount: 0,
-			wantErrContains:   "missing-secret",
+			wantErrContains: "secrets \"missing-secret\" not found",
 		},
 		{
 			name: "secret missing password key removes neighbor",
@@ -157,8 +174,7 @@ func TestResolvePasswordSecrets(t *testing.T) {
 					Data:       map[string][]byte{"wrong-key": []byte("value")},
 				},
 			},
-			wantNeighborCount: 0,
-			wantErrContains:   "missing key",
+			wantErrContains: "missing key \"password\"",
 		},
 		{
 			name: "secret password with newline removes neighbor",
@@ -176,8 +192,7 @@ func TestResolvePasswordSecrets(t *testing.T) {
 					Data:       map[string][]byte{"password": []byte("x\n  redistribute connected")},
 				},
 			},
-			wantNeighborCount: 0,
-			wantErrContains:   "whitespace",
+			wantErrContains: "contains whitespace or is empty",
 		},
 		{
 			name: "secret password with carriage return removes neighbor",
@@ -195,8 +210,7 @@ func TestResolvePasswordSecrets(t *testing.T) {
 					Data:       map[string][]byte{"password": []byte("pass\rword")},
 				},
 			},
-			wantNeighborCount: 0,
-			wantErrContains:   "whitespace",
+			wantErrContains: "contains whitespace or is empty",
 		},
 		{
 			name: "secret password with space removes neighbor",
@@ -214,8 +228,7 @@ func TestResolvePasswordSecrets(t *testing.T) {
 					Data:       map[string][]byte{"password": []byte("pass word")},
 				},
 			},
-			wantNeighborCount: 0,
-			wantErrContains:   "whitespace",
+			wantErrContains: "contains whitespace or is empty",
 		},
 		{
 			name: "secret password exceeding max length removes neighbor",
@@ -233,8 +246,7 @@ func TestResolvePasswordSecrets(t *testing.T) {
 					Data:       map[string][]byte{"password": []byte(strings.Repeat("a", 81))},
 				},
 			},
-			wantNeighborCount: 0,
-			wantErrContains:   "maximum length",
+			wantErrContains: "exceeds maximum length 80",
 		},
 		{
 			name: "mix of valid and invalid neighbors keeps valid ones",
@@ -261,9 +273,29 @@ func TestResolvePasswordSecrets(t *testing.T) {
 					Data:       map[string][]byte{"password": []byte("valid-password")},
 				},
 			},
-			wantPassword:      "valid-password",
-			wantNeighborCount: 2,
-			wantErrContains:   "missing-secret",
+			wantNeighbors: []v1alpha1.Neighbor{
+				{
+					Address:        new("192.168.1.2"),
+					ASN:            new(int64(64513)),
+					PasswordSecret: &v1alpha1.SecretKeyRef{Name: "good-secret"},
+				},
+				{Address: new("192.168.1.4"), ASN: new(int64(64515))},
+			},
+			wantPasswords:   map[string]string{"192.168.1.2": "valid-password"},
+			wantErrContains: "secrets \"missing-secret\" not found",
+		},
+		{
+			name: "secret password empty removes neighbor",
+			neighbors: []v1alpha1.Neighbor{{
+				Address:        new("192.168.1.2"),
+				ASN:            new(int64(64513)),
+				PasswordSecret: &v1alpha1.SecretKeyRef{Name: "empty-secret"},
+			}},
+			secrets: []corev1.Secret{{
+				ObjectMeta: metav1.ObjectMeta{Name: "empty-secret", Namespace: "openperouter-system"},
+				Data:       map[string][]byte{"password": []byte("")},
+			}},
+			wantErrContains: "contains whitespace or is empty",
 		},
 	}
 
@@ -296,16 +328,12 @@ func TestResolvePasswordSecrets(t *testing.T) {
 
 			checkResolveError(t, err, tt.wantErrContains)
 
-			neighbors := config.Underlays[0].Spec.Neighbors
-			if len(neighbors) != tt.wantNeighborCount {
-				t.Fatalf("neighbor count = %d, want %d", len(neighbors), tt.wantNeighborCount)
+			gotNeighbors := config.Underlays[0].Spec.Neighbors
+			if diff := cmp.Diff(tt.wantNeighbors, gotNeighbors, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("neighbors mismatch (-want +got):\n%s", diff)
 			}
-
-			if tt.wantPassword != "" && len(neighbors) > 0 {
-				got := config.Passwords[conversion.NeighborID(neighbors[0])]
-				if got != tt.wantPassword {
-					t.Errorf("password = %q, want %q", got, tt.wantPassword)
-				}
+			if diff := cmp.Diff(tt.wantPasswords, config.Passwords, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("passwords mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/controller/routerconfiguration/static_configuration_reader.go
+++ b/internal/controller/routerconfiguration/static_configuration_reader.go
@@ -303,6 +303,8 @@ func staticUnderlaysToAPI(
 		for j, sn := range staticUnderlay.Neighbors {
 			neighbor := sn.Neighbor
 			if sn.Password != nil {
+				// The static plaintext value supplies authentication, so retaining a
+				// Secret reference would make the mirrored CR misleading.
 				neighbor.PasswordSecret = nil
 			}
 			spec.Neighbors[j] = neighbor

--- a/internal/controller/routerconfiguration/static_configuration_reader.go
+++ b/internal/controller/routerconfiguration/static_configuration_reader.go
@@ -288,8 +288,7 @@ func staticUnderlaysToAPI(
 	var underlays []v1alpha1.Underlay
 	passwords := make(map[string]string)
 	for i, staticUnderlay := range staticUnderlays {
-		neighborsPath := field.NewPath("underlays").Index(i).Child("neighbors")
-		if errs := validateStaticNeighbors(staticUnderlay.Neighbors, neighborsPath); len(errs) > 0 {
+		if errs := validateStaticNeighbors(staticUnderlay.Neighbors); len(errs) > 0 {
 			allErrors = append(allErrors, errs...)
 			continue
 		}
@@ -302,7 +301,11 @@ func staticUnderlaysToAPI(
 		spec.NodeSelector = nodeSelector
 		spec.Neighbors = make([]v1alpha1.Neighbor, len(staticUnderlay.Neighbors))
 		for j, sn := range staticUnderlay.Neighbors {
-			spec.Neighbors[j] = sn.Neighbor
+			neighbor := sn.Neighbor
+			if sn.Password != nil {
+				neighbor.PasswordSecret = nil
+			}
+			spec.Neighbors[j] = neighbor
 		}
 		underlay := v1alpha1.Underlay{
 			TypeMeta: metav1.TypeMeta{
@@ -329,34 +332,22 @@ func staticUnderlaysToAPI(
 	return underlays, passwords, allErrors
 }
 
-// validateStaticNeighbors validates neighbors from static (systemd) config.
-// In static mode there are no Kubernetes Secrets, so passwords are set as
-// plaintext in StaticNeighbor.Password. When a plaintext password is present
-// it takes precedence and PasswordSecret is cleared so that the later
-// resolvePasswordSecrets call (which handles the CRD/Secret path) skips it.
-func validateStaticNeighbors(staticNeighbors []static.StaticNeighbor, basePath *field.Path) field.ErrorList {
-	seen := make(map[string]struct{}, len(staticNeighbors))
-	for i := range staticNeighbors {
-		sn := &staticNeighbors[i]
-		p := basePath.Index(i)
-		key := conversion.NeighborID(sn.Neighbor)
-		if key == "" {
-			return field.ErrorList{field.Invalid(p, nil, "neighbor has neither address nor interface")}
-		}
-		if _, dup := seen[key]; dup {
-			return field.ErrorList{field.Invalid(p, key, "duplicate neighbor")}
-		}
-		seen[key] = struct{}{}
-		if sn.Password == nil {
+// validateStaticNeighbors validates plaintext passwords carried by static
+// (systemd) neighbors. Other neighbor constraints are enforced by the CRD
+// schema and conversion.ValidateUnderlays during reconciliation.
+func validateStaticNeighbors(neighbors []static.StaticNeighbor) field.ErrorList {
+	var errs field.ErrorList
+	for _, neighbor := range neighbors {
+		if neighbor.Password == nil {
 			continue
 		}
-		if err := validatePassword(*sn.Password); err != nil {
-			return field.ErrorList{field.Invalid(
-				p.Child("password"), nil,
-				fmt.Sprintf("static config password for neighbor %s: %s", conversion.NeighborID(sn.Neighbor), err),
-			)}
+		if err := validatePassword(*neighbor.Password); err != nil {
+			errs = append(errs, field.Invalid(
+				field.NewPath("neighbors").Key(conversion.NeighborID(neighbor.Neighbor)).Child("password"),
+				nil,
+				fmt.Sprintf("static config password: %s", err),
+			))
 		}
-		sn.PasswordSecret = nil
 	}
-	return nil
+	return errs
 }

--- a/internal/controller/routerconfiguration/static_configuration_reader_test.go
+++ b/internal/controller/routerconfiguration/static_configuration_reader_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/openperouter/openperouter/api/v1alpha1"
 	"github.com/openperouter/openperouter/internal/conversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 )
 
@@ -1084,8 +1083,6 @@ func TestStaticConfigToAPIConfig_EmptyConfig(t *testing.T) {
 }
 
 func TestValidateStaticNeighbors(t *testing.T) {
-	basePath := field.NewPath("underlays").Index(0).Child("neighbors")
-
 	tests := []struct {
 		name            string
 		neighbors       []static.StaticNeighbor
@@ -1136,46 +1133,10 @@ func TestValidateStaticNeighbors(t *testing.T) {
 			},
 			wantErrContains: "whitespace",
 		},
-		{
-			name: "duplicate address",
-			neighbors: []static.StaticNeighbor{
-				{Neighbor: v1alpha1.Neighbor{Address: new("10.0.0.1"), ASN: new(int64(64512))}},
-				{Neighbor: v1alpha1.Neighbor{Address: new("10.0.0.1"), ASN: new(int64(64513))}},
-			},
-			wantErrContains: "duplicate",
-		},
-		{
-			name: "same address different ports is duplicate",
-			neighbors: []static.StaticNeighbor{
-				{Neighbor: v1alpha1.Neighbor{Address: new("10.0.0.1"), ASN: new(int64(64512)), Port: new(int32(179))}},
-				{Neighbor: v1alpha1.Neighbor{Address: new("10.0.0.1"), ASN: new(int64(64513)), Port: new(int32(1179))}},
-			},
-			wantErrContains: "duplicate",
-		},
-		{
-			name: "nil address and interface",
-			neighbors: []static.StaticNeighbor{
-				{Neighbor: v1alpha1.Neighbor{ASN: new(int64(64512))}},
-			},
-			wantErrContains: "neither address nor interface",
-		},
-		{
-			name: "password clears passwordSecret",
-			neighbors: []static.StaticNeighbor{
-				{
-					Neighbor: v1alpha1.Neighbor{
-						Address:        new("10.0.0.1"),
-						ASN:            new(int64(64512)),
-						PasswordSecret: &v1alpha1.SecretKeyRef{Name: "my-secret"},
-					},
-					Password: new("staticpass"),
-				},
-			},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			errs := validateStaticNeighbors(tt.neighbors, basePath)
+			errs := validateStaticNeighbors(tt.neighbors)
 			if tt.wantErrContains != "" {
 				if len(errs) == 0 {
 					t.Fatal("expected validation error, got none")
@@ -1190,27 +1151,76 @@ func TestValidateStaticNeighbors(t *testing.T) {
 			}
 		})
 	}
+}
 
-	// Verify passwordSecret was cleared when password takes priority.
-	t.Run("verify passwordSecret cleared", func(t *testing.T) {
-		neighbors := []static.StaticNeighbor{
-			{
-				Neighbor: v1alpha1.Neighbor{
-					Address:        new("10.0.0.1"),
-					ASN:            new(int64(64512)),
-					PasswordSecret: &v1alpha1.SecretKeyRef{Name: "my-secret"},
-				},
-				Password: new("staticpass"),
+func TestStaticUnderlaysToAPIClearsPasswordSecretWhenPlaintextSet(t *testing.T) {
+	underlays := []static.StaticUnderlaySpec{{
+		UnderlaySpec: v1alpha1.UnderlaySpec{
+			ASN: 64512,
+			Interfaces: []v1alpha1.UnderlayInterface{
+				{Type: "NetworkDevice", NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"}},
 			},
-		}
-		errs := validateStaticNeighbors(neighbors, basePath)
-		if len(errs) > 0 {
-			t.Fatalf("unexpected errors: %v", errs.ToAggregate())
-		}
-		if neighbors[0].PasswordSecret != nil {
-			t.Error("expected PasswordSecret to be cleared, got non-nil")
-		}
-	})
+		},
+		Neighbors: []static.StaticNeighbor{{
+			Neighbor: v1alpha1.Neighbor{
+				Address:        new("10.0.0.1"),
+				ASN:            new(int64(64513)),
+				PasswordSecret: &v1alpha1.SecretKeyRef{Name: "my-secret"},
+			},
+			Password: new("staticpass"),
+		}},
+	}}
+
+	built, passwords, errs := staticUnderlaysToAPI(underlays, "node1", "ns", testNodeSelector("node1"))
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs.ToAggregate())
+	}
+	if built[0].Spec.Neighbors[0].PasswordSecret != nil {
+		t.Error("expected PasswordSecret cleared on the built underlay, got non-nil")
+	}
+	if passwords[conversion.NeighborID(built[0].Spec.Neighbors[0])] != "staticpass" {
+		t.Error("expected plaintext static password in the passwords map")
+	}
+}
+
+func TestStaticDuplicateNeighborRejectedAtReconcile(t *testing.T) {
+	underlays := []static.StaticUnderlaySpec{{
+		UnderlaySpec: v1alpha1.UnderlaySpec{
+			ASN: 64512,
+			Interfaces: []v1alpha1.UnderlayInterface{
+				{Type: "NetworkDevice", NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"}},
+			},
+		},
+		Neighbors: []static.StaticNeighbor{
+			{Neighbor: v1alpha1.Neighbor{Address: new("10.0.0.1"), ASN: new(int64(64513))}},
+			{Neighbor: v1alpha1.Neighbor{Address: new("10.0.0.1"), ASN: new(int64(64514))}},
+		},
+	}}
+
+	built, _, errs := staticUnderlaysToAPI(underlays, "node1", "ns", testNodeSelector("node1"))
+	if len(errs) > 0 {
+		t.Fatalf("staticUnderlaysToAPI should not reject duplicates itself: %v", errs.ToAggregate())
+	}
+	if err := conversion.ValidateUnderlays(built); err == nil {
+		t.Fatal("expected ValidateUnderlays to reject duplicate static neighbors")
+	}
+}
+
+func TestStaticUnderlaysToAPIRejectsEmptyNeighbor(t *testing.T) {
+	underlays := []static.StaticUnderlaySpec{{
+		UnderlaySpec: v1alpha1.UnderlaySpec{
+			ASN: 64512,
+			Interfaces: []v1alpha1.UnderlayInterface{
+				{Type: "NetworkDevice", NetworkDevice: &v1alpha1.NetworkDevice{InterfaceName: "eth0"}},
+			},
+		},
+		Neighbors: []static.StaticNeighbor{{Neighbor: v1alpha1.Neighbor{ASN: new(int64(64513))}}},
+	}}
+
+	_, _, errs := staticUnderlaysToAPI(underlays, "node1", "ns", testNodeSelector("node1"))
+	if len(errs) == 0 {
+		t.Fatal("expected an empty neighbor to be rejected")
+	}
 }
 
 func TestStaticConfigPasswordsMap(t *testing.T) {
@@ -1299,4 +1309,8 @@ func TestStaticConfigInvalidPassword(t *testing.T) {
 			}
 		})
 	}
+}
+
+func testNodeSelector(nodeName string) *metav1.LabelSelector {
+	return &metav1.LabelSelector{MatchLabels: map[string]string{"kubernetes.io/hostname": nodeName}}
 }

--- a/internal/controller/routerconfiguration/underlay_vni_controller.go
+++ b/internal/controller/routerconfiguration/underlay_vni_controller.go
@@ -385,6 +385,7 @@ func (r *PERouterReconciler) fetchPasswordFromSecret(ctx context.Context, ref *v
 	return resolved, nil
 }
 
+// maxPasswordLength matches Linux TCP_MD5SIG_MAXKEYLEN, the BGP MD5 key limit.
 const maxPasswordLength = 80
 
 var validPasswordPattern = regexp.MustCompile(`^\S+$`)

--- a/internal/controller/routerconfiguration/underlay_vni_controller.go
+++ b/internal/controller/routerconfiguration/underlay_vni_controller.go
@@ -190,7 +190,10 @@ func mergeStaticConfig(staticConfigDir, nodeName, namespace string, config conve
 		return config, fmt.Errorf("failed to merge api config and static config: %w", err)
 	}
 
-	logger.Info("merge static config using", "from api", config, "static config", staticConfig, "merged", merged)
+	logger.Info("merge static config using",
+		"from api", conversion.RedactAPIConfigData(config),
+		"static config", conversion.RedactAPIConfigData(staticConfig),
+		"merged", conversion.RedactAPIConfigData(merged))
 	return merged, nil
 }
 
@@ -291,7 +294,7 @@ func (r *PERouterReconciler) getConfigFromAPI(ctx context.Context, logger *slog.
 		"l3vnis", l3vnis.Items,
 		"l2vnis", l2vnis.Items,
 		"l3passthrough", l3passthrough.Items,
-		"rawfrrconfigs", rawFRRConfigs.Items)
+		"rawfrrconfigs", conversion.RedactRawFRRConfigs(rawFRRConfigs.Items))
 
 	apiConfig := conversion.APIConfigData{
 		Underlays:     filteredUnderlays,

--- a/internal/controller/routerconfiguration/underlay_vni_controller.go
+++ b/internal/controller/routerconfiguration/underlay_vni_controller.go
@@ -322,6 +322,8 @@ func (r *PERouterReconciler) resolvePasswordSecrets(ctx context.Context, config 
 				continue
 			}
 
+			// A password already in the map comes from static (systemd) plaintext
+			// config, which takes precedence over the Secret.
 			if _, alreadyResolved := config.Passwords[conversion.NeighborID(n)]; alreadyResolved {
 				validNeighbors = append(validNeighbors, n)
 				continue

--- a/internal/conversion/api.go
+++ b/internal/conversion/api.go
@@ -5,8 +5,10 @@ package conversion
 import (
 	"errors"
 	"maps"
+	"slices"
 
 	"github.com/openperouter/openperouter/api/v1alpha1"
+	"github.com/openperouter/openperouter/internal/frr"
 	"github.com/openperouter/openperouter/internal/hostnetwork"
 )
 
@@ -52,6 +54,38 @@ func MergeAPIConfigs(configs ...APIConfigData) (APIConfigData, error) {
 	}
 
 	return merged, nil
+}
+
+const passwordRedactionMarker = "<REDACTED>"
+
+// RedactAPIConfigData returns a copy of data safe for logging: resolved BGP
+// passwords and any passwords embedded in raw FRR snippets are replaced with a
+// redaction marker. Underlays and VNIs carry only secret references, never
+// plaintext credentials, so they are shared unchanged.
+func RedactAPIConfigData(data APIConfigData) APIConfigData {
+	if data.Passwords != nil {
+		passwords := make(map[string]string, len(data.Passwords))
+		for id := range data.Passwords {
+			passwords[id] = passwordRedactionMarker
+		}
+		data.Passwords = passwords
+	}
+	data.RawFRRConfigs = RedactRawFRRConfigs(data.RawFRRConfigs)
+	return data
+}
+
+// RedactRawFRRConfigs returns a copy of configs with the passwords in each raw
+// FRR snippet replaced, safe for logging.
+func RedactRawFRRConfigs(configs []v1alpha1.RawFRRConfig) []v1alpha1.RawFRRConfig {
+	if configs == nil {
+		return nil
+	}
+
+	redacted := slices.Clone(configs)
+	for i := range redacted {
+		redacted[i].Spec.RawConfig = frr.RedactPasswords(redacted[i].Spec.RawConfig)
+	}
+	return redacted
 }
 
 // validateAPIConfigData flags invalid config data.

--- a/internal/conversion/api_test.go
+++ b/internal/conversion/api_test.go
@@ -184,3 +184,29 @@ func TestMergeAPIConfigs_ResourcesConcatenated(t *testing.T) {
 		t.Errorf("merged config mismatch (-want +got):\n%s", cmp.Diff(want, merged))
 	}
 }
+
+func TestRedactAPIConfigData(t *testing.T) {
+	in := APIConfigData{
+		Passwords: map[string]string{"10.0.0.1": "s3cret", "10.0.0.2": "hunter2"},
+		RawFRRConfigs: []v1alpha1.RawFRRConfig{
+			{Spec: v1alpha1.RawFRRConfigSpec{RawConfig: "neighbor 10.0.0.1 password topsecret"}},
+		},
+	}
+
+	got := RedactAPIConfigData(in)
+
+	for id, password := range got.Passwords {
+		if password != "<REDACTED>" {
+			t.Errorf("password for %s = %q, want <REDACTED>", id, password)
+		}
+	}
+	if want := "neighbor 10.0.0.1 password <REDACTED>"; got.RawFRRConfigs[0].Spec.RawConfig != want {
+		t.Errorf("raw config = %q, want %q", got.RawFRRConfigs[0].Spec.RawConfig, want)
+	}
+	if in.Passwords["10.0.0.1"] != "s3cret" {
+		t.Error("input Passwords map was mutated")
+	}
+	if in.RawFRRConfigs[0].Spec.RawConfig != "neighbor 10.0.0.1 password topsecret" {
+		t.Error("input RawFRRConfigs was mutated")
+	}
+}

--- a/internal/conversion/validate_underlay.go
+++ b/internal/conversion/validate_underlay.go
@@ -78,6 +78,11 @@ func validateUnderlay(underlay v1alpha1.Underlay) error {
 		return fmt.Errorf("underlay %s: %w", underlay.Name, err)
 	}
 
+	if err := validateNoDuplicates(neighborIDsOf(underlay.Spec.Neighbors)); err != nil {
+		return fmt.Errorf("underlay %s has neighbors sharing an identity (address, listen range or interface): %w",
+			underlay.Name, err)
+	}
+
 	// do a no-op conversion to catch validation errors
 	if _, err := underlayInterfacesToHost(underlay.Spec.Interfaces); err != nil {
 		return fmt.Errorf("underlay %s has invalid interfaces: %w", underlay.Name, err)
@@ -151,6 +156,18 @@ func interfaceNamesOf(neighbors []v1alpha1.Neighbor) []string {
 			continue
 		}
 		res = append(res, *n.Interface)
+	}
+	return res
+}
+
+func neighborIDsOf(neighbors []v1alpha1.Neighbor) []string {
+	res := []string{}
+	for _, n := range neighbors {
+		id := NeighborID(n)
+		if id == "" {
+			continue
+		}
+		res = append(res, id)
 	}
 	return res
 }

--- a/internal/conversion/validate_underlay_test.go
+++ b/internal/conversion/validate_underlay_test.go
@@ -945,6 +945,27 @@ func TestValidateUnderlay(t *testing.T) {
 	}
 }
 
+func TestValidateUnderlayRejectsDuplicateNeighborIdentity(t *testing.T) {
+	underlay := v1alpha1.Underlay{
+		ObjectMeta: metav1.ObjectMeta{Name: "u1"},
+		Spec: v1alpha1.UnderlaySpec{
+			ASN: 64512,
+			Neighbors: []v1alpha1.Neighbor{
+				{Address: new("10.0.0.1"), ASN: new(int64(64513))},
+				{Interface: new("10.0.0.1"), ASN: new(int64(64514))},
+			},
+		},
+	}
+
+	err := validateUnderlay(underlay)
+	if err == nil {
+		t.Fatal("expected error for neighbors sharing an identity, got nil")
+	}
+	if !strings.Contains(err.Error(), "identity") {
+		t.Fatalf("error = %q, want it to mention identity", err.Error())
+	}
+}
+
 func TestValidateUnderlaysForNodes(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/frr/config.go
+++ b/internal/frr/config.go
@@ -206,7 +206,9 @@ func (n NeighborConfig) IsRouteReflectorClientFor(afi networklayerprotocol.AFI, 
 	return nlp.Properties.RouteReflectorClient
 }
 
-var frrPasswordRe = regexp.MustCompile(`(neighbor .*) password (.*)`)
+var frrPasswordRe = regexp.MustCompile(
+	`(?im)^([ \t]*[+-]?[ \t]*(?:no[ \t]+)?neighbor[ \t]+\S+[ \t]+password)(?:[ \t]+[^\r\n]*)?[ \t]*\r?$`,
+)
 
 func (nc NeighborConfig) LogValue() slog.Value {
 	type noLogValuer NeighborConfig
@@ -216,7 +218,7 @@ func (nc NeighborConfig) LogValue() slog.Value {
 }
 
 func RedactPasswords(config string) string {
-	return frrPasswordRe.ReplaceAllString(config, "${1} password <REDACTED>")
+	return frrPasswordRe.ReplaceAllString(config, "${1} <REDACTED>")
 }
 
 // shouldRenderUnderlayEVPN tells whether the underlay needs the l2vpn evpn

--- a/internal/frr/config_redact_test.go
+++ b/internal/frr/config_redact_test.go
@@ -92,3 +92,35 @@ func TestFRRReloadOutputPasswordRedacted(t *testing.T) {
 		t.Fatalf("redacted reload output mismatch:\nwant:\n%s\ngot:\n%s", want, got)
 	}
 }
+
+func TestRedactPasswordsHandlesRawFRRPasswordFormatting(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "quoted password with whitespace",
+			in:   `neighbor 192.168.1.2 password "a password with spaces"`,
+			want: "neighbor 192.168.1.2 password <REDACTED>",
+		},
+		{
+			name: "uppercase keyword in a diff",
+			in:   `+ NEIGHBOR 192.168.1.2 PASSWORD secret`,
+			want: "+ NEIGHBOR 192.168.1.2 PASSWORD <REDACTED>",
+		},
+		{
+			name: "password deletion command",
+			in:   `no neighbor 192.0.2.1 password old-secret`,
+			want: "no neighbor 192.0.2.1 password <REDACTED>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RedactPasswords(tt.in); got != tt.want {
+				t.Errorf("RedactPasswords() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
fixing some leftover comments from this PR https://github.com/openperouter/openperouter/pull/567,
fixes #682

/kind cleanup

**What this PR does / why we need it**:

**Special notes for your reviewer**:

```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Sensitive BGP and FRR passwords are now redacted in debug logs and configuration-related output.
  * Passwords embedded in raw FRR configuration snippets are also protected from accidental exposure.

* **Validation**
  * Duplicate neighbor identities are rejected during configuration validation.
  * Invalid neighbor passwords are reported more comprehensively, while valid neighbors can still be retained.
  * Plaintext passwords take precedence over password references, and associated secret references are cleared when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->