### PR TITLE
fix(frr): do not set next-hop-self for route reflector clients

### DIFF
--- a/internal/frr/frr_test.go
+++ b/internal/frr/frr_test.go
@@ -1391,6 +1391,10 @@ func TestRouteReflector(t *testing.T) {
 	ipv4 := networklayerprotocol.NLP{AFI: networklayerprotocol.IPv4, SAFI: networklayerprotocol.Unicast}
 	evpnWithRRClient := networklayerprotocol.NLP{AFI: evpn.AFI, SAFI: evpn.SAFI,
 		Properties: networklayerprotocol.NLPProperties{RouteReflectorClient: true}}
+	ipv4WithRRClient := networklayerprotocol.NLP{AFI: networklayerprotocol.IPv4, SAFI: networklayerprotocol.Unicast,
+		Properties: networklayerprotocol.NLPProperties{RouteReflectorClient: true}}
+	ipv6WithRRClient := networklayerprotocol.NLP{AFI: networklayerprotocol.IPv6, SAFI: networklayerprotocol.Unicast,
+		Properties: networklayerprotocol.NLPProperties{RouteReflectorClient: true}}
 
 	config := Config{
 		Underlay: UnderlayConfig{
@@ -1416,11 +1420,15 @@ func TestRouteReflector(t *testing.T) {
 					NetworkLayerProtocols: []networklayerprotocol.NLP{evpnWithRRClient},
 				},
 				{
-					ASN:                   mustNewPeerASNFromType("Internal"),
-					ListenRange:           "fd00:10::/64",
-					ID:                    "fd00:10::/64",
-					ExtendedNexthop:       true,
-					NetworkLayerProtocols: []networklayerprotocol.NLP{evpnWithRRClient},
+					ASN:             mustNewPeerASNFromType("Internal"),
+					ListenRange:     "fd00:10::/64",
+					ID:              "fd00:10::/64",
+					ExtendedNexthop: true,
+					NetworkLayerProtocols: []networklayerprotocol.NLP{
+						evpnWithRRClient,
+						ipv4WithRRClient,
+						ipv6WithRRClient,
+					},
 				},
 				{
 					ASN:                   mustNewPeerASNFromType("Internal"),

--- a/internal/frr/templates/neighboripfamily.tmpl
+++ b/internal/frr/templates/neighboripfamily.tmpl
@@ -8,8 +8,9 @@
 {{- else }}
 {{- if .neighbor.IsRouteReflectorClientFor "ipv4" "unicast" }}
     neighbor {{.neighbor.ID}} route-reflector-client
-{{- end }}
+{{- else }}
     neighbor {{.neighbor.ID}} next-hop-self force
+{{- end }}
 {{- end }}
   exit-address-family
 
@@ -22,8 +23,9 @@
 {{- else }}
 {{- if .neighbor.IsRouteReflectorClientFor "ipv6" "unicast" }}
     neighbor {{.neighbor.ID}} route-reflector-client
-{{- end }}
+{{- else }}
     neighbor {{.neighbor.ID}} next-hop-self force
+{{- end }}
 {{- end }}
   exit-address-family
 {{- end -}}

--- a/internal/frr/templates/underlay_l3vpn.tmpl
+++ b/internal/frr/templates/underlay_l3vpn.tmpl
@@ -3,9 +3,10 @@
 {{- range $neighbor := .Underlay.Neighbors }}
 {{- if $neighbor.ActivateFor "ipv4" "vpn" }}
     neighbor {{ $neighbor.ID }} activate
-    neighbor {{ $neighbor.ID }} next-hop-self
 {{- if $neighbor.IsRouteReflectorClientFor "ipv4" "vpn" }}
     neighbor {{ $neighbor.ID }} route-reflector-client
+{{- else }}
+    neighbor {{ $neighbor.ID }} next-hop-self
 {{- end }}
 {{- end }}
 {{- end }}
@@ -15,9 +16,10 @@
 {{- range $neighbor := .Underlay.Neighbors }}
 {{- if $neighbor.ActivateFor "ipv6" "vpn" }}
     neighbor {{ $neighbor.ID }} activate
-    neighbor {{ $neighbor.ID }} next-hop-self
 {{- if $neighbor.IsRouteReflectorClientFor "ipv6" "vpn" }}
     neighbor {{ $neighbor.ID }} route-reflector-client
+{{- else }}
+    neighbor {{ $neighbor.ID }} next-hop-self
 {{- end }}
 {{- end }}
 {{- end }}

--- a/internal/frr/testdata/TestRouteReflector.golden
+++ b/internal/frr/testdata/TestRouteReflector.golden
@@ -40,6 +40,14 @@ router bgp 64514
   exit-address-family
 
 
+  address-family ipv4 unicast
+    neighbor fd00:10::/64 activate
+    neighbor fd00:10::/64 route-reflector-client
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor fd00:10::/64 activate
+    neighbor fd00:10::/64 route-reflector-client
+  exit-address-family
 
   address-family ipv4 unicast
     neighbor 192.168.10.4 activate

--- a/internal/frr/testdata/TestRouteReflectorL3VPN.golden
+++ b/internal/frr/testdata/TestRouteReflectorL3VPN.golden
@@ -20,13 +20,11 @@ router bgp 64514
 
   address-family ipv4 vpn
     neighbor fc00::2:172:31:1:12 activate
-    neighbor fc00::2:172:31:1:12 next-hop-self
     neighbor fc00::2:172:31:1:12 route-reflector-client
   exit-address-family
   !
   address-family ipv6 vpn
     neighbor fc00::2:172:31:1:12 activate
-    neighbor fc00::2:172:31:1:12 next-hop-self
     neighbor fc00::2:172:31:1:12 route-reflector-client
   exit-address-family
   !


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Route reflectors that set `next-hop-self` insert themselves into the data path for all reflected routes, creating a traffic bottleneck. This PR makes `next-hop-self` and `route-reflector-client` mutually exclusive for IPv4/IPv6 unicast and IPv4/IPv6 VPN address families, matching the existing l2vpn evpn behavior.

Fixes #728

**Special notes for your reviewer**:

The same pattern existed in both `neighboripfamily.tmpl` (IPv4/IPv6 unicast) and `underlay_l3vpn.tmpl` (IPv4/IPv6 VPN). Both are fixed.

**Release note**:

```release-note
Fix route reflectors setting next-hop-self for route reflector clients in IPv4/IPv6 unicast and VPN address families, which caused the route reflector to be inserted into the data path.
```

AI Guidelines Acknowledgment:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected route-reflector neighbor configuration for IPv4 and IPv6 address families.
  - Route-reflector clients now receive the appropriate client configuration without conflicting next-hop behavior.
  - Updated L3VPN route-reflector settings to apply consistently across IPv4 and IPv6 VPNs.
  - Expanded IPv6 peer-group configuration to support IPv4 and IPv6 unicast route-reflector clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->