### PR TITLE
fix(hostconversion): calculate correct tunnel overhead for IPv6 VXLAN

### DIFF
--- a/internal/conversion/host_conversion.go
+++ b/internal/conversion/host_conversion.go
@@ -26,6 +26,11 @@ type tunnelOverheads struct {
 	forL2VNIs map[string]int
 }
 
+type tunnelVtepIPs struct {
+	forL3VNIs map[string]string
+	forL2VNIs map[string]string
+}
+
 func APItoHostConfig(nodeIndex int, targetNS string, apiConfig APIConfigData) (HostConfigData, error) {
 	err := validateAPIConfigData(apiConfig)
 	e := NoUnderlaysError("")
@@ -82,11 +87,19 @@ func APItoHostConfig(nodeIndex int, targetNS string, apiConfig APIConfigData) (H
 		return HostConfigData{}, err
 	}
 
-	tunnelOverheads := overheadForTunnels(apiConfig)
+	vtepIPs, err := resolveVTEPIPs(apiConfig, underlayConfigTunnelEndpoint)
+	if err != nil {
+		return HostConfigData{}, fmt.Errorf("failed to determine VNI tunnel endpoint addresses, err: %w", err)
+	}
+
+	tunnelOverheads, err := overheadForTunnels(apiConfig, vtepIPs)
+	if err != nil {
+		return HostConfigData{}, fmt.Errorf("failed to determine tunnel overheads, err: %w", err)
+	}
 
 	l3VNIs, err := l3vnisToHost(
 		apiConfig.L3VNIs,
-		underlayConfigTunnelEndpoint,
+		vtepIPs,
 		targetNS,
 		nodeIndex,
 		tunnelOverheads.forL3VNIs)
@@ -97,7 +110,7 @@ func APItoHostConfig(nodeIndex int, targetNS string, apiConfig APIConfigData) (H
 	vrfMap := createVRFMap(apiConfig.L3VNIs, apiConfig.L3VPNs)
 	l2VNIs, err := l2vnisToHost(
 		apiConfig.L2VNIs,
-		underlayConfigTunnelEndpoint,
+		vtepIPs,
 		targetNS,
 		vrfMap,
 		tunnelOverheads.forL2VNIs)
@@ -228,14 +241,14 @@ func tunnelEndpointToHost(tunnelEndpointConfig *v1alpha1.TunnelEndpointConfig, n
 
 func l3vnisToHost(
 	l3vnis []v1alpha1.L3VNI,
-	tunnelEndpoint hostnetwork.UnderlayTunnelEndpointParams,
+	vtepIPs tunnelVtepIPs,
 	targetNS string,
 	nodeIndex int,
 	tunnelOverheads map[string]int,
 ) ([]hostnetwork.L3VNIParams, error) {
 	hostL3VNIs := []hostnetwork.L3VNIParams{}
 	for _, l3vni := range l3vnis {
-		hostL3VNI, err := l3vniToHost(l3vni, tunnelEndpoint, targetNS, nodeIndex, tunnelOverheads)
+		hostL3VNI, err := l3vniToHost(l3vni, vtepIPs, targetNS, nodeIndex, tunnelOverheads)
 		if err != nil {
 			return nil, fmt.Errorf("failed to translate L3VNI %s, err: %w", l3vni.Name, err)
 		}
@@ -246,14 +259,15 @@ func l3vnisToHost(
 
 func l3vniToHost(
 	l3vni v1alpha1.L3VNI,
-	tunnelEndpoint hostnetwork.UnderlayTunnelEndpointParams,
+	vtepIPs tunnelVtepIPs,
 	targetNS string,
 	nodeIndex int,
 	tunnelOverheads map[string]int,
 ) (hostnetwork.L3VNIParams, error) {
-	vtepIP, err := resolveVTEPIP(l3vni.Spec.UnderlayAddressFamily, tunnelEndpoint)
-	if err != nil {
-		return hostnetwork.L3VNIParams{}, fmt.Errorf("L3VNI %s: %w", l3vni.Name, err)
+	vtepIP, found := vtepIPs.forL3VNIs[l3vni.Name]
+	if !found {
+		return hostnetwork.L3VNIParams{}, fmt.Errorf("L3VNI %s: not found in map of tunnel VTEP IPs: %+v",
+			l3vni.Name, vtepIPs)
 	}
 	tunnelOverhead, found := tunnelOverheads[l3vni.Name]
 	if !found {
@@ -296,14 +310,14 @@ func l3vniToHost(
 
 func l2vnisToHost(
 	l2vnis []v1alpha1.L2VNI,
-	tunnelEndpoint hostnetwork.UnderlayTunnelEndpointParams,
+	vtepIPs tunnelVtepIPs,
 	targetNS string,
 	vrfMap map[string]string,
 	tunnelOverheads map[string]int,
 ) ([]hostnetwork.L2VNIParams, error) {
 	hostL2VNIs := []hostnetwork.L2VNIParams{}
 	for _, l2vni := range l2vnis {
-		vni, err := l2vniToHost(l2vni, tunnelEndpoint, targetNS, vrfMap, tunnelOverheads)
+		vni, err := l2vniToHost(l2vni, vtepIPs, targetNS, vrfMap, tunnelOverheads)
 		if err != nil {
 			return nil, fmt.Errorf("failed to translate L2VNI %s, err: %w", l2vni.Name, err)
 		}
@@ -314,14 +328,15 @@ func l2vnisToHost(
 
 func l2vniToHost(
 	l2vni v1alpha1.L2VNI,
-	tunnelEndpoint hostnetwork.UnderlayTunnelEndpointParams,
+	vtepIPs tunnelVtepIPs,
 	targetNS string,
 	vrfMap map[string]string,
 	tunnelOverheads map[string]int,
 ) (hostnetwork.L2VNIParams, error) {
-	vtepIP, err := resolveVTEPIP(l2vni.Spec.UnderlayAddressFamily, tunnelEndpoint)
-	if err != nil {
-		return hostnetwork.L2VNIParams{}, fmt.Errorf("L2VNI %s: %w", l2vni.Name, err)
+	vtepIP, found := vtepIPs.forL2VNIs[l2vni.Name]
+	if !found {
+		return hostnetwork.L2VNIParams{}, fmt.Errorf("L2VNI %s: not found in map of tunnel VTEP IPs: %+v",
+			l2vni.Name, vtepIPs)
 	}
 	tunnelOverhead, found := tunnelOverheads[l2vni.Name]
 	if !found {
@@ -421,42 +436,146 @@ func l3vpnToHost(
 	return hostL3VPN, nil
 }
 
-// overheadForTunnels returns a map[resource name] -> calculated tunnel overhead for each L3 type.
-func overheadForTunnels(apiConfig APIConfigData) tunnelOverheads {
-	srv6Overhead := hostnetwork.SRv6Overhead
-	if hasEncapsRed(apiConfig) {
-		srv6Overhead = hostnetwork.SRv6OverheadEncapReduced
+// resolveVTEPIPs returns a map[resource name] -> calculated VTEP IP (can be IPv4 or IPv6) for each VNI type.
+func resolveVTEPIPs(
+	apiConfig APIConfigData,
+	tunnelEndpoint hostnetwork.UnderlayTunnelEndpointParams,
+) (tunnelVtepIPs, error) {
+	forL3VNIs := make(map[string]string, len(apiConfig.L3VNIs))
+	forL2VNIs := make(map[string]string, len(apiConfig.L2VNIs))
+	errs := []error{}
+	for _, l3vni := range apiConfig.L3VNIs {
+		vtepIP, err := resolveVTEPIP(l3vni.Spec.UnderlayAddressFamily, tunnelEndpoint)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("L3VNI %q, err: %w", l3vni.Name, err))
+			continue
+		}
+		forL3VNIs[l3vni.Name] = vtepIP
 	}
+	for _, l2vni := range apiConfig.L2VNIs {
+		vtepIP, err := resolveVTEPIP(l2vni.Spec.UnderlayAddressFamily, tunnelEndpoint)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("L2VNI %q, err: %w", l2vni.Name, err))
+			continue
+		}
+		forL2VNIs[l2vni.Name] = vtepIP
+	}
+	return tunnelVtepIPs{
+		forL3VNIs: forL3VNIs,
+		forL2VNIs: forL2VNIs,
+	}, errors.Join(errs...)
+}
 
+// overheadForTunnels returns a map[resource name] -> calculated tunnel overhead for each L3/L2 type.
+func overheadForTunnels(apiConfig APIConfigData, vtepIPs tunnelVtepIPs) (tunnelOverheads, error) {
 	forL3VNIs := make(map[string]int, len(apiConfig.L3VNIs))
 	forL3VPNs := make(map[string]int, len(apiConfig.L3VPNs))
 	forL2VNIs := make(map[string]int, len(apiConfig.L2VNIs))
+
+	// Seed L3VNIs with their own overhead.
 	for _, l3vni := range apiConfig.L3VNIs {
-		forL3VNIs[l3vni.Name] = hostnetwork.VXLanOverhead
+		vxlanOverhead, err := overheadForVXLANTunnel(l3vni.Name, vtepIPs.forL3VNIs)
+		if err != nil {
+			return tunnelOverheads{}, fmt.Errorf("L3VNI %s: %w", l3vni.Name, err)
+		}
+		forL3VNIs[l3vni.Name] = vxlanOverhead
+	}
+
+	// Seed L3VPNs with their own overhead.
+	srv6Overhead := hostnetwork.SRv6Overhead
+	if hasEncapsRed(apiConfig) {
+		srv6Overhead = hostnetwork.SRv6OverheadEncapReduced
 	}
 	for _, l3vpn := range apiConfig.L3VPNs {
 		forL3VPNs[l3vpn.Name] = srv6Overhead
 	}
 
+	// For all routing domains with l2vnis, we must calculate the routing domain's overhead from the max of the L3 +
+	// all L2VNIs in the routing domain.
 	for _, l2vni := range apiConfig.L2VNIs {
-		forL2VNIs[l2vni.Name] = hostnetwork.VXLanOverhead
-		if l2vni.Spec.RoutingDomain == nil || l2vni.Spec.RoutingDomain.Type == v1alpha1.RoutingDomainTypeL3VNI {
+		if l2vni.Spec.RoutingDomain == nil {
 			continue
 		}
+
+		l2VXLANOverhead, err := overheadForVXLANTunnel(l2vni.Name, vtepIPs.forL2VNIs)
+		if err != nil {
+			return tunnelOverheads{}, fmt.Errorf("L2VNI %s: %w", l2vni.Name, err)
+		}
+
+		if l2vni.Spec.RoutingDomain.Type == v1alpha1.RoutingDomainTypeL3VNI {
+			l3vniName := l2vni.Spec.RoutingDomain.L3VNI.Name
+			l3vniOverhead, found := forL3VNIs[l3vniName]
+			if !found {
+				return tunnelOverheads{}, fmt.Errorf("L2VNI %s: could not find corresponding L3VNI %q in tunnel overheads %+v",
+					l2vni.Name, l3vniName, forL3VNIs)
+			}
+			forL3VNIs[l3vniName] = max(l2VXLANOverhead, l3vniOverhead)
+			continue
+		}
+
 		l3vpnName := l2vni.Spec.RoutingDomain.L3VPN.Name
 		l3vpnOverhead, found := forL3VPNs[l3vpnName]
 		if !found {
+			return tunnelOverheads{}, fmt.Errorf("L2VNI %s: could not find corresponding L3VPN %q in tunnel overheads %+v",
+				l2vni.Name, l3vpnName, forL3VPNs)
+		}
+		forL3VPNs[l3vpnName] = max(l2VXLANOverhead, l3vpnOverhead)
+	}
+
+	// We now know the correct overheads for the L3VNI and L3VPN routing domains. Iterate over all l2vnis. For the l2vnis
+	// with routing domains, set the overhead to that of the entire domain. Otherwise, the L2's overhead is the overhead
+	// of its VXLAN tunnel.
+	for _, l2vni := range apiConfig.L2VNIs {
+		if l2vni.Spec.RoutingDomain == nil {
+			vxlanOverhead, err := overheadForVXLANTunnel(l2vni.Name, vtepIPs.forL2VNIs)
+			if err != nil {
+				return tunnelOverheads{}, fmt.Errorf("L2VNI %s: %w", l2vni.Name, err)
+			}
+			forL2VNIs[l2vni.Name] = vxlanOverhead
 			continue
 		}
-		newOverhead := max(hostnetwork.VXLanOverhead, l3vpnOverhead)
-		forL3VPNs[l3vpnName] = newOverhead
-		forL2VNIs[l2vni.Name] = newOverhead
+
+		if l2vni.Spec.RoutingDomain.Type == v1alpha1.RoutingDomainTypeL3VNI {
+			l3vniName := l2vni.Spec.RoutingDomain.L3VNI.Name
+			l3vniOverhead, found := forL3VNIs[l3vniName]
+			if !found {
+				return tunnelOverheads{}, fmt.Errorf("L2VNI %s: could not find corresponding L3VNI %s in tunnel overheads %+v",
+					l2vni.Name, l3vniName, forL3VNIs)
+			}
+			forL2VNIs[l2vni.Name] = l3vniOverhead
+			continue
+		}
+
+		l3vpnName := l2vni.Spec.RoutingDomain.L3VPN.Name
+		l3vpnOverhead, found := forL3VPNs[l3vpnName]
+		if !found {
+			return tunnelOverheads{}, fmt.Errorf("L2VNI %s: could not find corresponding L3VPN %s in tunnel overheads %+v",
+				l2vni.Name, l3vpnName, forL3VPNs)
+		}
+		forL2VNIs[l2vni.Name] = l3vpnOverhead
 	}
 
 	return tunnelOverheads{
 		forL3VNIs: forL3VNIs,
 		forL3VPNs: forL3VPNs,
 		forL2VNIs: forL2VNIs,
+	}, nil
+}
+
+// overheadForVXLANTunnel takes a mapping of VNI -> VTEP IP (which is either the IPv4 or IPv6 tunnel endpoint).
+// It returns the corresponding VXLAN overhead (50 bytes for IPv4, 70 bytes for IPv6 underlay).
+func overheadForVXLANTunnel(vniName string, forVNIs map[string]string) (int, error) {
+	vtepIP, found := forVNIs[vniName]
+	if !found {
+		return 0, fmt.Errorf("not found in map of tunnel VTEP IPs: %+v", forVNIs)
+	}
+	switch ipfamily.ForCIDRString(vtepIP) {
+	case ipfamily.IPv4:
+		return hostnetwork.VXLanOverhead, nil
+	case ipfamily.IPv6:
+		return hostnetwork.IPv6VXLanOverhead, nil
+	default:
+		return 0, fmt.Errorf("could not determine AF of tunnel VTEP IP: %q", vtepIP)
 	}
 }
 

--- a/internal/conversion/host_conversion_test.go
+++ b/internal/conversion/host_conversion_test.go
@@ -737,6 +737,19 @@ func TestAPItoHostConfig(t *testing.T) {
 						VXLanPort: new(int32(4789)),
 					},
 				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "vni2",
+					},
+					Spec: v1alpha1.L3VNISpec{
+						VRF: "yellow",
+						HostSession: &v1alpha1.HostSession{
+							LocalCIDRs: []string{"10.1.0.0/24"},
+						},
+						VNI:       101,
+						VXLanPort: new(int32(4789)),
+					},
+				},
 			},
 			l3vpns: []v1alpha1.L3VPN{
 				{
@@ -748,9 +761,9 @@ func TestAPItoHostConfig(t *testing.T) {
 						HostSession: &v1alpha1.HostSession{
 							LocalCIDRs: []string{"10.1.0.0/24"},
 						},
-						ImportRTs:        []v1alpha1.RouteTarget{"65000:100"},
-						ExportRTs:        []v1alpha1.RouteTarget{"65001:100"},
-						RDAssignedNumber: 101,
+						ImportRTs:        []v1alpha1.RouteTarget{"65000:150"},
+						ExportRTs:        []v1alpha1.RouteTarget{"65001:150"},
+						RDAssignedNumber: 150,
 					},
 				},
 				{
@@ -762,9 +775,23 @@ func TestAPItoHostConfig(t *testing.T) {
 						HostSession: &v1alpha1.HostSession{
 							LocalCIDRs: []string{"10.1.0.0/24"},
 						},
-						ImportRTs:        []v1alpha1.RouteTarget{"65000:100"},
-						ExportRTs:        []v1alpha1.RouteTarget{"65001:100"},
-						RDAssignedNumber: 102,
+						ImportRTs:        []v1alpha1.RouteTarget{"65000:151"},
+						ExportRTs:        []v1alpha1.RouteTarget{"65001:151"},
+						RDAssignedNumber: 151,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "vpn3",
+					},
+					Spec: v1alpha1.L3VPNSpec{
+						VRF: "purple",
+						HostSession: &v1alpha1.HostSession{
+							LocalCIDRs: []string{"10.1.0.0/24"},
+						},
+						ImportRTs:        []v1alpha1.RouteTarget{"65000:152"},
+						ExportRTs:        []v1alpha1.RouteTarget{"65001:152"},
+						RDAssignedNumber: 152,
 					},
 				},
 			},
@@ -774,9 +801,32 @@ func TestAPItoHostConfig(t *testing.T) {
 						Name: "l2-for-vni1",
 					},
 					Spec: v1alpha1.L2VNISpec{
-						VNI:           200,
-						VXLanPort:     new(int32(4789)),
-						RoutingDomain: l3vniRoutingDomain("vni1"),
+						VNI:                   200,
+						VXLanPort:             new(int32(4789)),
+						RoutingDomain:         l3vniRoutingDomain("vni1"),
+						UnderlayAddressFamily: new("IPv4"),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "l2-for-vni2-a",
+					},
+					Spec: v1alpha1.L2VNISpec{
+						VNI:                   201,
+						VXLanPort:             new(int32(4789)),
+						RoutingDomain:         l3vniRoutingDomain("vni2"),
+						UnderlayAddressFamily: new("IPv4"),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "l2-for-vni2-b",
+					},
+					Spec: v1alpha1.L2VNISpec{
+						VNI:                   202,
+						VXLanPort:             new(int32(4789)),
+						RoutingDomain:         l3vniRoutingDomain("vni2"),
+						UnderlayAddressFamily: new("IPv6"),
 					},
 				},
 				{
@@ -784,9 +834,52 @@ func TestAPItoHostConfig(t *testing.T) {
 						Name: "l2-for-vpn1",
 					},
 					Spec: v1alpha1.L2VNISpec{
-						VNI:           201,
-						VXLanPort:     new(int32(4789)),
-						RoutingDomain: l3vpnRoutingDomain("vpn1"),
+						VNI:                   250,
+						VXLanPort:             new(int32(4789)),
+						RoutingDomain:         l3vpnRoutingDomain("vpn1"),
+						UnderlayAddressFamily: new("IPv4"),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "l2-for-vpn2-a",
+					},
+					Spec: v1alpha1.L2VNISpec{
+						VNI:                   251,
+						VXLanPort:             new(int32(4789)),
+						RoutingDomain:         l3vpnRoutingDomain("vpn2"),
+						UnderlayAddressFamily: new("IPv4"),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "l2-for-vpn2-b",
+					},
+					Spec: v1alpha1.L2VNISpec{
+						VNI:                   252,
+						VXLanPort:             new(int32(4789)),
+						RoutingDomain:         l3vpnRoutingDomain("vpn2"),
+						UnderlayAddressFamily: new("IPv6"),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "l2-ipv4",
+					},
+					Spec: v1alpha1.L2VNISpec{
+						VNI:                   253,
+						VXLanPort:             new(int32(4789)),
+						UnderlayAddressFamily: new("IPv4"),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "l2-ipv6",
+					},
+					Spec: v1alpha1.L2VNISpec{
+						VNI:                   254,
+						VXLanPort:             new(int32(4789)),
+						UnderlayAddressFamily: new("IPv6"),
 					},
 				},
 			},
@@ -815,12 +908,28 @@ func TestAPItoHostConfig(t *testing.T) {
 						NSIPv4:   "10.1.0.1/24",
 					},
 				},
+				{
+					Name: "vni2",
+					VNIParams: hostnetwork.VNIParams{
+						VRF:       "yellow",
+						TargetNS:  "namespace",
+						VTEPIP:    "10.0.0.0/32",
+						VNI:       101,
+						VXLanPort: new(int32(4789)),
+						// Mixed IPv4 VXLAN and IPv6 VXLAN, so the IPv6VXLAN overhead wins.
+						TunnelOverhead: hostnetwork.IPv6VXLanOverhead,
+					},
+					LinkIPs: &hostnetwork.LinkIPs{
+						HostIPv4: "10.1.0.2/24",
+						NSIPv4:   "10.1.0.1/24",
+					},
+				},
 			},
 			wantL3VPNParams: []hostnetwork.L3VPNParams{
 				{
 					Name:             "vpn1",
 					VRF:              "blue",
-					RDAssignedNumber: 101,
+					RDAssignedNumber: 150,
 					TargetNS:         "namespace",
 					// VXLan overhead (50) > SRv6 encaps reduced (40), so the L2VNI in this VRF bumps both to VXLan.
 					TunnelOverhead: hostnetwork.VXLanOverhead,
@@ -832,7 +941,19 @@ func TestAPItoHostConfig(t *testing.T) {
 				{
 					Name:             "vpn2",
 					VRF:              "green",
-					RDAssignedNumber: 102,
+					RDAssignedNumber: 151,
+					TargetNS:         "namespace",
+					// IPv6 VXLan overhead (70) > SRv6 encaps reduced (40), so the L2VNI in this VRF bumps both to IPv6 VXLan.
+					TunnelOverhead: hostnetwork.IPv6VXLanOverhead,
+					LinkIPs: &hostnetwork.LinkIPs{
+						HostIPv4: "10.1.0.2/24",
+						NSIPv4:   "10.1.0.1/24",
+					},
+				},
+				{
+					Name:             "vpn3",
+					VRF:              "purple",
+					RDAssignedNumber: 152,
 					TargetNS:         "namespace",
 					// No L2VNI in this VRF, so the native SRv6 encaps reduced overhead applies.
 					TunnelOverhead: hostnetwork.SRv6OverheadEncapReduced,
@@ -857,14 +978,95 @@ func TestAPItoHostConfig(t *testing.T) {
 					HostMaster:   nil,
 				},
 				{
+					Name: "l2-for-vni2-a",
+					VNIParams: hostnetwork.VNIParams{
+						VRF:       "yellow",
+						TargetNS:  "namespace",
+						VTEPIP:    "10.0.0.0/32",
+						VNI:       201,
+						VXLanPort: new(int32(4789)),
+						// In a mixed environment with IPv4 and IPv6 VXLAN tunnels, we must pick IPv6 VXLAN.
+						TunnelOverhead: hostnetwork.IPv6VXLanOverhead,
+					},
+					L2GatewayIPs: nil,
+					HostMaster:   nil,
+				},
+				{
+					Name: "l2-for-vni2-b",
+					VNIParams: hostnetwork.VNIParams{
+						VRF:       "yellow",
+						TargetNS:  "namespace",
+						VTEPIP:    "2001:db8::/128",
+						VNI:       202,
+						VXLanPort: new(int32(4789)),
+						// In a mixed environment with IPv4 and IPv6 VXLAN tunnels, we must pick IPv6 VXLAN.
+						TunnelOverhead: hostnetwork.IPv6VXLanOverhead,
+					},
+					L2GatewayIPs: nil,
+					HostMaster:   nil,
+				},
+				{
 					Name: "l2-for-vpn1",
 					VNIParams: hostnetwork.VNIParams{
-						VRF:            "blue",
+						VRF:       "blue",
+						TargetNS:  "namespace",
+						VTEPIP:    "10.0.0.0/32",
+						VNI:       250,
+						VXLanPort: new(int32(4789)),
+						// IPv4 VXLAN overhead is larger than SRv6 encaps reduced.
+						TunnelOverhead: hostnetwork.VXLanOverhead,
+					},
+					L2GatewayIPs: nil,
+					HostMaster:   nil,
+				},
+				{
+					Name: "l2-for-vpn2-a",
+					VNIParams: hostnetwork.VNIParams{
+						VRF:       "green",
+						TargetNS:  "namespace",
+						VTEPIP:    "10.0.0.0/32",
+						VNI:       251,
+						VXLanPort: new(int32(4789)),
+						// In a mixed environment with SRv6, IPv4 and IPv6 VXLAN tunnels, we must pick IPv6 VXLAN.
+						TunnelOverhead: hostnetwork.IPv6VXLanOverhead,
+					},
+					L2GatewayIPs: nil,
+					HostMaster:   nil,
+				},
+				{
+					Name: "l2-for-vpn2-b",
+					VNIParams: hostnetwork.VNIParams{
+						VRF:       "green",
+						TargetNS:  "namespace",
+						VTEPIP:    "2001:db8::/128",
+						VNI:       252,
+						VXLanPort: new(int32(4789)),
+						// In a mixed environment with SRv6, IPv4 and IPv6 VXLAN tunnels, we must pick IPv6 VXLAN.
+						TunnelOverhead: hostnetwork.IPv6VXLanOverhead,
+					},
+					L2GatewayIPs: nil,
+					HostMaster:   nil,
+				},
+				{
+					Name: "l2-ipv4",
+					VNIParams: hostnetwork.VNIParams{
 						TargetNS:       "namespace",
 						VTEPIP:         "10.0.0.0/32",
-						VNI:            201,
+						VNI:            253,
 						VXLanPort:      new(int32(4789)),
 						TunnelOverhead: hostnetwork.VXLanOverhead,
+					},
+					L2GatewayIPs: nil,
+					HostMaster:   nil,
+				},
+				{
+					Name: "l2-ipv6",
+					VNIParams: hostnetwork.VNIParams{
+						TargetNS:       "namespace",
+						VTEPIP:         "2001:db8::/128",
+						VNI:            254,
+						VXLanPort:      new(int32(4789)),
+						TunnelOverhead: hostnetwork.IPv6VXLanOverhead,
 					},
 					L2GatewayIPs: nil,
 					HostMaster:   nil,
@@ -1103,7 +1305,7 @@ func TestAPItoHostConfigAddressFamily(t *testing.T) {
 					UnderlayAddressFamily: new("IPv6"),
 				},
 			},
-			wantErr: "L3VNI vni-mismatch",
+			wantErr: "L3VNI \"vni-mismatch\", err: IPv6 address family requested but no IPv6 VTEP IP available",
 		},
 	}
 
@@ -1171,27 +1373,6 @@ func checkAddressFamilyResult(t *testing.T, got HostConfigData, err error, wantE
 			t.Errorf("L2VNI VTEPIP = %q, want %q", got.L2VNIs[0].VTEPIP, wantVTEPIP)
 		}
 	}
-}
-
-func mustMarshal(v any) string {
-	b, err := json.Marshal(v)
-	if err != nil {
-		panic(err)
-	}
-	return string(b)
-}
-
-// netdevInterfaces builds hostnetwork.UnderlayInterface entries of the
-// netdev kind for the given names.
-func netdevInterfaces(names ...string) []hostnetwork.UnderlayInterface {
-	res := make([]hostnetwork.UnderlayInterface, 0, len(names))
-	for _, name := range names {
-		res = append(res, hostnetwork.UnderlayInterface{
-			InterfaceName: name,
-			Kind:          hostnetwork.UnderlayInterfaceNetDev,
-		})
-	}
-	return res
 }
 
 func TestAPItoHostConfigCNIInterfaces(t *testing.T) {
@@ -1310,4 +1491,359 @@ func TestAPItoHostConfigCNIInterfaces(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOverheadForTunnels(t *testing.T) {
+	ipv4VTEP := "10.0.0.1/32"
+	ipv6VTEP := "2001:db8::1/128"
+
+	tests := []struct {
+		name      string
+		apiConfig APIConfigData
+		vtepIPs   tunnelVtepIPs
+		want      tunnelOverheads
+		wantErr   string
+	}{
+		{
+			name: "L3VNI only, IPv4",
+			apiConfig: APIConfigData{
+				L3VNIs: []v1alpha1.L3VNI{
+					{ObjectMeta: metav1.ObjectMeta{Name: "vni1"}},
+				},
+			},
+			vtepIPs: tunnelVtepIPs{
+				forL3VNIs: map[string]string{"vni1": ipv4VTEP},
+				forL2VNIs: map[string]string{},
+			},
+			want: tunnelOverheads{
+				forL3VNIs: map[string]int{"vni1": hostnetwork.VXLanOverhead},
+				forL3VPNs: map[string]int{},
+				forL2VNIs: map[string]int{},
+			},
+		},
+		{
+			name: "L3VNI only, IPv6",
+			apiConfig: APIConfigData{
+				L3VNIs: []v1alpha1.L3VNI{
+					{ObjectMeta: metav1.ObjectMeta{Name: "vni1"}},
+				},
+			},
+			vtepIPs: tunnelVtepIPs{
+				forL3VNIs: map[string]string{"vni1": ipv6VTEP},
+				forL2VNIs: map[string]string{},
+			},
+			want: tunnelOverheads{
+				forL3VNIs: map[string]int{"vni1": hostnetwork.IPv6VXLanOverhead},
+				forL3VPNs: map[string]int{},
+				forL2VNIs: map[string]int{},
+			},
+		},
+		{
+			name: "L3VNI routing domain, all IPv4",
+			apiConfig: APIConfigData{
+				L3VNIs: []v1alpha1.L3VNI{
+					{ObjectMeta: metav1.ObjectMeta{Name: "vni1"}},
+				},
+				L2VNIs: []v1alpha1.L2VNI{
+					{ObjectMeta: metav1.ObjectMeta{Name: "l2a"}, Spec: v1alpha1.L2VNISpec{RoutingDomain: l3vniRoutingDomain("vni1")}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "l2b"}, Spec: v1alpha1.L2VNISpec{RoutingDomain: l3vniRoutingDomain("vni1")}},
+				},
+			},
+			vtepIPs: tunnelVtepIPs{
+				forL3VNIs: map[string]string{"vni1": ipv4VTEP},
+				forL2VNIs: map[string]string{"l2a": ipv4VTEP, "l2b": ipv4VTEP},
+			},
+			want: tunnelOverheads{
+				forL3VNIs: map[string]int{"vni1": hostnetwork.VXLanOverhead},
+				forL3VPNs: map[string]int{},
+				forL2VNIs: map[string]int{"l2a": hostnetwork.VXLanOverhead, "l2b": hostnetwork.VXLanOverhead},
+			},
+		},
+		{
+			name: "L3VNI routing domain, mixed IPv4 and IPv6 L2VNIs",
+			apiConfig: APIConfigData{
+				L3VNIs: []v1alpha1.L3VNI{
+					{ObjectMeta: metav1.ObjectMeta{Name: "vni1"}},
+				},
+				L2VNIs: []v1alpha1.L2VNI{
+					{ObjectMeta: metav1.ObjectMeta{Name: "l2a"}, Spec: v1alpha1.L2VNISpec{RoutingDomain: l3vniRoutingDomain("vni1")}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "l2b"}, Spec: v1alpha1.L2VNISpec{RoutingDomain: l3vniRoutingDomain("vni1")}},
+				},
+			},
+			vtepIPs: tunnelVtepIPs{
+				forL3VNIs: map[string]string{"vni1": ipv4VTEP},
+				forL2VNIs: map[string]string{"l2a": ipv4VTEP, "l2b": ipv6VTEP},
+			},
+			want: tunnelOverheads{
+				forL3VNIs: map[string]int{"vni1": hostnetwork.IPv6VXLanOverhead},
+				forL3VPNs: map[string]int{},
+				forL2VNIs: map[string]int{"l2a": hostnetwork.IPv6VXLanOverhead, "l2b": hostnetwork.IPv6VXLanOverhead},
+			},
+		},
+		{
+			name: "L3VNI routing domain, IPv6 L3VNI with IPv4 L2VNIs",
+			apiConfig: APIConfigData{
+				L3VNIs: []v1alpha1.L3VNI{
+					{ObjectMeta: metav1.ObjectMeta{Name: "vni1"}},
+				},
+				L2VNIs: []v1alpha1.L2VNI{
+					{ObjectMeta: metav1.ObjectMeta{Name: "l2a"}, Spec: v1alpha1.L2VNISpec{RoutingDomain: l3vniRoutingDomain("vni1")}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "l2b"}, Spec: v1alpha1.L2VNISpec{RoutingDomain: l3vniRoutingDomain("vni1")}},
+				},
+			},
+			vtepIPs: tunnelVtepIPs{
+				forL3VNIs: map[string]string{"vni1": ipv6VTEP},
+				forL2VNIs: map[string]string{"l2a": ipv4VTEP, "l2b": ipv4VTEP},
+			},
+			want: tunnelOverheads{
+				forL3VNIs: map[string]int{"vni1": hostnetwork.IPv6VXLanOverhead},
+				forL3VPNs: map[string]int{},
+				forL2VNIs: map[string]int{"l2a": hostnetwork.IPv6VXLanOverhead, "l2b": hostnetwork.IPv6VXLanOverhead},
+			},
+		},
+		{
+			name: "L3VPN SRv6 full overhead with IPv4 L2VNI, SRv6 wins",
+			apiConfig: APIConfigData{
+				Underlays: []v1alpha1.Underlay{{Spec: v1alpha1.UnderlaySpec{SRV6: &v1alpha1.SRV6Config{}}}},
+				L3VPNs: []v1alpha1.L3VPN{
+					{ObjectMeta: metav1.ObjectMeta{Name: "vpn1"}},
+				},
+				L2VNIs: []v1alpha1.L2VNI{
+					{ObjectMeta: metav1.ObjectMeta{Name: "l2a"}, Spec: v1alpha1.L2VNISpec{RoutingDomain: l3vpnRoutingDomain("vpn1")}},
+				},
+			},
+			vtepIPs: tunnelVtepIPs{
+				forL3VNIs: map[string]string{},
+				forL2VNIs: map[string]string{"l2a": ipv4VTEP},
+			},
+			want: tunnelOverheads{
+				forL3VNIs: map[string]int{},
+				forL3VPNs: map[string]int{"vpn1": hostnetwork.SRv6Overhead},
+				forL2VNIs: map[string]int{"l2a": hostnetwork.SRv6Overhead},
+			},
+		},
+		{
+			name: "L3VPN SRv6 full overhead with IPv6 L2VNI, IPv6 VXLAN wins",
+			apiConfig: APIConfigData{
+				Underlays: []v1alpha1.Underlay{{Spec: v1alpha1.UnderlaySpec{SRV6: &v1alpha1.SRV6Config{}}}},
+				L3VPNs: []v1alpha1.L3VPN{
+					{ObjectMeta: metav1.ObjectMeta{Name: "vpn1"}},
+				},
+				L2VNIs: []v1alpha1.L2VNI{
+					{ObjectMeta: metav1.ObjectMeta{Name: "l2a"}, Spec: v1alpha1.L2VNISpec{RoutingDomain: l3vpnRoutingDomain("vpn1")}},
+				},
+			},
+			vtepIPs: tunnelVtepIPs{
+				forL3VNIs: map[string]string{},
+				forL2VNIs: map[string]string{"l2a": ipv6VTEP},
+			},
+			want: tunnelOverheads{
+				forL3VNIs: map[string]int{},
+				forL3VPNs: map[string]int{"vpn1": hostnetwork.IPv6VXLanOverhead},
+				forL2VNIs: map[string]int{"l2a": hostnetwork.IPv6VXLanOverhead},
+			},
+		},
+		{
+			name: "L3VPN SRv6 reduced overhead with IPv4 L2VNI, VXLAN wins",
+			apiConfig: APIConfigData{
+				Underlays: []v1alpha1.Underlay{{Spec: v1alpha1.UnderlaySpec{
+					SRV6: &v1alpha1.SRV6Config{EncapBehavior: new(v1alpha1.HEncapsRed)},
+				}}},
+				L3VPNs: []v1alpha1.L3VPN{
+					{ObjectMeta: metav1.ObjectMeta{Name: "vpn1"}},
+				},
+				L2VNIs: []v1alpha1.L2VNI{
+					{ObjectMeta: metav1.ObjectMeta{Name: "l2a"}, Spec: v1alpha1.L2VNISpec{RoutingDomain: l3vpnRoutingDomain("vpn1")}},
+				},
+			},
+			vtepIPs: tunnelVtepIPs{
+				forL3VNIs: map[string]string{},
+				forL2VNIs: map[string]string{"l2a": ipv4VTEP},
+			},
+			want: tunnelOverheads{
+				forL3VNIs: map[string]int{},
+				forL3VPNs: map[string]int{"vpn1": hostnetwork.VXLanOverhead},
+				forL2VNIs: map[string]int{"l2a": hostnetwork.VXLanOverhead},
+			},
+		},
+		{
+			name: "L3VPN with no L2VNIs keeps pure SRv6 overhead",
+			apiConfig: APIConfigData{
+				Underlays: []v1alpha1.Underlay{{Spec: v1alpha1.UnderlaySpec{SRV6: &v1alpha1.SRV6Config{}}}},
+				L3VPNs: []v1alpha1.L3VPN{
+					{ObjectMeta: metav1.ObjectMeta{Name: "vpn1"}},
+				},
+			},
+			vtepIPs: tunnelVtepIPs{
+				forL3VNIs: map[string]string{},
+				forL2VNIs: map[string]string{},
+			},
+			want: tunnelOverheads{
+				forL3VNIs: map[string]int{},
+				forL3VPNs: map[string]int{"vpn1": hostnetwork.SRv6Overhead},
+				forL2VNIs: map[string]int{},
+			},
+		},
+		{
+			name: "L3VPN with no L2VNIs keeps pure SRv6 reduced overhead",
+			apiConfig: APIConfigData{
+				Underlays: []v1alpha1.Underlay{{Spec: v1alpha1.UnderlaySpec{
+					SRV6: &v1alpha1.SRV6Config{EncapBehavior: new(v1alpha1.HEncapsRed)},
+				}}},
+				L3VPNs: []v1alpha1.L3VPN{
+					{ObjectMeta: metav1.ObjectMeta{Name: "vpn1"}},
+				},
+			},
+			vtepIPs: tunnelVtepIPs{
+				forL3VNIs: map[string]string{},
+				forL2VNIs: map[string]string{},
+			},
+			want: tunnelOverheads{
+				forL3VNIs: map[string]int{},
+				forL3VPNs: map[string]int{"vpn1": hostnetwork.SRv6OverheadEncapReduced},
+				forL2VNIs: map[string]int{},
+			},
+		},
+		{
+			name: "standalone L2VNIs without routing domain get individual overhead",
+			apiConfig: APIConfigData{
+				L2VNIs: []v1alpha1.L2VNI{
+					{ObjectMeta: metav1.ObjectMeta{Name: "l2-v4"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "l2-v6"}},
+				},
+			},
+			vtepIPs: tunnelVtepIPs{
+				forL3VNIs: map[string]string{},
+				forL2VNIs: map[string]string{"l2-v4": ipv4VTEP, "l2-v6": ipv6VTEP},
+			},
+			want: tunnelOverheads{
+				forL3VNIs: map[string]int{},
+				forL3VPNs: map[string]int{},
+				forL2VNIs: map[string]int{"l2-v4": hostnetwork.VXLanOverhead, "l2-v6": hostnetwork.IPv6VXLanOverhead},
+			},
+		},
+		{
+			name: "L3VNI missing from VTEP IPs map",
+			apiConfig: APIConfigData{
+				L3VNIs: []v1alpha1.L3VNI{
+					{ObjectMeta: metav1.ObjectMeta{Name: "vni1"}},
+				},
+			},
+			vtepIPs: tunnelVtepIPs{
+				forL3VNIs: map[string]string{},
+				forL2VNIs: map[string]string{},
+			},
+			wantErr: "L3VNI vni1: not found in map of tunnel VTEP IPs: map[]",
+		},
+		{
+			name: "L2VNI in L3VNI routing domain missing from VTEP IPs map",
+			apiConfig: APIConfigData{
+				L3VNIs: []v1alpha1.L3VNI{
+					{ObjectMeta: metav1.ObjectMeta{Name: "vni1"}},
+				},
+				L2VNIs: []v1alpha1.L2VNI{
+					{ObjectMeta: metav1.ObjectMeta{Name: "l2a"}, Spec: v1alpha1.L2VNISpec{RoutingDomain: l3vniRoutingDomain("vni1")}},
+				},
+			},
+			vtepIPs: tunnelVtepIPs{
+				forL3VNIs: map[string]string{"vni1": ipv4VTEP},
+				forL2VNIs: map[string]string{},
+			},
+			wantErr: "L2VNI l2a: not found in map of tunnel VTEP IPs: map[]",
+		},
+		{
+			name: "L2VNI references nonexistent L3VPN",
+			apiConfig: APIConfigData{
+				L2VNIs: []v1alpha1.L2VNI{
+					{ObjectMeta: metav1.ObjectMeta{Name: "l2a"}, Spec: v1alpha1.L2VNISpec{RoutingDomain: l3vpnRoutingDomain("missing")}},
+				},
+			},
+			vtepIPs: tunnelVtepIPs{
+				forL3VNIs: map[string]string{},
+				forL2VNIs: map[string]string{"l2a": ipv4VTEP},
+			},
+			wantErr: "L2VNI l2a: could not find corresponding L3VPN \"missing\" in tunnel overheads map[]",
+		},
+		{
+			name: "L2VNI references nonexistent L3VNI",
+			apiConfig: APIConfigData{
+				L2VNIs: []v1alpha1.L2VNI{
+					{ObjectMeta: metav1.ObjectMeta{Name: "l2a"}, Spec: v1alpha1.L2VNISpec{RoutingDomain: l3vniRoutingDomain("missing")}},
+				},
+			},
+			vtepIPs: tunnelVtepIPs{
+				forL3VNIs: map[string]string{},
+				forL2VNIs: map[string]string{"l2a": ipv4VTEP},
+			},
+			wantErr: "L2VNI l2a: could not find corresponding L3VNI \"missing\" in tunnel overheads map[]",
+		},
+		{
+			name: "L3VNI with unparseable VTEP IP",
+			apiConfig: APIConfigData{
+				L3VNIs: []v1alpha1.L3VNI{
+					{ObjectMeta: metav1.ObjectMeta{Name: "vni1"}},
+				},
+			},
+			vtepIPs: tunnelVtepIPs{
+				forL3VNIs: map[string]string{"vni1": "not-a-cidr"},
+				forL2VNIs: map[string]string{},
+			},
+			wantErr: `L3VNI vni1: could not determine AF of tunnel VTEP IP: "not-a-cidr"`,
+		},
+		{
+			name: "standalone L2VNI with unparseable VTEP IP",
+			apiConfig: APIConfigData{
+				L2VNIs: []v1alpha1.L2VNI{
+					{ObjectMeta: metav1.ObjectMeta{Name: "l2a"}},
+				},
+			},
+			vtepIPs: tunnelVtepIPs{
+				forL3VNIs: map[string]string{},
+				forL2VNIs: map[string]string{"l2a": "garbage"},
+			},
+			wantErr: `L2VNI l2a: could not determine AF of tunnel VTEP IP: "garbage"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := overheadForTunnels(tt.apiConfig, tt.vtepIPs)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("overheadForTunnels()\ngot  = %+v\nwant = %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func mustMarshal(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+// netdevInterfaces builds hostnetwork.UnderlayInterface entries of the
+// netdev kind for the given names.
+func netdevInterfaces(names ...string) []hostnetwork.UnderlayInterface {
+	res := make([]hostnetwork.UnderlayInterface, 0, len(names))
+	for _, name := range names {
+		res = append(res, hostnetwork.UnderlayInterface{
+			InterfaceName: name,
+			Kind:          hostnetwork.UnderlayInterfaceNetDev,
+		})
+	}
+	return res
 }

--- a/internal/hostnetwork/vni.go
+++ b/internal/hostnetwork/vni.go
@@ -22,6 +22,8 @@ import (
 const (
 	// VXLanOverhead is the number of bytes added by VXLan encapsulation.
 	VXLanOverhead = 50
+	// IPv6VXLanOverhead is the number of bytes added by VXLan over IPv6 encapsulation.
+	IPv6VXLanOverhead = 70
 )
 
 type VNIParams struct {


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:
For l2vnis and L3 domains, make sure to correctly calculate the tunnel
overhead in the presence of IPv6 VXLAN tunnels. For standalone l2vnis,
this means pick either IPv6 VXLAN overhead (70 bytes) or IPv4 VXLAN
overhead (50 bytes). For L3 domains, this means pick the maximum
overhead of all elements inside the same domain.

**Special notes for your reviewer**:
N/A

**Release note**:

```release-note
Correctly calculate tunnel overhead while L2VNIs or L3VNIs with IPv6 tunnel endpoint are present.
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tunnel overhead calculations for IPv4 and IPv6 VXLAN connections.
  - Applied routing-domain overheads consistently across Layer 2 and Layer 3 network configurations.
  - Added clearer errors when required VTEP information is unavailable or address families do not match.
- **New Features**
  - Added support for IPv6 VXLAN overhead calculations, accounting for the larger encapsulation size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->