### PR TITLE
API: Extend CRDs print columns

### DIFF
--- a/api/v1alpha1/l2vni_types.go
+++ b/api/v1alpha1/l2vni_types.go
@@ -199,6 +199,10 @@ type L2VNIStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:webhook:verbs=create;update,path=/validate-openperouter-io-v1alpha1-l2vni,mutating=false,failurePolicy=fail,groups=network.openperouter.io,resources=l2vnis,versions=v1alpha1,name=l2vnivalidationwebhook.openperouter.io,sideEffects=None,admissionReviewVersions=v1
+// +kubebuilder:printcolumn:name="VNI",type=integer,JSONPath=`.spec.vni`
+// +kubebuilder:printcolumn:name="Routing Domain",type=string,JSONPath=`.spec.routingDomain.*.name`
+// +kubebuilder:printcolumn:name="Gateway IPs",type=string,JSONPath=`.spec.gatewayIPs`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // L2VNI represents a VXLan VNI to receive EVPN type 2 routes
 // from.

--- a/api/v1alpha1/l3passthrough_types.go
+++ b/api/v1alpha1/l3passthrough_types.go
@@ -41,6 +41,9 @@ type L3PassthroughStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:webhook:verbs=create;update,path=/validate-openperouter-io-v1alpha1-l3passthrough,mutating=false,failurePolicy=fail,groups=network.openperouter.io,resources=l3passthroughs,versions=v1alpha1,name=l3passthroughvalidationwebhook.openperouter.io,sideEffects=None,admissionReviewVersions=v1
+// +kubebuilder:printcolumn:name="ASN",type=integer,JSONPath=`.spec.hostSession.asn`
+// +kubebuilder:printcolumn:name="HostASN",type=integer,JSONPath=`.spec.hostSession.hostASN`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // L3Passthrough represents a session with the host which is not encapsulated and
 // takes part to the bgp fabric.

--- a/api/v1alpha1/l3vni_types.go
+++ b/api/v1alpha1/l3vni_types.go
@@ -86,6 +86,9 @@ type L3VNIStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:webhook:verbs=create;update,path=/validate-openperouter-io-v1alpha1-l3vni,mutating=false,failurePolicy=fail,groups=network.openperouter.io,resources=l3vnis,versions=v1alpha1,name=l3vnivalidationwebhook.openperouter.io,sideEffects=None,admissionReviewVersions=v1
+// +kubebuilder:printcolumn:name="VNI",type=integer,JSONPath=`.spec.vni`
+// +kubebuilder:printcolumn:name="VRF",type=string,JSONPath=`.spec.vrf`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // L3VNI represents a VXLan L3VNI to receive EVPN type 5 routes
 // from.

