### PR TITLE
fix(grout): assign random MAC to underlay port

### DIFF
--- a/e2etests/pkg/openperouter/interface.go
+++ b/e2etests/pkg/openperouter/interface.go
@@ -78,6 +78,32 @@ func InterfaceIPv4InNetns(nodeName, intf, ns string) (string, error) {
 	return "", fmt.Errorf("no global IPv4 address on %s/%s in netns %s", nodeName, intf, ns)
 }
 
+// NetnsLinkLocalOwners returns, for the given netns on nodeName, a map from
+// each IPv6 link-local (fe80::/10) address to the interfaces that carry it.
+// A correct setup has a single owner per address; a link-local shared across
+// interfaces (the issue #720 failure signature, caused by a duplicate MAC)
+// shows up as more than one owner.
+func NetnsLinkLocalOwners(nodeName, ns string) (map[string][]string, error) {
+	exec := executor.ForNode(nodeName)
+	out, err := exec.Exec("ip", "netns", "exec", ns, "ip", "-o", "-6", "addr", "show", "scope", "link")
+	if err != nil {
+		return nil, fmt.Errorf("listing link-local addresses in netns %s on %s: %w", ns, nodeName, err)
+	}
+
+	owners := map[string][]string{}
+	for line := range strings.SplitSeq(out, "\n") {
+		// e.g. "36: u_toswitch1    inet6 fe80::a8c1:abff:fe84:5cc8/128 scope link nodad"
+		fields := strings.Fields(line)
+		if len(fields) < 4 || fields[2] != "inet6" {
+			continue
+		}
+		iface := fields[1]
+		addr, _, _ := strings.Cut(fields[3], "/")
+		owners[addr] = append(owners[addr], iface)
+	}
+	return owners, nil
+}
+
 // InterfaceIsUp checks whether the interface in the default netns
 // on nodeName has state UP.
 func InterfaceIsUp(nodeName, intf string) bool {

--- a/e2etests/tests/sessions.go
+++ b/e2etests/tests/sessions.go
@@ -5,6 +5,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	frrk8sapi "github.com/metallb/frr-k8s/api/v1beta1"
@@ -1098,4 +1099,65 @@ var _ = Describe("Underlay explicit address family configuration", Ordered, Grou
 			networklayerprotocol.NLP{AFI: networklayerprotocol.IPv6, SAFI: networklayerprotocol.Unicast},
 		)
 	})
+
+	// Regression test for https://github.com/openperouter/openperouter/issues/720.
+	// When grout reuses the backing veth's MAC for the underlay port, the port's
+	// kernel shadow u_<iface> derives the same EUI-64 link-local as the veth. The
+	// collision triggers DAD, which can strip u_<iface>'s link-local and break any
+	// session carrying an IPv6 nexthop (ipv6unicast/ipv6vpn). Assert the
+	// port owns a link-local that is not shared with its backing veth. Note the
+	// shadow shares its link-local with grout's own tap_<iface> by design; only a
+	// collision with the veth is the failure signature.
+	//
+	// This test is marked as failing until we fix this bug.
+	It("assigns each underlay port a unique IPv6 link-local", func() {
+		By("deploying an underlay with both ToR neighbors carrying ipv4unicast and ipv6unicast")
+		underlay := *infra.Underlay.DeepCopy()
+		for i := range underlay.Spec.Neighbors {
+			underlay.Spec.Neighbors[i].AddressFamilies = []v1alpha1.NeighborAddressFamily{
+				{Type: "ipv4unicast"},
+				{Type: "ipv6unicast"},
+			}
+		}
+		Expect(Updater.Update(config.Resources{Underlays: []v1alpha1.Underlay{underlay}})).To(Succeed())
+
+		By("waiting for the underlay to be configured on all nodes")
+		for _, node := range nodes {
+			Eventually(func(g Gomega) {
+				g.Expect(openperouter.UnderlayConfigured(node.Name)).To(BeTrue())
+			}, 2*time.Minute, time.Second).Should(Succeed())
+		}
+
+		By("checking each underlay port owns a link-local not shared with its veth")
+		for _, node := range nodes {
+			for _, iface := range infra.DefaultInterfaces {
+				veth := iface.NetworkDevice.InterfaceName
+				port := "u_" + veth
+				Eventually(func(g Gomega) {
+					owners, err := openperouter.NetnsLinkLocalOwners(node.Name, openperouter.NamedNetns)
+					g.Expect(err).NotTo(HaveOccurred())
+
+					portLinkLocals := linkLocalsOwnedBy(owners, port)
+					g.Expect(portLinkLocals).To(HaveLen(1),
+						"port %s on %s must own exactly one IPv6 link-local, owners=%v", port, node.Name, owners)
+					g.Expect(owners[portLinkLocals[0]]).NotTo(ContainElement(veth),
+						"link-local %s of port %s on %s is shared with its backing veth %s, owners=%v",
+						portLinkLocals[0], port, node.Name, veth, owners[portLinkLocals[0]],
+					)
+				}, time.Minute, 2*time.Second).Should(Succeed())
+			}
+		}
+	})
 })
+
+// linkLocalsOwnedBy returns the link-local addresses from owners that are
+// carried by iface.
+func linkLocalsOwnedBy(owners map[string][]string, iface string) []string {
+	var res []string
+	for addr, ifaces := range owners {
+		if slices.Contains(ifaces, iface) {
+			res = append(res, addr)
+		}
+	}
+	return res
+}

