### PR TITLE
Improve test portability

### DIFF
--- a/e2etests/pkg/k8s/namespace.go
+++ b/e2etests/pkg/k8s/namespace.go
@@ -18,6 +18,11 @@ func CreateNamespace(cs clientset.Interface, name string) (*corev1.Namespace, er
 	_, err := cs.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
+			Labels: map[string]string{
+				"pod-security.kubernetes.io/enforce": "privileged",
+				"pod-security.kubernetes.io/audit":   "privileged",
+				"pod-security.kubernetes.io/warn":    "privileged",
+			},
 		},
 	}, metav1.CreateOptions{})
 	if err != nil {

--- a/e2etests/pkg/k8s/pods.go
+++ b/e2etests/pkg/k8s/pods.go
@@ -94,6 +94,19 @@ func OnNode(nodeName string) func(*corev1.Pod) {
 	}
 }
 
+func WithCapabilities(caps ...corev1.Capability) PodModifier {
+	return func(pod *corev1.Pod) {
+		c := &pod.Spec.Containers[0]
+		if c.SecurityContext == nil {
+			c.SecurityContext = &corev1.SecurityContext{}
+		}
+		if c.SecurityContext.Capabilities == nil {
+			c.SecurityContext.Capabilities = &corev1.Capabilities{}
+		}
+		c.SecurityContext.Capabilities.Add = append(c.SecurityContext.Capabilities.Add, caps...)
+	}
+}
+
 func waitForPodReady(cs clientset.Interface, pod *corev1.Pod) (*corev1.Pod, error) {
 	timeout := time.After(3 * time.Minute)
 	ticker := time.NewTicker(500 * time.Millisecond)

--- a/e2etests/tests/bridgerefresh.go
+++ b/e2etests/tests/bridgerefresh.go
@@ -155,6 +155,7 @@ var _ = Describe("BridgeRefresher E2E - Type 2 Route Persistence", Ordered, func
 				testNamespace,
 				k8s.WithNad(testNad.Name, testNamespace, []string{silentPodIP}),
 				k8s.OnNode(nodes[0].Name),
+				k8s.WithCapabilities("NET_RAW"),
 			)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/e2etests/tests/evpn_routes.go
+++ b/e2etests/tests/evpn_routes.go
@@ -480,16 +480,13 @@ func evpnRoutesOverUnderlay(params evpnUnderlayParams) {
 
 				By(fmt.Sprintf("trying to hit pod %s on the %s network from host %s", podIP, vni.Name, hostName))
 
-				urlStr = url.Format("http://%s:8090/clientip", podIP)
+				urlStr = url.Format("http://%s:8090/hostname", podIP)
 				res, err = externalHostExecutor.Exec("curl", "-sS", urlStr)
 				if err != nil {
 					return fmt.Errorf("curl from %s to %s:8090 failed: %s", hostName, podIP, res)
 				}
-				hostClientIP, err := extractClientIP(res)
-				Expect(err).NotTo(HaveOccurred())
-
-				if hostClientIP != externalHostIP {
-					return fmt.Errorf("curl from %s to %s:8090 returned %s, expected %s", hostName, podIP, clientIP, externalHostIP)
+				if res != testPod.Name {
+					return fmt.Errorf("curl from %s to %s:8090 returned hostname %s, expected %s", hostName, podIP, res, testPod.Name)
 				}
 				return nil
 			}, 5*time.Minute, 5*time.Second).ShouldNot(HaveOccurred())
@@ -695,16 +692,13 @@ var _ = Describe("Routes between bgp and the fabric with iBGP testing e2e integr
 
 			By(fmt.Sprintf("trying to hit pod %s on the %s network from host %s", podIP, vni.Name, hostName))
 
-			urlStr = url.Format("http://%s:8090/clientip", podIP)
+			urlStr = url.Format("http://%s:8090/hostname", podIP)
 			res, err = externalHostExecutor.Exec("curl", "-sS", urlStr)
 			if err != nil {
 				return fmt.Errorf("curl from %s to %s:8090 failed: %s", hostName, podIP, res)
 			}
-			hostClientIP, err := extractClientIP(res)
-			Expect(err).NotTo(HaveOccurred())
-
-			if hostClientIP != externalHostIP {
-				return fmt.Errorf("curl from %s to %s:8090 returned %s, expected %s", hostName, podIP, clientIP, externalHostIP)
+			if res != testPod.Name {
+				return fmt.Errorf("curl from %s to %s:8090 returned hostname %s, expected %s", hostName, podIP, res, testPod.Name)
 			}
 			return nil
 		}, 5*time.Minute, 5*time.Second).ShouldNot(HaveOccurred())

--- a/e2etests/tests/l3vpn_routes.go
+++ b/e2etests/tests/l3vpn_routes.go
@@ -409,18 +409,13 @@ var _ = Describe("SRV6 routes between bgp and the fabric", Ordered, func() {
 
 				By(fmt.Sprintf("from %s: trying to hit pod %s (%s) on the %s network from host %s",
 					hostName, testPod.Name, podIP, l3vpn.Name, hostName))
-				urlStr = url.Format("http://%s:8090/clientip", podIP)
+				urlStr = url.Format("http://%s:8090/hostname", podIP)
 				res, err = externalHostExecutor.Exec("curl", "-sS", urlStr)
 				if err != nil {
 					return fmt.Errorf("curl from %s to %s:8090 failed: %s", hostName, podIP, res)
 				}
-				hostClientIP, err := extractClientIP(res)
-				Expect(err).NotTo(HaveOccurred())
-
-				By(fmt.Sprintf("from %s: checking that detected clientIP %s and externalHostIP %s are equal",
-					hostName, clientIP, externalHostIP))
-				if hostClientIP != externalHostIP {
-					return fmt.Errorf("curl from %s to %s:8090 returned %s, expected %s", hostName, podIP, clientIP, externalHostIP)
+				if res != testPod.Name {
+					return fmt.Errorf("curl from %s to %s:8090 returned hostname %s, expected %s", hostName, podIP, res, testPod.Name)
 				}
 				return nil
 			}, 5*time.Minute, 5*time.Second).ShouldNot(HaveOccurred())
@@ -595,18 +590,13 @@ var _ = Describe("SRV6 routes between bgp and the fabric with iBGP testing e2e i
 
 			By(fmt.Sprintf("from %s: trying to hit pod %s (%s) on the %s network from host %s",
 				hostName, testPod.Name, podIP, l3vpnRed.Name, hostName))
-			urlStr = url.Format("http://%s:8090/clientip", podIP)
+			urlStr = url.Format("http://%s:8090/hostname", podIP)
 			res, err = externalHostExecutor.Exec("curl", "-sS", urlStr)
 			if err != nil {
 				return fmt.Errorf("curl from %s to %s:8090 failed: %s", hostName, podIP, res)
 			}
-			hostClientIP, err := extractClientIP(res)
-			Expect(err).NotTo(HaveOccurred())
-
-			By(fmt.Sprintf("from %s: checking that detected clientIP %s and externalHostIP %s are equal",
-				hostName, clientIP, externalHostIP))
-			if hostClientIP != externalHostIP {
-				return fmt.Errorf("curl from %s to %s:8090 returned %s, expected %s", hostName, podIP, clientIP, externalHostIP)
+			if res != testPod.Name {
+				return fmt.Errorf("curl from %s to %s:8090 returned hostname %s, expected %s", hostName, podIP, res, testPod.Name)
 			}
 			return nil
 		}, 5*time.Minute, 5*time.Second).ShouldNot(HaveOccurred())

--- a/e2etests/tests/passthrough_routes.go
+++ b/e2etests/tests/passthrough_routes.go
@@ -270,16 +270,13 @@ var _ = Describe("Routes between bgp and the fabric with Underlay in ipv4", Labe
 
 				By(fmt.Sprintf("trying to hit pod %s on the passthrough network from host %s", podIP, hostName))
 
-				urlStr = url.Format("http://%s:8090/clientip", podIP)
+				urlStr = url.Format("http://%s:8090/hostname", podIP)
 				res, err = externalHostExecutor.Exec("curl", "-sS", urlStr)
 				if err != nil {
 					return fmt.Errorf("curl from %s to %s:8090 failed: %s", hostName, podIP, res)
 				}
-				hostClientIP, err := extractClientIP(res)
-				Expect(err).NotTo(HaveOccurred())
-
-				if hostClientIP != externalHostIP {
-					return fmt.Errorf("curl from %s to %s:8090 returned %s, expected %s", hostName, podIP, clientIP, externalHostIP)
+				if res != testPod.Name {
+					return fmt.Errorf("curl from %s to %s:8090 returned hostname %s, expected %s", hostName, podIP, res, testPod.Name)
 				}
 				return nil
 			}, 5*time.Minute, 5*time.Second).ShouldNot(HaveOccurred())


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

Test portability improvements:

- create the test namespace with permissions to perform network activities
- don't validate host ip for ingress traffic, as there is no guarantee it's preserved on all the platforms

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - End-to-end Kubernetes test namespaces now apply Pod Security Admission labels consistently.
  - Added support for configuring Linux capabilities on test pods, including `NET_RAW` where required.
  - Network connectivity checks now verify the pod hostname directly, improving validation across EVPN, L3VPN, and passthrough routing scenarios.
  - Updated expected responses and error reporting for host-to-pod reachability tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->