--- a/api/v1alpha1/l3vpn_types.go
+++ b/api/v1alpha1/l3vpn_types.go
@@ -75,6 +75,8 @@ type L3VPNStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:webhook:verbs=create;update,path=/validate-openperouter-io-v1alpha1-l3vpn,mutating=false,failurePolicy=fail,groups=network.openperouter.io,resources=l3vpns,versions=v1alpha1,name=l3vpnsvalidationwebhook.openperouter.io,sideEffects=None,admissionReviewVersions=v1
+// +kubebuilder:printcolumn:name="VRF",type=string,JSONPath=`.spec.vrf`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // L3VPN represents an SRv6 IP VPN.
 type L3VPN struct {

--- a/api/v1alpha1/underlay_types.go
+++ b/api/v1alpha1/underlay_types.go
@@ -402,6 +402,10 @@ type UnderlayStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:webhook:verbs=create;update,path=/validate-openperouter-io-v1alpha1-underlay,mutating=false,failurePolicy=fail,groups=network.openperouter.io,resources=underlays,versions=v1alpha1,name=underlayvalidationwebhook.openperouter.io,sideEffects=None,admissionReviewVersions=v1
+// +kubebuilder:printcolumn:name="ASN",type=integer,JSONPath=`.spec.asn`
+// +kubebuilder:printcolumn:name="Router ID Pool",type=string,JSONPath=`.spec.routerIDCIDR`
+// +kubebuilder:printcolumn:name="VTEP CIDR",type=string,JSONPath=`.spec.tunnelEndpoint.cidrs`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // Underlay is the Schema for the underlays API.
 type Underlay struct {

--- a/charts/openperouter/charts/crds/templates/network.openperouter.io_l2vnis.yaml
+++ b/charts/openperouter/charts/crds/templates/network.openperouter.io_l2vnis.yaml
@@ -14,7 +14,20 @@ spec:
     singular: l2vni
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.vni
+      name: VNI
+      type: integer
+    - jsonPath: .spec.routingDomain.*.name
+      name: Routing Domain
+      type: string
+    - jsonPath: .spec.gatewayIPs
+      name: Gateway IPs
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-

--- a/charts/openperouter/charts/crds/templates/network.openperouter.io_l3passthroughs.yaml
+++ b/charts/openperouter/charts/crds/templates/network.openperouter.io_l3passthroughs.yaml
@@ -14,7 +14,17 @@ spec:
     singular: l3passthrough
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hostSession.asn
+      name: ASN
+      type: integer
+    - jsonPath: .spec.hostSession.hostASN
+      name: HostASN
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-

--- a/charts/openperouter/charts/crds/templates/network.openperouter.io_l3vnis.yaml
+++ b/charts/openperouter/charts/crds/templates/network.openperouter.io_l3vnis.yaml
@@ -14,7 +14,17 @@ spec:
     singular: l3vni
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.vni
+      name: VNI
+      type: integer
+    - jsonPath: .spec.vrf
+      name: VRF
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-

--- a/charts/openperouter/charts/crds/templates/network.openperouter.io_l3vpns.yaml
+++ b/charts/openperouter/charts/crds/templates/network.openperouter.io_l3vpns.yaml
@@ -14,7 +14,14 @@ spec:
     singular: l3vpn
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.vrf
+      name: VRF
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: L3VPN represents an SRv6 IP VPN.

--- a/charts/openperouter/charts/crds/templates/network.openperouter.io_underlays.yaml
+++ b/charts/openperouter/charts/crds/templates/network.openperouter.io_underlays.yaml
@@ -14,7 +14,20 @@ spec:
     singular: underlay
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.asn
+      name: ASN
+      type: integer
+    - jsonPath: .spec.routerIDCIDR
+      name: Router ID Pool
+      type: string
+    - jsonPath: .spec.tunnelEndpoint.cidrs
+      name: VTEP CIDR
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Underlay is the Schema for the underlays API.

--- a/config/all-in-one/crio.yaml
+++ b/config/all-in-one/crio.yaml
@@ -23,7 +23,20 @@ spec:
     singular: l2vni
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.vni
+      name: VNI
+      type: integer
+    - jsonPath: .spec.routingDomain.*.name
+      name: Routing Domain
+      type: string
+    - jsonPath: .spec.gatewayIPs
+      name: Gateway IPs
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-
@@ -293,7 +306,17 @@ spec:
     singular: l3passthrough
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hostSession.asn
+      name: ASN
+      type: integer
+    - jsonPath: .spec.hostSession.hostASN
+      name: HostASN
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-
@@ -456,7 +479,17 @@ spec:
     singular: l3vni
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.vni
+      name: VNI
+      type: integer
+    - jsonPath: .spec.vrf
+      name: VRF
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-
@@ -675,7 +708,14 @@ spec:
     singular: l3vpn
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.vrf
+      name: VRF
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: L3VPN represents an SRv6 IP VPN.
@@ -1162,7 +1202,20 @@ spec:
     singular: underlay
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.asn
+      name: ASN
+      type: integer
+    - jsonPath: .spec.routerIDCIDR
+      name: Router ID Pool
+      type: string
+    - jsonPath: .spec.tunnelEndpoint.cidrs
+      name: VTEP CIDR
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Underlay is the Schema for the underlays API.

--- a/config/all-in-one/openpe.yaml
+++ b/config/all-in-one/openpe.yaml
@@ -23,7 +23,20 @@ spec:
     singular: l2vni
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.vni
+      name: VNI
+      type: integer
+    - jsonPath: .spec.routingDomain.*.name
+      name: Routing Domain
+      type: string
+    - jsonPath: .spec.gatewayIPs
+      name: Gateway IPs
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-
@@ -293,7 +306,17 @@ spec:
     singular: l3passthrough
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hostSession.asn
+      name: ASN
+      type: integer
+    - jsonPath: .spec.hostSession.hostASN
+      name: HostASN
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-
@@ -456,7 +479,17 @@ spec:
     singular: l3vni
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.vni
+      name: VNI
+      type: integer
+    - jsonPath: .spec.vrf
+      name: VRF
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-
@@ -675,7 +708,14 @@ spec:
     singular: l3vpn
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.vrf
+      name: VRF
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: L3VPN represents an SRv6 IP VPN.
@@ -1162,7 +1202,20 @@ spec:
     singular: underlay
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.asn
+      name: ASN
+      type: integer
+    - jsonPath: .spec.routerIDCIDR
+      name: Router ID Pool
+      type: string
+    - jsonPath: .spec.tunnelEndpoint.cidrs
+      name: VTEP CIDR
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Underlay is the Schema for the underlays API.

--- a/config/crd/bases/network.openperouter.io_l2vnis.yaml
+++ b/config/crd/bases/network.openperouter.io_l2vnis.yaml
@@ -14,7 +14,20 @@ spec:
     singular: l2vni
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.vni
+      name: VNI
+      type: integer
+    - jsonPath: .spec.routingDomain.*.name
+      name: Routing Domain
+      type: string
+    - jsonPath: .spec.gatewayIPs
+      name: Gateway IPs
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-

--- a/config/crd/bases/network.openperouter.io_l3passthroughs.yaml
+++ b/config/crd/bases/network.openperouter.io_l3passthroughs.yaml
@@ -14,7 +14,17 @@ spec:
     singular: l3passthrough
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hostSession.asn
+      name: ASN
+      type: integer
+    - jsonPath: .spec.hostSession.hostASN
+      name: HostASN
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-

--- a/config/crd/bases/network.openperouter.io_l3vnis.yaml
+++ b/config/crd/bases/network.openperouter.io_l3vnis.yaml
@@ -14,7 +14,17 @@ spec:
     singular: l3vni
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.vni
+      name: VNI
+      type: integer
+    - jsonPath: .spec.vrf
+      name: VRF
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-

--- a/config/crd/bases/network.openperouter.io_l3vpns.yaml
+++ b/config/crd/bases/network.openperouter.io_l3vpns.yaml
@@ -14,7 +14,14 @@ spec:
     singular: l3vpn
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.vrf
+      name: VRF
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: L3VPN represents an SRv6 IP VPN.

--- a/config/crd/bases/network.openperouter.io_underlays.yaml
+++ b/config/crd/bases/network.openperouter.io_underlays.yaml
@@ -14,7 +14,20 @@ spec:
     singular: underlay
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.asn
+      name: ASN
+      type: integer
+    - jsonPath: .spec.routerIDCIDR
+      name: Router ID Pool
+      type: string
+    - jsonPath: .spec.tunnelEndpoint.cidrs
+      name: VTEP CIDR
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Underlay is the Schema for the underlays API.

--- a/operator/bundle/manifests/network.openperouter.io_l2vnis.yaml
+++ b/operator/bundle/manifests/network.openperouter.io_l2vnis.yaml
@@ -14,7 +14,20 @@ spec:
     singular: l2vni
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.vni
+      name: VNI
+      type: integer
+    - jsonPath: .spec.routingDomain.*.name
+      name: Routing Domain
+      type: string
+    - jsonPath: .spec.gatewayIPs
+      name: Gateway IPs
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-

--- a/operator/bundle/manifests/network.openperouter.io_l3passthroughs.yaml
+++ b/operator/bundle/manifests/network.openperouter.io_l3passthroughs.yaml
@@ -14,7 +14,17 @@ spec:
     singular: l3passthrough
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hostSession.asn
+      name: ASN
+      type: integer
+    - jsonPath: .spec.hostSession.hostASN
+      name: HostASN
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-

--- a/operator/bundle/manifests/network.openperouter.io_l3vnis.yaml
+++ b/operator/bundle/manifests/network.openperouter.io_l3vnis.yaml
@@ -14,7 +14,17 @@ spec:
     singular: l3vni
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.vni
+      name: VNI
+      type: integer
+    - jsonPath: .spec.vrf
+      name: VRF
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-

--- a/operator/bundle/manifests/network.openperouter.io_l3vpns.yaml
+++ b/operator/bundle/manifests/network.openperouter.io_l3vpns.yaml
@@ -14,7 +14,14 @@ spec:
     singular: l3vpn
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.vrf
+      name: VRF
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: L3VPN represents an SRv6 IP VPN.

--- a/operator/bundle/manifests/network.openperouter.io_underlays.yaml
+++ b/operator/bundle/manifests/network.openperouter.io_underlays.yaml
@@ -14,7 +14,20 @@ spec:
     singular: underlay
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.asn
+      name: ASN
+      type: integer
+    - jsonPath: .spec.routerIDCIDR
+      name: Router ID Pool
+      type: string
+    - jsonPath: .spec.tunnelEndpoint.cidrs
+      name: VTEP CIDR
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Underlay is the Schema for the underlays API.


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
/kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:
Extend the following CRD print-column per [API improvements enhancement](https://github.com/openperouter/openperouter/blob/main/enhancements/api-improvements.md#print-columns).
And for the recently added L3VPN CRD.

| CRD | Columns |
|-----|---------|
| Underlay | ASN, Router ID Pool, VTEP CIDR |
| L3VNI | VNI, VRF |
| L3Passthrough | ASN, HostASN |
| L2VNI | VNI, Routing Domain, Gateway IPs |
| L3VPN | VRF |

Example (examples/evpn/layer2):
```
$ kubectl -n openperouter-system get underlay,l3vni,l2vni
NAMESPACE             NAME                                        ASN     ROUTER ID POOL   VTEP CIDR           AGE
openperouter-system   underlay.network.openperouter.io/underlay   64514   10.0.0.0/24      ["100.65.0.0/24"]   5m29s

NAMESPACE             NAME                                VNI   VRF   AGE
openperouter-system   l3vni.network.openperouter.io/red   100   red   5m29s

NAMESPACE             NAME                                   VNI   ROUTING DOMAIN   GATEWAY IPS          AGE
openperouter-system   l2vni.network.openperouter.io/layer2   110   red              ["192.170.1.1/24"]   5m29s
```
L3VPN (examples/l3vpn/layer2)
```
$ kubectl -n openperouter-system get underlay,l2vni,l3vnp
NAMESPACE             NAME                                        ASN     ROUTER ID POOL   VTEP CIDR                                     AGE
openperouter-system   underlay.network.openperouter.io/underlay   64514   10.0.0.0/24      ["100.65.0.0/24","2001:db8:1234:5678::/64"]   23s

NAMESPACE             NAME                                VRF   AGE
openperouter-system   l3vpn.network.openperouter.io/red   red    23s

NAMESPACE             NAME                                   VNI   ROUTING DOMAIN   GATEWAY IPS          AGE
openperouter-system   l2vni.network.openperouter.io/layer2   110   red              ["192.170.1.1/24"]   23s
```

**Special notes for your reviewer**:
- The L3VPN was added after the enhancement was merged. The L3VPN print column now reflect the VRF as well. Additional infos can be added later on.
- The L3VPN was added after the enhancement was merged, where L2VNI could have only L3VNI as "backend". The recently added L3VPN can act as "backend" for L2VNI as well. Hence, the proposed L3VNI reference column was generalized to "Routing Domain".

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
API: The following CRDs were extend to have additional info as part of their print-column: 
- `Underlay`: ASN, Router ID Pool, VTEP CIDR
- `L3VNI`: VNI, VRF
- `L3Passthrough`:  ASN, HostASN
- `L2VNI`:  VNI, Routing Domain, Gateway IPs
- `L3VPN`: VRF

```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced `kubectl get` output for L2VNI resources with VNI, routing domain, gateway IPs, and age.
  - Added ASN, host ASN, and age columns for L3Passthrough resources.
  - Added VNI, VRF, and age columns for L3VNI resources.
  - Added VRF and age columns for L3VPN resources.
  - Added ASN, Router ID Pool, VTEP CIDR, and age columns for Underlay resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->