--- a/internal/grout/grout_client.go
+++ b/internal/grout/grout_client.go
@@ -49,7 +49,7 @@ func (c *Client) deleteAddress(ctx context.Context, iface, addr string) error {
 	return nil
 }
 
-func (c *Client) ensurePort(ctx context.Context, name, devargs string) error {
+func (c *Client) ensurePort(ctx context.Context, name, devargs, mac string) error {
 	exists, err := c.portExists(ctx, name)
 	if err != nil {
 		return fmt.Errorf("checking if port %s exists: %w", name, err)
@@ -59,8 +59,12 @@ func (c *Client) ensurePort(ctx context.Context, name, devargs string) error {
 		return nil
 	}
 
-	slog.InfoContext(ctx, "creating grout port", "name", name, "devargs", devargs)
-	if err := c.run(ctx, "interface", "add", "port", name, "devargs", devargs); err != nil {
+	args := []string{"interface", "add", "port", name, "devargs", devargs}
+	if mac != "" {
+		args = append(args, "mac", mac)
+	}
+	slog.InfoContext(ctx, "creating grout port", "name", name, "devargs", devargs, "mac", mac)
+	if err := c.run(ctx, args...); err != nil {
 		return fmt.Errorf("creating grout port %s: %w", name, err)
 	}
 	return nil

--- a/internal/grout/grout_client_test.go
+++ b/internal/grout/grout_client_test.go
@@ -64,6 +64,7 @@ func TestEnsurePort(t *testing.T) {
 				context.Background(),
 				"p0",
 				"net_tap0,remote=remote_i,iface=p0_tap",
+				"",
 			),
 		)
 	})
@@ -80,6 +81,28 @@ func TestEnsurePort(t *testing.T) {
 				context.Background(),
 				"p0",
 				"net_tap0,remote=remote_i,iface=p0_tap",
+				"",
+			),
+		)
+	})
+
+	t.Run("ensure port with explicit MAC", func(t *testing.T) {
+		defer mockCmdExec(
+			cmdCall{
+				cmd: "grcli --err-exit --json --socket sock interface show name p0",
+				err: fmt.Errorf("error: command failed: No such device (ENODEV)"),
+			},
+			cmdCall{
+				cmd: "grcli --err-exit --json --socket sock interface add port p0 devargs net_tap0,remote=remote_i,iface=p0_tap mac 02:00:00:00:00:01",
+			},
+		)()
+
+		assert.NoError(t,
+			NewClient("sock").ensurePort(
+				context.Background(),
+				"p0",
+				"net_tap0,remote=remote_i,iface=p0_tap",
+				"02:00:00:00:00:01",
 			),
 		)
 	})

--- a/internal/grout/mac.go
+++ b/internal/grout/mac.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package grout
+
+import (
+	"crypto/rand"
+	"net"
+)
+
+func randomMAC() (net.HardwareAddr, error) {
+	mac := make(net.HardwareAddr, 6)
+	if _, err := rand.Read(mac); err != nil {
+		return nil, err
+	}
+
+	mac[0] = (mac[0] | 0x02) & 0xfe // locally administered, unicast
+	return mac, nil
+}

--- a/internal/grout/mac_test.go
+++ b/internal/grout/mac_test.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package grout
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRandomMAC(t *testing.T) {
+	seen := map[string]struct{}{}
+	for range 100 {
+		mac, err := randomMAC()
+		require.NoError(t, err)
+		require.Len(t, mac, 6)
+		assert.Zero(t, mac[0]&0x01, "MAC must be unicast")
+		assert.NotZero(t, mac[0]&0x02, "MAC must be locally administered")
+
+		_, duplicate := seen[mac.String()]
+		assert.False(t, duplicate, "generated duplicate MAC %s", mac)
+		seen[mac.String()] = struct{}{}
+	}
+}

--- a/internal/grout/underlay.go
+++ b/internal/grout/underlay.go
@@ -166,8 +166,13 @@ func configureUnderlayPort(ctx context.Context, client *Client, underlayInterfac
 		return fmt.Errorf("failed to read underlay interface addresses: %w", err)
 	}
 
+	mac, err := randomMAC()
+	if err != nil {
+		return fmt.Errorf("failed to generate MAC for grout underlay port: %w", err)
+	}
+
 	devargs := fmt.Sprintf("net_tap%s,remote=%s,iface=%s", makeTapRandomString(), underlayInterface, "tap_"+underlayInterface)
-	if err := client.ensurePort(ctx, UnderlayPortNamePrefix+underlayInterface, devargs); err != nil {
+	if err := client.ensurePort(ctx, UnderlayPortNamePrefix+underlayInterface, devargs, mac.String()); err != nil {
 		return fmt.Errorf("failed to create grout underlay port: %w", err)
 	}
 


### PR DESCRIPTION
Generate a random locally administered MAC address for the grout underlay port and pass it when creating the port. Extend ensurePort to accept an optional MAC argument and add unit tests for the MAC generation.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
/kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

Fixes
- https://github.com/openperouter/openperouter/issues/720

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Assign random MAC address to grout underlay ports
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Underlay ports now receive automatically generated locally administered MAC addresses.
  * Explicit MAC addresses are applied when creating ports.
* **Bug Fixes**
  * Improved handling and reporting of MAC-address generation failures.
  * Underlay ports now maintain distinct IPv6 link-local addresses from their backing interfaces.
* **Tests**
  * Added coverage for MAC-address validity, uniqueness, explicit assignment, and underlay IPv6 link-local ownership.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->