### PR TITLE
fix(is-is): set HostName for systemd routerpod quadlet

### DIFF
--- a/systemdmode/quadlets/routerpod.pod
+++ b/systemdmode/quadlets/routerpod.pod
@@ -13,6 +13,7 @@ After=network-online.target
 [Pod]
 # Pod name - will create Podman pod named "systemd-routerpod"
 PodName=routerpod
+HostName=%H
 
 Network=ns:/var/run/netns/perouter
 


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

We derive the FRR hostname setting from the namespace's
hostname, meaning that in k8s pods, we already correctly use the node's
hostname. However, in systemd based deployments, the routerpod's
hostname is currently set to "routerpod". This creates issues when
displaying the IS-IS database, as IS-IS name resolution will show all
OpenPERouter FRR instances with the same name, leading to confusing
output. For the routerpod.pod, set HostName to the %H (FQDN) systemd
specifier, to match what we already see in k8s deployments.

**Special notes for your reviewer**:

For further details, see https://github.com/openperouter/openperouter/issues/741

**Release note**:

```release-note
Use the node's hostname in routerpod and FRR configuration instead of 'routerpod'.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The router pod now uses the host system’s name as its hostname.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->